### PR TITLE
feat(docs): render check_list blocks as GFM task list markdown

### DIFF
--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -73,9 +73,16 @@ _DIVIDER_RE = re.compile(r"^\s*(?:---+|\*\*\*+|___+)\s*$")
 _CODE_FENCE_RE = re.compile(r"^\s*```\s*([\w-]*)\s*$")
 
 
-def _text_content(text: str) -> dict[str, Any]:
-    """Monday's text-bearing blocks use a Quill-like delta format."""
-    return {"deltaFormat": [{"insert": text}]}
+def _text_content(text: str, *, checked: bool = False) -> dict[str, Any]:
+    """Monday's text-bearing blocks use a Quill-like delta format.
+
+    `checked=True` emits a `check_list`-style flag; unchecked items omit the
+    key to mirror monday's wire shape (the live API never sends `checked: false`).
+    """
+    content: dict[str, Any] = {"deltaFormat": [{"insert": text}]}
+    if checked:
+        content["checked"] = True
+    return content
 
 
 def markdown_to_blocks(md: str) -> list[dict[str, Any]]:
@@ -153,9 +160,7 @@ def markdown_to_blocks(md: str) -> list[dict[str, Any]]:
         if m:
             flush_paragraph()
             checked = m.group(1).lower() == "x"
-            content = _text_content(m.group(2).strip())
-            if checked:
-                content["checked"] = True
+            content = _text_content(m.group(2).strip(), checked=checked)
             blocks.append({"type": "check_list", "content": content})
             i += 1
             continue
@@ -187,33 +192,42 @@ def markdown_to_blocks(md: str) -> list[dict[str, Any]]:
 # --- blocks → markdown ------------------------------------------------------
 
 
+def _as_content_dict(content: Any) -> dict[str, Any] | None:
+    """Normalize a block's `content` field to a dict, or None if not parseable.
+
+    monday's API returns `content` as a JSON-encoded string in some versions
+    and as an already-parsed dict in others. Callers that need keyed access
+    funnel through this helper instead of repeating the str-or-dict dance.
+    """
+    if isinstance(content, str):
+        try:
+            content = json.loads(content)
+        except ValueError:
+            return None
+    return content if isinstance(content, dict) else None
+
+
 def _extract_text(content: Any) -> str:
     """Pull the plain text out of a block's content field.
 
-    monday's actual API returns `content` as a JSON-encoded **string** (not a
-    parsed object); we detect and re-parse. Known shape:
-    `{"deltaFormat": [{"insert": "..."}]}`.
+    Known shape: `{"deltaFormat": [{"insert": "..."}]}`. Falls back to
+    `text`/`value`/`plainText` for monday variants that embed text directly,
+    and to the raw string for unparseable content (so it isn't silently lost).
     """
     if not content:
         return ""
-    # monday returns content as a JSON string in many API versions — re-parse.
-    if isinstance(content, str):
-        try:
-            parsed = json.loads(content)
-        except ValueError:
-            return content  # plain string fallback
-        content = parsed
-    if not isinstance(content, dict):
-        return str(content)
+    parsed = _as_content_dict(content)
+    if parsed is None:
+        # Unparseable JSON string — surface it verbatim rather than dropping.
+        return content if isinstance(content, str) else str(content)
 
-    delta = content.get("deltaFormat")
+    delta = parsed.get("deltaFormat")
     if isinstance(delta, list):
         pieces = [d.get("insert", "") for d in delta if isinstance(d, dict)]
         return "".join(pieces)
 
-    # Fall-through attempts — some monday variants just embed "text" directly.
     for key in ("text", "value", "plainText"):
-        val = content.get(key)
+        val = parsed.get(key)
         if isinstance(val, str):
             return val
     return ""
@@ -225,14 +239,8 @@ def _extract_checked(content: Any) -> bool:
     monday omits the key (or sets it to false) for unchecked items; an
     unchecked block has no `checked` field at all in the live API output.
     """
-    if isinstance(content, str):
-        try:
-            content = json.loads(content)
-        except ValueError:
-            return False
-    if isinstance(content, dict):
-        return bool(content.get("checked"))
-    return False
+    parsed = _as_content_dict(content)
+    return bool(parsed.get("checked")) if parsed else False
 
 
 _READ_ALIASES = {
@@ -366,15 +374,8 @@ def _render_table(
     schema is missing/malformed and the caller should fall back to the
     generic `[!TABLE]` blockquote so cell text isn't silently dropped.
     """
-    raw = block.get("content")
-    if isinstance(raw, str):
-        try:
-            content = json.loads(raw)
-        except ValueError:
-            return False
-    elif isinstance(raw, dict):
-        content = raw
-    else:
+    content = _as_content_dict(block.get("content"))
+    if content is None:
         return False
 
     cells_matrix = content.get("cells")
@@ -472,8 +473,8 @@ def _render_block_list(
         elif btype == "quote":
             lines.append(f"{prefix}> {text}")
         elif btype == "code":
-            content = block.get("content") or {}
-            lang = content.get("language", "") if isinstance(content, dict) else ""
+            content = _as_content_dict(block.get("content")) or {}
+            lang = content.get("language", "")
             lines.append(f"{prefix}```{lang}")
             if text:
                 lines.append(f"{prefix}{text}")

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -5,7 +5,8 @@ Scope (plan §6.4 / monday-api.md §11.5.22):
   returns the `objectId`(s) pointing to workspace doc(s).
 - `markdown_to_blocks` converts a markdown source into a list of monday's
   `CreateBlockInput` dicts. Supported blocks: heading (h1/h2/h3),
-  normal_text, bullet_list, numbered_list, quote, code, divider.
+  normal_text, bullet_list, numbered_list, check_list (GFM task list
+  syntax `- [ ] / - [x]`), quote, code, divider.
 - `blocks_to_markdown` reverses the above for display.
 
 Unsupported markdown (images, tables, nested lists, inline formatting)
@@ -63,6 +64,7 @@ def extract_doc_ids_from_column_value(raw: str | None) -> list[int]:
 _HEADING_TYPES = {1: "large_title", 2: "medium_title", 3: "small_title"}
 _BULLET_LIST_TYPE = "bulleted_list"
 
+_TASK_LIST_RE = re.compile(r"^\s*[-*+]\s+\[([ xX])\]\s+(.*)$")
 _BULLET_RE = re.compile(r"^\s*[-*+]\s+(.*)$")
 _NUMBERED_RE = re.compile(r"^\s*\d+\.\s+(.*)$")
 _QUOTE_RE = re.compile(r"^\s*>\s?(.*)$")
@@ -143,6 +145,21 @@ def markdown_to_blocks(md: str) -> list[dict[str, Any]]:
             i += 1
             continue
 
+        # GFM task list (must match before plain bullet list, since a
+        # task-list line is a bullet line with `[x]`/`[ ]` after the marker).
+        # monday models checked state via a `checked: true` flag in content;
+        # unchecked items omit the key.
+        m = _TASK_LIST_RE.match(line)
+        if m:
+            flush_paragraph()
+            checked = m.group(1).lower() == "x"
+            content = _text_content(m.group(2).strip())
+            if checked:
+                content["checked"] = True
+            blocks.append({"type": "check_list", "content": content})
+            i += 1
+            continue
+
         # Bullet list
         m = _BULLET_RE.match(line)
         if m:
@@ -202,6 +219,22 @@ def _extract_text(content: Any) -> str:
     return ""
 
 
+def _extract_checked(content: Any) -> bool:
+    """True if a check_list block's content carries `checked: true`.
+
+    monday omits the key (or sets it to false) for unchecked items; an
+    unchecked block has no `checked` field at all in the live API output.
+    """
+    if isinstance(content, str):
+        try:
+            content = json.loads(content)
+        except ValueError:
+            return False
+    if isinstance(content, dict):
+        return bool(content.get("checked"))
+    return False
+
+
 _READ_ALIASES = {
     # old name → normalized-for-dispatch name
     "heading": "large_title",
@@ -249,6 +282,7 @@ _LEAF_TYPES = frozenset(
         "small_title",
         "bulleted_list",
         "numbered_list",
+        "check_list",
         "quote",
         "code",
         "normal_text",
@@ -432,6 +466,9 @@ def _render_block_list(
         elif btype == "numbered_list":
             numbered_counter += 1
             lines.append(f"{prefix}{numbered_counter}. {text}")
+        elif btype == "check_list":
+            mark = "x" if _extract_checked(block.get("content")) else " "
+            lines.append(f"{prefix}- [{mark}] {text}")
         elif btype == "quote":
             lines.append(f"{prefix}> {text}")
         elif btype == "code":

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -68,20 +68,23 @@ class TestMarkdownToBlocks:
         blocks = markdown_to_blocks("1. one\n2. two")
         assert [b["type"] for b in blocks] == ["numbered_list", "numbered_list"]
 
-    def test_task_list_unchecked(self) -> None:
-        blocks = markdown_to_blocks("- [ ] todo")
+    @pytest.mark.parametrize(
+        "marker,expected_checked",
+        [
+            (" ", False),  # unchecked
+            ("x", True),  # checked, lowercase
+            ("X", True),  # checked, capital
+        ],
+    )
+    def test_task_list_marker(self, marker: str, expected_checked: bool) -> None:
+        blocks = markdown_to_blocks(f"- [{marker}] todo")
         assert blocks[0]["type"] == "check_list"
-        # unchecked items omit the `checked` key (matches monday's wire shape)
-        assert "checked" not in blocks[0]["content"]
-
-    def test_task_list_checked(self) -> None:
-        blocks = markdown_to_blocks("- [x] done")
-        assert blocks[0]["type"] == "check_list"
-        assert blocks[0]["content"]["checked"] is True
-
-    def test_task_list_capital_x_also_checked(self) -> None:
-        blocks = markdown_to_blocks("- [X] done")
-        assert blocks[0]["content"]["checked"] is True
+        # Unchecked items omit the key entirely (mirrors monday's wire shape:
+        # the API never sends `checked: false`).
+        if expected_checked:
+            assert blocks[0]["content"]["checked"] is True
+        else:
+            assert "checked" not in blocks[0]["content"]
 
     def test_task_list_does_not_consume_plain_bullet(self) -> None:
         """`- foo` (no `[ ]`) must remain a bulleted_list, not a check_list."""

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -68,6 +68,26 @@ class TestMarkdownToBlocks:
         blocks = markdown_to_blocks("1. one\n2. two")
         assert [b["type"] for b in blocks] == ["numbered_list", "numbered_list"]
 
+    def test_task_list_unchecked(self) -> None:
+        blocks = markdown_to_blocks("- [ ] todo")
+        assert blocks[0]["type"] == "check_list"
+        # unchecked items omit the `checked` key (matches monday's wire shape)
+        assert "checked" not in blocks[0]["content"]
+
+    def test_task_list_checked(self) -> None:
+        blocks = markdown_to_blocks("- [x] done")
+        assert blocks[0]["type"] == "check_list"
+        assert blocks[0]["content"]["checked"] is True
+
+    def test_task_list_capital_x_also_checked(self) -> None:
+        blocks = markdown_to_blocks("- [X] done")
+        assert blocks[0]["content"]["checked"] is True
+
+    def test_task_list_does_not_consume_plain_bullet(self) -> None:
+        """`- foo` (no `[ ]`) must remain a bulleted_list, not a check_list."""
+        blocks = markdown_to_blocks("- plain")
+        assert blocks[0]["type"] == "bulleted_list"
+
     def test_blockquote(self) -> None:
         blocks = markdown_to_blocks("> wise words")
         assert blocks[0]["type"] == "quote"
@@ -152,6 +172,37 @@ class TestBlocksToMarkdown:
         )
         assert "1. a" in out
         assert "2. b" in out
+
+    def test_check_list_unchecked(self) -> None:
+        out = blocks_to_markdown([self._block("check_list", "todo")])
+        assert "- [ ] todo" in out
+
+    def test_check_list_checked(self) -> None:
+        # `checked: true` inside content (mirroring monday's live shape).
+        block = {
+            "type": "check_list",
+            "content": {"deltaFormat": [{"insert": "done"}], "checked": True},
+        }
+        out = blocks_to_markdown([block])
+        assert "- [x] done" in out
+
+    def test_check_list_with_space_in_type_name(self) -> None:
+        """Live API returns `"check list"` with a space; _normalize_type
+        must funnel it to the `check_list` branch, not the plain-text fallback."""
+        block = {
+            "type": "check list",
+            "content": '{"deltaFormat":[{"insert":"unchecked"}]}',
+        }
+        out = blocks_to_markdown([block])
+        assert "- [ ] unchecked" in out
+
+    def test_check_list_roundtrip(self) -> None:
+        """Markdown task list → blocks → markdown must preserve the marks."""
+        md_in = "- [ ] todo\n- [x] done\n"
+        blocks = markdown_to_blocks(md_in)
+        out = blocks_to_markdown(blocks)
+        assert "- [ ] todo" in out
+        assert "- [x] done" in out
 
     def test_quote(self) -> None:
         out = blocks_to_markdown([self._block("quote", "wise")])


### PR DESCRIPTION
## Summary

Follow-up to #2. The notice/callout/table fix surfaced one remaining gap on the test doc (`MONDO_TEST_DOC_ID=5095668848`): `check_list` blocks were dropping into the `normal_text` fallback in `blocks_to_markdown`, so checkbox state was lost on read. The inverse path also folded `- [ ] / - [x]` into `bulleted_list`, so the markdown→blocks→markdown round-trip lost both the type and the check state.

## What changed

**Read side** (`blocks_to_markdown`)
- New `_extract_checked(content)` helper reads `content.checked` from the live API shape (string or dict). Live inspection of the test doc shows monday omits the key entirely for unchecked items and sets `checked: true` for checked ones.
- New `_render_block_list` branch emits `- [ ] {text}` / `- [x] {text}` for `check_list` (the legacy space form `"check list"` from the live API funnels through `_normalize_type` first).
- `check_list` added to `_LEAF_TYPES` so a stray `parent_block_id` reference can't push it into the unknown-container `[!CHECK_LIST]` fallback.

**Write side** (`markdown_to_blocks`)
- New `_TASK_LIST_RE` matched **before** `_BULLET_RE` (a task-list line is a bullet line with a `[x]`/`[ ]` prefix — order matters). Emits a `check_list` block; unchecked items omit the `checked` key to mirror monday's wire shape, checked items set `checked: true`. Both lowercase `[x]` and uppercase `[X]` accepted.

## Test plan

- [x] `pytest tests/unit/` — 1239 tests pass (8 new: 4 parser + 4 renderer including a full round-trip).
- [x] `mypy src/mondo/docs.py` — clean.
- [x] `ruff check` — clean.
- [x] **Live re-verified** against `MONDO_TEST_DOC_ID=5095668848`: the three check-list items in the doc now render as `- [ ] check list - unchecked`, `- [x] check list - checked`, `- [ ] one more`. No regression on the notice box, table, or other blocks fixed in #2.