### PR TITLE
fix(cli): apply column codecs to scalar shorthand on item/subitem create

### DIFF
--- a/src/mondo/cli/item.py
+++ b/src/mondo/cli/item.py
@@ -193,16 +193,20 @@ def _build_column_values(
     out: dict[str, Any] = {}
     for col_id, raw_value in parsed_pairs:
         definition = defs.get(col_id)
-        # Non-string values mean the user passed JSON — honor it as raw.
-        if definition is None or not isinstance(raw_value, str):
+        # dict/list/None mean the user passed a structured JSON payload (or an
+        # explicit "clear" signal) — honor it as raw. Bare scalars (int, float,
+        # bool) are valid codec shorthand (e.g. people: `42`, numbers: `5`) and
+        # must be stringified back so the codec sees them.
+        if definition is None or isinstance(raw_value, (dict, list)) or raw_value is None:
             out[col_id] = raw_value
             continue
         col_type = definition["type"]
         settings = parse_settings(definition.get("settings_str"))
+        str_value = raw_value if isinstance(raw_value, str) else json.dumps(raw_value)
         if col_type == "tags":
-            raw_value = resolve_tag_names_to_ids(client, board_id, raw_value, cache=tag_cache)
+            str_value = resolve_tag_names_to_ids(client, board_id, str_value, cache=tag_cache)
         try:
-            out[col_id] = parse_value(col_type, raw_value, settings, create_labels=create_labels)
+            out[col_id] = parse_value(col_type, str_value, settings, create_labels=create_labels)
         except UnknownColumnTypeError:
             # Unfamiliar column type → don't translate, send raw
             out[col_id] = raw_value

--- a/src/mondo/cli/subitem.py
+++ b/src/mondo/cli/subitem.py
@@ -88,7 +88,10 @@ def _build_column_values(
     out: dict[str, Any] = {}
     for col_id, raw_value in parsed_pairs:
         definition = defs.get(col_id)
-        if definition is None or not isinstance(raw_value, str):
+        # dict/list/None: structured JSON the user crafted — pass through as raw.
+        # Bare scalars (int, float, bool) are valid codec shorthand and must be
+        # stringified so the codec sees them (mirror of item.py:_build_column_values).
+        if definition is None or isinstance(raw_value, (dict, list)) or raw_value is None:
             out[col_id] = raw_value
             continue
         col_type = definition.get("type")
@@ -96,8 +99,9 @@ def _build_column_values(
             out[col_id] = raw_value
             continue
         settings = _parse_settings(definition.get("settings_str"))
+        str_value = raw_value if isinstance(raw_value, str) else json.dumps(raw_value)
         try:
-            out[col_id] = parse_value(col_type, raw_value, settings, create_labels=create_labels)
+            out[col_id] = parse_value(col_type, str_value, settings, create_labels=create_labels)
         except UnknownColumnTypeError:
             out[col_id] = raw_value
         except ValueError as e:

--- a/tests/integration/test_live_writes.py
+++ b/tests/integration/test_live_writes.py
@@ -30,6 +30,7 @@ from ._helpers import (
     json_output,
     wait_for,
 )
+from .conftest import PmBoard
 
 runner = CliRunner()
 
@@ -471,6 +472,55 @@ def test_live_item_create_batch_partial_failure(
         f"batch ok item {ok_results[0]['name']}",
         "item", "delete", "--id", str(ok_results[0]["id"]), "--hard",
     )
+
+
+@pytest.mark.integration
+def test_live_item_create_with_people_column_shorthand(
+    pm_board_session: PmBoard, cleanup_plan: CleanupPlan
+) -> None:
+    """Regression: `--column <people_col>=<user_id>` must hit the people codec.
+
+    Before the fix, parse_column_kv JSON-decoded the bare id to int and the
+    codec dispatcher short-circuited, sending the integer raw — monday then
+    rejected with ColumnValueException. After the fix the value is expanded
+    to `{"personsAndTeams":[{"id":<user_id>,"kind":"person"}]}` and the
+    mutation succeeds. Closes #4.
+    """
+    pm = pm_board_session
+    suffix = uuid.uuid4().hex[:8]
+    item_name = f"E2E #4 person codec {suffix}"
+
+    created = invoke_json(
+        [
+            "item", "create",
+            "--board", str(pm.board_id),
+            "--name", item_name,
+            "--column", f"{pm.column_ids['person']}={pm.person_id}",
+        ]
+    )
+    item_id = int(created["id"])
+    cleanup_plan.add(
+        f"item #4 codec {item_id}",
+        "item", "delete", "--id", str(item_id), "--hard",
+    )
+
+    def _person_set() -> None:
+        raw = invoke_json(
+            [
+                "column", "get",
+                "--item", str(item_id),
+                "--column", pm.column_ids["person"],
+                "--raw",
+            ]
+        )
+        # --raw returns {id, type, value (JSON-string), text}; people-column
+        # `value` decodes to {"personsAndTeams":[{"id":<int>,"kind":"person",...}]}.
+        decoded = json.loads(raw["value"]) if raw.get("value") else {}
+        persons = decoded.get("personsAndTeams") or []
+        ids = {int(entry["id"]) for entry in persons if entry.get("kind") == "person"}
+        assert pm.person_id in ids, f"expected person {pm.person_id} on item {item_id}, got {raw!r}"
+
+    wait_for("person column populated via codec shorthand", _person_set)
 
 
 @pytest.mark.integration

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -551,6 +551,58 @@ class TestItemCreate:
         # Status codec converts "Done" → {"label": "Done"}
         assert values == {"text": "Hello", "status": {"label": "Done"}}
 
+    def test_people_codec_on_bare_integer_id(self, httpx_mock: HTTPXMock) -> None:
+        """`--column person=37251583` must hit the people codec.
+
+        Regression: parse_column_kv JSON-decodes `37251583` to int, and the
+        codec dispatcher used to short-circuit on non-string values, sending
+        the bare int to monday (which rejects with ColumnValueException).
+        """
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "boards": [
+                        {
+                            "id": "42",
+                            "name": "B",
+                            "columns": [
+                                {"id": "person", "type": "people", "settings_str": "{}"},
+                                {"id": "long_text", "type": "long_text", "settings_str": "{}"},
+                            ],
+                        }
+                    ]
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_item": {"id": "99", "name": "New"}}),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "item",
+                "create",
+                "--board",
+                "42",
+                "--name",
+                "New",
+                "--column",
+                "person=37251583",
+                "--column",
+                "long_text=Body text",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        values = json.loads(_last_body(httpx_mock)["variables"]["values"])
+        assert values == {
+            "person": {"personsAndTeams": [{"id": 37251583, "kind": "person"}]},
+            "long_text": {"text": "Body text"},
+        }
+
     def test_raw_columns_skips_codec(self, httpx_mock: HTTPXMock) -> None:
         # No preflight when --raw-columns
         httpx_mock.add_response(

--- a/tests/unit/test_cli_subitem.py
+++ b/tests/unit/test_cli_subitem.py
@@ -305,6 +305,57 @@ class TestCreate:
         v = _last_body(httpx_mock)["variables"]
         assert json.loads(v["values"]) == {"status9": {"label": "Done"}}
 
+    def test_people_codec_on_bare_integer_id(self, httpx_mock: HTTPXMock) -> None:
+        """Same regression as TestItemCreate.test_people_codec_on_bare_integer_id,
+        for the subitem `_build_column_values` path."""
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "boards": [
+                        {
+                            "id": "99",
+                            "name": "SubBoard",
+                            "columns": [
+                                {
+                                    "id": "person9",
+                                    "title": "Owner",
+                                    "type": "people",
+                                    "settings_str": "{}",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_subitem": {"id": "20"}}),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "subitem",
+                "create",
+                "--parent",
+                "1",
+                "--name",
+                "Hi",
+                "--subitems-board",
+                "99",
+                "--column",
+                "person9=37251583",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        v = _last_body(httpx_mock)["variables"]
+        assert json.loads(v["values"]) == {
+            "person9": {"personsAndTeams": [{"id": 37251583, "kind": "person"}]}
+        }
+
 
 class TestMoveRenameArchive:
     def test_rename(self, httpx_mock: HTTPXMock) -> None:


### PR DESCRIPTION
## Summary
- `mondo item create --column person=37251583` now hits the people codec and sends `{\"personsAndTeams\":[{\"id\":37251583,\"kind\":\"person\"}]}` instead of the bare integer that monday rejected with `ColumnValueException`.
- Same fix applied to `subitem create` (identical short-circuit at `subitem.py:91`).
- Root cause: `parse_column_kv(\"person=37251583\")` JSON-decodes the value to int, and `_build_column_values` treated any non-string as a structured-JSON payload the user crafted (\"honor it as raw\"). That policy is wrong — bare scalars are valid shorthand for several codecs (`people: 42`, `numbers: 5`, `checkbox: true`). New policy: only `dict`/`list`/`None` pass through as raw; scalars are stringified back and run through `parse_value`.

## Test plan
- [x] `uv run pytest tests/unit/` — 1404 passed, no regressions.
- [x] New unit test `test_people_codec_on_bare_integer_id` in `test_cli_item.py` — asserts the dry-run variables payload contains the expanded shape.
- [x] New unit test `test_people_codec_on_bare_integer_id` in `test_cli_subitem.py` — same coverage for the subitem path.
- [x] New live integration test `test_live_item_create_with_people_column_shorthand` in `test_live_writes.py` — creates a real item on the session PM board with `--column <person_col>=<user_id>`, verifies the value via `column get --raw`, cleans up via the function-scoped cleanup plan. Passed in 45s end-to-end.

Closes #4.