### PR TITLE
fix(cli): refuse --dry-run on mondo graphql instead of silently sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,7 +895,7 @@ directory is resident. Full contract: [`docs/caching.md`](docs/caching.md).
 --verbose,-v                                INFO-level logging to stderr
 --debug                                     Full request/response to stderr (token redacted)
 --yes,-y                                    Skip confirmation prompts
---dry-run                                   Print the GraphQL that would be sent, don't send
+--dry-run                                   On typed mutating commands: print the GraphQL that would be sent, don't send. Rejected with exit 2 on `mondo graphql`.
 --version,-V                                Show version and exit
 ```
 

--- a/README.md
+++ b/README.md
@@ -786,6 +786,12 @@ mondo graphql @query.graphql
 cat mutation.graphql | mondo graphql -
 ```
 
+> **`--dry-run` is rejected on `mondo graphql`.** Unlike typed mutations,
+> the raw passthrough can't safely preview your query (mondo doesn't
+> parse it). Passing `--dry-run` exits 2 with an error instead of
+> silently executing. Review the GraphQL manually before running, or
+> reach for a typed subcommand when one exists.
+
 ---
 
 ## Output formatting

--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -722,7 +722,7 @@
       "errors?",
       "extensions?"
     ],
-    "notes": "Raw GraphQL response envelope from monday; shape depends entirely on the submitted query.",
+    "notes": "Raw GraphQL response envelope from monday; shape depends entirely on the submitted query. --dry-run is not supported (refused with exit 2 — mondo can't safely preview a query it doesn't parse).",
     "source": "client.execute(..., raw=True)"
   },
   {

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -321,7 +321,7 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   type: `dynamic object`
   fields: `data?`, `errors?`, `extensions?`
   source: `client.execute(..., raw=True)`
-  notes: Raw GraphQL response envelope from monday; shape depends entirely on the submitted query.
+  notes: Raw GraphQL response envelope from monday; shape depends entirely on the submitted query. --dry-run is not supported (refused with exit 2 — mondo can't safely preview a query it doesn't parse).
 
 ## group
 

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -412,7 +412,11 @@ MANUAL_ROWS: dict[str, Row] = {
         command="graphql",
         output_type="dynamic object",
         fields=["data?", "errors?", "extensions?"],
-        notes="Raw GraphQL response envelope from monday; shape depends entirely on the submitted query.",
+        notes=(
+            "Raw GraphQL response envelope from monday; shape depends entirely "
+            "on the submitted query. --dry-run is not supported (refused with "
+            "exit 2 — mondo can't safely preview a query it doesn't parse)."
+        ),
         source="client.execute(..., raw=True)",
     ),
     "help": Row(

--- a/src/mondo/cli/graphql.py
+++ b/src/mondo/cli/graphql.py
@@ -48,8 +48,25 @@ def graphql_command(
         help="Variables as a JSON string. Use `@path` to read from a file.",
     ),
 ) -> None:
-    """Send a raw GraphQL query to monday.com and print the response."""
+    """Send a raw GraphQL query to monday.com and print the response.
+
+    Note: `--dry-run` is not supported on this command. Raw GraphQL can't
+    be safely previewed (mondo doesn't parse your query), so the flag is
+    rejected rather than silently ignored.
+    """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+
+    if opts.dry_run:
+        typer.secho(
+            "error: --dry-run is not supported with `mondo graphql`. The raw "
+            "passthrough can't preview safely (mondo doesn't parse your query, "
+            "and verifying success requires sending it). Review the GraphQL "
+            "manually and re-run without --dry-run, or use a typed subcommand "
+            "if one wraps your operation.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=2)
 
     if query is None:
         # A4/A5 in the friction report: detect when the user passed their

--- a/src/mondo/cli/main.py
+++ b/src/mondo/cli/main.py
@@ -208,7 +208,10 @@ _TOP_LEVEL_ENTRIES: tuple[_LazyEntry, ...] = (
         name="graphql",
         module="mondo.cli.graphql",
         attr="graphql_command",
-        help_text="Send a raw GraphQL query/mutation to monday.com.",
+        help_text=(
+            "Send a raw GraphQL query/mutation to monday.com. "
+            "Note: --dry-run is not supported here and is refused with exit 2."
+        ),
         epilog=epilog_for("graphql"),
         is_group=False,
     ),

--- a/src/mondo/cli/main.py
+++ b/src/mondo/cli/main.py
@@ -402,7 +402,15 @@ def main() -> None:
     """
     args = reorder_argv(sys.argv[1:])
     try:
-        app(args=args, standalone_mode=False)
+        rv = app(args=args, standalone_mode=False)
+        # Under standalone_mode=False, Click swallows `click.exceptions.Exit`
+        # (raised by `typer.Exit(code=N)`) and returns its exit_code as the
+        # function's return value. Without this, every `typer.Exit(code=N)`
+        # in command handlers — auth (3), validation (5), not-found (6), the
+        # graphql --dry-run refusal (2) — silently exits 0. Successful
+        # callbacks return None, so the isinstance guard is safe.
+        if isinstance(rv, int) and rv != 0:
+            sys.exit(rv)
     except click.exceptions.UsageError as e:
         from mondo.cli._errors import (
             emit_envelope,

--- a/src/mondo/help/agent-tips.md
+++ b/src/mondo/help/agent-tips.md
@@ -142,6 +142,9 @@ When `mondo schema` shows the field you want isn't selected and no
 
 `mondo graphql` skips codecs, complexity injection, and pagination —
 you're talking to monday directly with the same auth and exit codes.
+`--dry-run` is also unsupported on this command: it's refused with
+exit 2 rather than silently sending, since mondo can't preview a
+query it doesn't parse. Eyeball your GraphQL before running.
 See `mondo help graphql` for the input forms (inline / `@file` /
 stdin) and variables.
 

--- a/src/mondo/help/graphql.md
+++ b/src/mondo/help/graphql.md
@@ -44,7 +44,11 @@ Unlike the typed subcommands, `mondo graphql` is a **raw passthrough**:
 - No codec dispatch — column values must already be in monday's expected
   JSON shape.
 - No pagination — cursor handling is your responsibility.
-- No dry-run — `--dry-run` is a no-op here.
+- No dry-run — passing `--dry-run` is **rejected with exit 2**. The raw
+  passthrough can't preview safely (mondo doesn't parse your query), so
+  rather than silently send the mutation anyway, the flag is refused.
+  Eyeball your query manually, then re-run without `--dry-run` — or use
+  a typed subcommand when one wraps your operation.
 
 All the *other* globals still apply: `--output`, `--query`, `--profile`,
 `--api-token`, `--debug`.

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -68,7 +68,7 @@ Consult these *before* improvising. Each is a Goal / Command / Output / Gotcha s
 - **Filter server-side** with `--filter col=val` (repeatable, AND'ed) instead of paging then JMESPath-filtering. On `item list` specifically, `--group <id>` and `--parent <item-id>` are first-class shortcuts (no need to reach for `--filter group=…` or switch to `subitem list`).
 - **JSON error envelope** on stderr (non-TTY): `{"error": "...", "code": "...", "exit_code": N, "request_id": "...", "retry_in_seconds": N, "suggestion": "..."}`. Branch on `exit_code`, never parse stderr text.
 - **Stable exit codes:** 0 ok · 2 usage · 3 auth · 4 rate/complexity (retry after 60s) · 5 validation · 6 not-found · 7 network.
-- **Dry-run writes first:** every mutating command takes `--dry-run` (prints GraphQL + variables, sends nothing). Use it when the task is unfamiliar.
+- **Dry-run writes first:** every typed mutating command takes `--dry-run` (prints GraphQL + variables, sends nothing). Use it when the task is unfamiliar. Not supported on `mondo graphql` — the raw passthrough refuses `--dry-run` with exit 2 because mondo can't safely preview a query it doesn't parse.
 - **Batch:** `--batch <file.json>` on bulk operations (`item create`, `column set`, `import board`). Returns a per-row envelope; partial failure → exit 1, full success → exit 0.
 - **URLs:** pass `--with-url` on `board get`, `board list`, `item get`, `item create` (NEW — single-call create + URL retrieval), `subitem get`, `doc get`, `doc list` to return a clickable monday.com link to the user.
 - **Wait for async state changes** with `--poll-until '<jmespath>'` + `--poll-interval` + `--poll-timeout` on `item list`, `item get`, `board get` — replaces hand-rolled bash `until/sleep` loops.

--- a/tests/unit/test_cli_graphql.py
+++ b/tests/unit/test_cli_graphql.py
@@ -108,3 +108,97 @@ def test_graphql_hint_only_when_q_looks_like_graphql() -> None:
     assert result.exit_code != 0
     combined = ((result.stdout or "") + (result.stderr or "")).lower()
     assert "passed to" not in combined
+
+
+def test_graphql_dry_run_refuses_mutation(httpx_mock: HTTPXMock) -> None:
+    """`mondo graphql --dry-run '<mutation>'` must NOT send the request.
+
+    Regression for issue #5: silent execution under --dry-run was deemed
+    more dangerous than refusing the flag. The raw passthrough can't
+    safely preview (mondo doesn't parse the query), so --dry-run is
+    rejected with exit 2.
+    """
+    result = runner.invoke(
+        app,
+        ["--dry-run", "graphql", "mutation { delete_item (item_id: 1) { id } }"],
+    )
+    assert result.exit_code == 2, result.stdout
+    combined = ((result.stdout or "") + (result.stderr or "")).lower()
+    assert "--dry-run" in combined
+    assert "not supported" in combined
+    # And critically: no HTTP request was issued.
+    assert httpx_mock.get_requests() == []
+
+
+def test_graphql_dry_run_refuses_query_too(httpx_mock: HTTPXMock) -> None:
+    """Refusal is unconditional — not heuristic on mutation/query.
+
+    Sniffing the query text for `mutation` is fragile (whitespace,
+    aliases, multi-document). Since `--dry-run` on raw GraphQL has no
+    safe semantics, we refuse for any operation.
+    """
+    result = runner.invoke(
+        app,
+        ["--dry-run", "graphql", "query { me { id name } }"],
+    )
+    assert result.exit_code == 2, result.stdout
+    combined = ((result.stdout or "") + (result.stderr or "")).lower()
+    assert "--dry-run" in combined
+    assert httpx_mock.get_requests() == []
+
+
+def test_graphql_dry_run_refused_before_file_load(tmp_path: Path) -> None:
+    """Dry-run check must run before `_load_query` slurps `@path`.
+
+    If the user passes `--dry-run` plus `@nonexistent.graphql`, they
+    should see the dry-run refusal — not a FileNotFoundError. Confirms
+    the flag is rejected before any side-effects.
+    """
+    nope = tmp_path / "does-not-exist.graphql"
+    result = runner.invoke(app, ["--dry-run", "graphql", f"@{nope}"])
+    assert result.exit_code == 2, result.stdout
+    combined = ((result.stdout or "") + (result.stderr or "")).lower()
+    assert "--dry-run" in combined
+    # Specifically NOT a file-system error.
+    assert "no such file" not in combined
+    assert "filenotfounderror" not in combined
+
+
+def test_graphql_dry_run_refusal_propagates_exit_code_through_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`main()` must surface `typer.Exit(code=2)` as `sys.exit(2)`.
+
+    The `CliRunner.invoke` path uses `standalone_mode=True`, where Click
+    converts `Exit(N)` into `SystemExit(N)`. The console-script entry
+    point uses `standalone_mode=False`, where Click swallows `Exit` and
+    returns the code as `app()`'s return value. Without explicit
+    propagation in `main()`, the user-facing CLI exits 0 even when the
+    refusal fired — defeating the safety purpose of issue #5's fix.
+    """
+    from mondo.cli.main import main
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["mondo", "--dry-run", "graphql", "mutation { delete_item(item_id: 1) { id } }"],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 2
+
+
+def test_graphql_dry_run_refused_before_vars_parse() -> None:
+    """Dry-run check must run before `--vars` is parsed.
+
+    With `--dry-run` and malformed `--vars`, the user should see the
+    dry-run refusal — not the vars-parse error. Confirms ordering.
+    """
+    result = runner.invoke(
+        app,
+        ["--dry-run", "graphql", "mutation { noop }", "--vars", "not json"],
+    )
+    assert result.exit_code == 2, result.stdout
+    combined = ((result.stdout or "") + (result.stderr or "")).lower()
+    assert "--dry-run" in combined
+    # Specifically NOT the JSON parse error from --vars.
+    assert "--variables" not in combined or "not supported" in combined


### PR DESCRIPTION
Closes #5.

## Summary

- `mondo graphql --dry-run '<mutation>'` previously **sent the mutation** while the help topic claimed `--dry-run` was a no-op. Reported as dangerous in #5: users reach for the raw passthrough for higher-stakes operations and lose the dry-run safety net silently.
- Now: passing `--dry-run` to `mondo graphql` is **rejected with exit 2** and a clear stderr error explaining why and pointing to the workarounds.
- The raw passthrough can't safely preview (mondo doesn't parse the query; "would this succeed?" requires sending it), so refusing the flag is preferable to either silent execution or echoing a possibly-invalid envelope.

## Design grilling (resolved before coding)

| Decision | Choice |
|---|---|
| Behavior | **Refuse with exit 2**, no echo, no execute |
| Detection order | `opts.dry_run` checked first — before file/stdin load, vars parsing, token resolution. Works offline. |
| Operation discrimination | None — refusal is unconditional (query/mutation/anonymous). String-sniffing for `mutation` is fragile. |
| Docs surfaces | help topic + `--help` docstring + SKILL.md qualifier + README callout |

## Drive-by fix: exit-code propagation in `main()`

Discovered while verifying — Click's `standalone_mode=False` swallows `typer.Exit(code=N)` and returns the code as `app()`'s return value. The `except click.exceptions.Exit` block at `src/mondo/cli/main.py:426` was **dead code** and every non-zero exit was silently dropping to 0 in the actual CLI:

```
$ MONDAY_API_TOKEN=invalid mondo graphql 'query { me { id } }'
error: unauthorized — check your API token
{"error":"unauthorized — check your API token","code":"AuthError","exit_code":3}
$ echo $?
0    # ← was 0, should be 3
```

One-line fix in `main()`: check the return value and `sys.exit(rv)` on a non-zero int. Required for this PR's exit-2 to actually surface; incidentally fixes auth (3) / validation (5) / not-found (6) / usage (2) across the rest of the CLI.

## Files

- `src/mondo/cli/graphql.py` — refuse `opts.dry_run` first thing in the handler
- `src/mondo/cli/main.py` — propagate `app()`'s non-zero int return as `sys.exit`
- `src/mondo/help/graphql.md` — replaced false "no-op" claim with refusal-with-exit-2 description
- `src/mondo/skill/SKILL.md` — qualified "every mutating command takes --dry-run" → "every *typed* mutating command…; raw `graphql` excluded"
- `README.md` — callout in the raw-GraphQL section
- `tests/unit/test_cli_graphql.py` — 5 new tests (see below)

## Test plan

- [x] `uv run pytest tests/unit/` → **1407 passed** (was 1402; +5)
- [x] `uv run mondo --dry-run graphql 'mutation { foo }'` → exit 2, no network, error explains why and how to recover
- [x] `uv run mondo graphql --dry-run 'query { me { id } }'` → exit 2 (refusal is operation-agnostic)
- [x] `uv run mondo --dry-run graphql @nonexistent.graphql` → exit 2 with dry-run message, **not** `FileNotFoundError` (proves check fires before file slurp)
- [x] `uv run mondo --dry-run graphql 'mutation {}' --vars 'not json'` → exit 2 with dry-run message, **not** vars-parse error (proves check fires before `parse_json_flag`)
- [x] `MONDAY_API_TOKEN=invalid uv run mondo graphql 'query { me { id } }'` → exit **3** (now actually surfaces; previously exited 0)
- [x] `uv run mondo --version` → exit 0 (success path regression check)
- [x] `uv run ruff check` clean on modified files
- [x] `uv run mondo graphql --help` renders cleanly with the new docstring note

New tests in `tests/unit/test_cli_graphql.py`:
1. `test_graphql_dry_run_refuses_mutation` — mutation + `--dry-run` → exit 2, no HTTP request
2. `test_graphql_dry_run_refuses_query_too` — query + `--dry-run` → same refusal (no operation-type heuristic)
3. `test_graphql_dry_run_refused_before_file_load` — `@nonexistent.graphql` → dry-run error, not file error
4. `test_graphql_dry_run_refused_before_vars_parse` — bad `--vars` → dry-run error, not vars error
5. `test_graphql_dry_run_refusal_propagates_exit_code_through_main` — drives `main()` directly (not CliRunner) to catch the `standalone_mode=False` regression