### PR TITLE
feat(cli): accept `mondo graphql --query '<gql>'` as the query instead of erroring

### DIFF
--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -63,7 +63,8 @@ EXAMPLES: dict[str, list[Example]] = {
             "cat mutation.graphql | mondo graphql -",
         ),
         Example(
-            "Tip: pass GraphQL as positional, not `-q` (which is global JMESPath)",
+            "Tip: prefer positional GraphQL; a GraphQL-looking `-q` value is "
+            "accepted as the query (JMESPath disabled)",
             "mondo graphql 'query { me { id } }'",
         ),
     ],

--- a/src/mondo/cli/graphql.py
+++ b/src/mondo/cli/graphql.py
@@ -50,6 +50,12 @@ def graphql_command(
 ) -> None:
     """Send a raw GraphQL query to monday.com and print the response.
 
+    Pass the query positionally. As a convenience, a GraphQL document
+    passed to the global `-q/--query` (JMESPath projection) flag is run
+    as the query — with the projection disabled, since the value can't
+    be both. Pass the query positionally to combine it with a JMESPath
+    projection.
+
     Note: `--dry-run` is not supported on this command. Raw GraphQL can't
     be safely previewed (mondo doesn't parse your query), so the flag is
     rejected rather than silently ignored.
@@ -69,26 +75,27 @@ def graphql_command(
         raise typer.Exit(code=2)
 
     if query is None:
-        # A4/A5 in the friction report: detect when the user passed their
-        # GraphQL to `-q` (global JMESPath) instead of as the positional,
-        # and emit a targeted recovery hint instead of the generic
-        # "Missing argument 'QUERY'" Click message.
+        # Issue #13: `--query '<gql>'` is the #1 agent guess (gh-api style).
+        # The global `-q/--query` JMESPath flag swallows it, so when no
+        # positional was given and the projection value reads as GraphQL,
+        # run it as the document instead of exiting 2. The value can't be
+        # both, so the JMESPath projection is disabled for this invocation.
         if opts.query and _looks_like_graphql(opts.query):
+            query = opts.query
+            opts.query = None
             typer.secho(
-                "error: your GraphQL query was passed to `-q` (global JMESPath "
-                "projection) instead of as a positional argument. Pass it "
-                "positionally:\n"
-                "  mondo graphql 'query { … }'",
+                "note: --query interpreted as the GraphQL document; pass it "
+                "positionally to combine with a JMESPath projection.",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
+        else:
+            typer.secho(
+                "error: missing required argument 'QUERY'.",
                 fg=typer.colors.RED,
                 err=True,
             )
             raise typer.Exit(code=2)
-        typer.secho(
-            "error: missing required argument 'QUERY'.",
-            fg=typer.colors.RED,
-            err=True,
-        )
-        raise typer.Exit(code=2)
 
     query_text = _load_query(query)
     vars_dict: dict[str, object] = {}

--- a/src/mondo/help/graphql.md
+++ b/src/mondo/help/graphql.md
@@ -20,12 +20,14 @@ when you need to:
     # From stdin (note the trailing `-`)
     cat mutation.graphql | mondo graphql -
 
-> **Common trap — don't pass your query via `-q`.** `-q` is the global
-> JMESPath projection. If you type `mondo graphql -q 'query { … }'`,
-> Click consumes the GraphQL string as the JMESPath and leaves the
-> positional empty. `mondo` detects this case and emits a targeted hint
-> pointing at the correct invocation (positional argument). Pass the
-> query positionally instead.
+> **Common trap — `-q`/`--query` is the global JMESPath projection,
+> not the GraphQL query.** If you type `mondo graphql --query 'query
+> { … }'` (or `-q '…'`), Click consumes the GraphQL string as the
+> JMESPath and leaves the positional empty. `mondo` detects this case
+> and runs the value as the GraphQL document anyway (with a stderr
+> note), but the JMESPath projection is disabled for that invocation —
+> the value can't be both. Pass the query positionally to combine it
+> with a projection: `mondo graphql 'query { … }' -q 'data.me'`.
 
 ## Variables
 

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -75,7 +75,7 @@ Consult these *before* improvising. Each is a Goal / Command / Output / Gotcha s
 - **Find items by column value** with `mondo item find --board X --column COL --value VAL` (sugar over `item list --filter`, with the same codec dispatch).
 - **Inspect a single column's metadata** with `mondo column get-meta --board X --column COL` (returns one column with `settings_str` preserved; `column list` strips it).
 - **Cleanup:** delete commands soft-archive by default; pass `--hard` for true delete.
-- **Escape hatch:** `mondo graphql '<query>'` for anything no subcommand wraps. **Pass the query as a positional**, not via `-q` (`-q` is the global JMESPath; mondo will hint if you confuse the two).
+- **Escape hatch:** `mondo graphql '<query>'` for anything no subcommand wraps. **Pass the query as a positional** — `-q/--query` is the global JMESPath projection, not the GraphQL query. If a GraphQL document lands in `--query` anyway, mondo runs it as the query (stderr note) but disables the projection for that call; pass it positionally to combine with `-q`.
 - **Cache notice:** read commands may emit `cache: hit (entity=…, age=…)` to stderr. Suppress with `MONDO_NO_CACHE_NOTICE=1`. Force refresh with `--no-cache` or `--refresh-cache` on any cached read (`<entity> list/get` directories plus per-board / per-item / per-doc caches — `item get`, `subitem list/get`, `update list --item`, `doc get`, `board get`, `webhook list`, `tag list/get`). Board-scope `item list` (no `--parent`), account-wide `update list`, and `mondo graphql` stay live. See `docs/caching.md` for the per-entity TTL table.
 
 ## When references aren't enough

--- a/tests/unit/test_cli_graphql.py
+++ b/tests/unit/test_cli_graphql.py
@@ -87,27 +87,90 @@ def test_graphql_query_from_file(httpx_mock: HTTPXMock, tmp_path: Path) -> None:
     assert body["query"] == "query { me { id } }"
 
 
-def test_graphql_hint_when_q_swallowed_query() -> None:
-    """User typed `mondo graphql -q 'query { … }'`. After `reorder_argv`,
-    Typer parses `-q` as the global JMESPath and dispatches `graphql` with
-    no positional. Emit a targeted recovery hint instead of the generic
-    "Missing argument 'QUERY'" message.
+def test_graphql_query_flag_runs_as_document(httpx_mock: HTTPXMock) -> None:
+    """User typed `mondo graphql --query 'query { … }'`. After `reorder_argv`,
+    Typer parses `--query` as the global JMESPath and dispatches `graphql`
+    with no positional. Issue #13: run the value as the GraphQL document
+    instead of exiting 2, with a stderr note pointing at the positional form.
     """
+    httpx_mock.add_response(
+        url=ENDPOINT,
+        method="POST",
+        json={"data": {"me": {"id": "1", "name": "Alice"}}, "extensions": {"request_id": "r"}},
+    )
     # Reordered form, matching what `main()` produces from the user's argv.
-    result = runner.invoke(app, ["-q", "query { me { id } }", "graphql"])
-    assert result.exit_code != 0
+    result = runner.invoke(app, ["--query", "query { me { id name } }", "graphql"])
+    assert result.exit_code == 0, result.output
+    body = json.loads(httpx_mock.get_request().content)  # type: ignore[union-attr]
+    assert body["query"] == "query { me { id name } }"
+    # Projection is disabled: the full envelope is printed, un-projected.
+    out = json.loads(result.stdout)
+    assert out["data"]["me"]["name"] == "Alice"
+    assert "note:" in (result.stderr or "")
+    assert "positionally" in (result.stderr or "")
+
+
+def test_graphql_query_flag_through_main(
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Acceptance: the literal user invocation `mondo graphql --query '<gql>'`
+    works end-to-end through `main()` (argv reordering included)."""
+    from mondo.cli.main import main
+
+    httpx_mock.add_response(
+        url=ENDPOINT,
+        method="POST",
+        json={"data": {"me": {"id": "1"}}, "extensions": {"request_id": "r"}},
+    )
+    monkeypatch.setattr("sys.argv", ["mondo", "graphql", "--query", "query { me { id } }"])
+    try:
+        main()
+    except SystemExit as e:  # main() may sys.exit(0)
+        assert not e.code, f"expected success, got exit {e.code}"
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["data"]["me"]["id"] == "1"
+    assert "note:" in captured.err
+
+
+def test_graphql_positional_plus_projection_unchanged(httpx_mock: HTTPXMock) -> None:
+    """Canonical form: positional document + `-q` JMESPath projection."""
+    httpx_mock.add_response(
+        url=ENDPOINT,
+        method="POST",
+        json={"data": {"me": {"id": "1", "name": "Alice"}}, "extensions": {"request_id": "r"}},
+    )
+    result = runner.invoke(
+        app, ["-o", "json", "-q", "data.me", "graphql", "query { me { id name } }"]
+    )
+    assert result.exit_code == 0, result.output
+    body = json.loads(httpx_mock.get_request().content)  # type: ignore[union-attr]
+    assert body["query"] == "query { me { id name } }"
+    out = json.loads(result.stdout)
+    assert out == {"id": "1", "name": "Alice"}
+
+
+def test_graphql_dry_run_still_refused_for_query_flag(httpx_mock: HTTPXMock) -> None:
+    """Issue #13: the --dry-run refusal (#5) fires before the --query
+    fallback executes anything."""
+    result = runner.invoke(
+        app,
+        ["--dry-run", "--query", "mutation { delete_item(item_id: 1) { id } }", "graphql"],
+    )
+    assert result.exit_code == 2, result.output
     combined = ((result.stdout or "") + (result.stderr or "")).lower()
-    assert "graphql query" in combined and "-q" in combined
-    assert "positional" in combined
+    assert "--dry-run" in combined
+    assert httpx_mock.get_requests() == []
 
 
-def test_graphql_hint_only_when_q_looks_like_graphql() -> None:
-    """A real JMESPath in -q (e.g. 'data.me.id') without a positional should
-    still error, but without the GraphQL-payload hint (it'd be misleading)."""
+def test_graphql_no_positional_and_non_graphql_q_exits_2() -> None:
+    """A real JMESPath in -q (e.g. 'data.me.id') without a positional is
+    still a usage error — the fallback only fires for GraphQL-looking text."""
     result = runner.invoke(app, ["-q", "data.me.id", "graphql"])
-    assert result.exit_code != 0
+    assert result.exit_code == 2
     combined = ((result.stdout or "") + (result.stderr or "")).lower()
-    assert "passed to" not in combined
+    assert "missing required argument" in combined
 
 
 def test_graphql_dry_run_refuses_mutation(httpx_mock: HTTPXMock) -> None:


### PR DESCRIPTION
Closes #13

## What

When `mondo graphql` gets no positional QUERY and the global `-q/--query` (JMESPath projection) value passes `_looks_like_graphql()`, the value is now **run as the GraphQL document** instead of exiting 2:

- JMESPath projection is disabled for that invocation (the value can't be both).
- One-line stderr note keeps the canonical form discoverable: `note: --query interpreted as the GraphQL document; pass it positionally to combine with a JMESPath projection.`
- Positional + `-q` projection: unchanged (positional is the document, `-q` projects).
- `-q` with a non-GraphQL value and no positional: unchanged exit-2 usage error.
- `--dry-run` refusal (#5) still fires before the new path executes anything.

## Docs

- `mondo help graphql` topic and the `graphql` command docstring updated.
- Bundled skill `SKILL.md` escape-hatch bullet updated.

## Verification

- Unit tests cover all four branches (incl. an end-to-end `main()` test for the literal `mondo graphql --query '…'` argv form). Full unit suite: 1412 passed.
- Live check against the real API: `mondo graphql --query 'query { me { id name } }'` → exit 0, envelope printed, note on stderr.