### PR TITLE
fix(cli): `column set --column name` error should point at `mondo item rename`, not --raw

### DIFF
--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -391,8 +391,9 @@ def set_cmd(
                 except UnknownColumnTypeError as e:
                     if col_type == "name":
                         # The item title masquerades as a `name` column in
-                        # monday's UI but isn't settable via column mutations
-                        # (--raw won't work either). Point at the real command.
+                        # monday's UI but isn't settable via
+                        # change_column_value — what `column set` sends,
+                        # including --raw. Point at the real command.
                         typer.secho(
                             "error: 'name' is the item's title, not a settable "
                             "column. Use: mondo item rename "

--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -389,6 +389,18 @@ def set_cmd(
                     typer.secho(f"error: {e}", fg=typer.colors.RED, err=True)
                     raise typer.Exit(code=5) from e
                 except UnknownColumnTypeError as e:
+                    if col_type == "name":
+                        # The item title masquerades as a `name` column in
+                        # monday's UI but isn't settable via column mutations
+                        # (--raw won't work either). Point at the real command.
+                        typer.secho(
+                            "error: 'name' is the item's title, not a settable "
+                            "column. Use: mondo item rename "
+                            f'{item_id} --board {board_id} --name "<new name>"',
+                            fg=typer.colors.RED,
+                            err=True,
+                        )
+                        raise typer.Exit(code=5) from e
                     typer.secho(
                         f"error: no codec for column type {col_type!r}. "
                         f"Use --raw to send a literal JSON payload. Details: {e}",

--- a/src/mondo/skill/references/columns.md
+++ b/src/mondo/skill/references/columns.md
@@ -111,6 +111,8 @@ mondo column set --item 9876543210 --column e2e_status --value Done --dry-run
 
 *Gotcha:* the `--value` syntax goes through monday's per-type codec (see `mondo help codecs`). For complex types (timeline, board_relation, dropdown with multiple labels) the codec may need JSON instead of a label — `mondo column set --help` shows examples per type. When in doubt, run with `--dry-run` first to inspect the payload.
 
+*Gotcha:* the `name` "column" (the item's title in monday's UI) is **not settable** via `column set` — it's not a real column. Rename items with `mondo item rename <item-id> --board <board-id> --name "<new name>"` instead (the error message points there too).
+
 ## Multi-column writes on `item create`
 
 Repeat `--column k=v` to set multiple columns at item creation time:

--- a/src/mondo/skill/references/columns.md
+++ b/src/mondo/skill/references/columns.md
@@ -111,7 +111,7 @@ mondo column set --item 9876543210 --column e2e_status --value Done --dry-run
 
 *Gotcha:* the `--value` syntax goes through monday's per-type codec (see `mondo help codecs`). For complex types (timeline, board_relation, dropdown with multiple labels) the codec may need JSON instead of a label — `mondo column set --help` shows examples per type. When in doubt, run with `--dry-run` first to inspect the payload.
 
-*Gotcha:* the `name` "column" (the item's title in monday's UI) is **not settable** via `column set` — it's not a real column. Rename items with `mondo item rename <item-id> --board <board-id> --name "<new name>"` instead (the error message points there too).
+*Gotcha:* the `name` "column" (the item's title in monday's UI) is **not settable** via `change_column_value` — the mutation `column set` sends (including `--raw`). Rename items with `mondo item rename <item-id> --board <board-id> --name "<new name>"` instead (the error message points there too).
 
 ## Multi-column writes on `item create`
 

--- a/tests/unit/test_cli_column.py
+++ b/tests/unit/test_cli_column.py
@@ -329,6 +329,51 @@ class TestColumnSet:
         body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["variables"]["value"] == json.dumps({"index": 7})
 
+    def test_name_pseudo_column_points_at_item_rename(self, httpx_mock: HTTPXMock) -> None:
+        """Issue #11: `--column name` is the item's title, not a settable
+        column. The error must contain the exact `mondo item rename`
+        invocation instead of the dead-end --raw suggestion."""
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_context_response(
+                board_id=42,
+                cols=[{"id": "name", "title": "Name", "type": "name", "settings_str": "{}"}],
+                values=[{"id": "name", "type": "name", "text": "item", "value": None}],
+            ),
+        )
+        result = runner.invoke(
+            app,
+            ["column", "set", "--item", "1", "--column", "name", "--value", "New title"],
+        )
+        assert result.exit_code == 5, result.output
+        combined = (result.output or "") + (result.stderr or "")
+        assert "mondo item rename 1 --board 42 --name" in combined
+        assert "--raw" not in combined
+        # Only the context fetch went out — no mutation was attempted.
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_unknown_type_keeps_generic_no_codec_message(self, httpx_mock: HTTPXMock) -> None:
+        """The generic no-codec error (with the --raw suggestion) is
+        unchanged for genuinely unknown column types."""
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_context_response(
+                board_id=42,
+                cols=[{"id": "weird", "title": "W", "type": "doc", "settings_str": "{}"}],
+                values=[{"id": "weird", "type": "doc", "text": "", "value": None}],
+            ),
+        )
+        result = runner.invoke(
+            app,
+            ["column", "set", "--item", "1", "--column", "weird", "--value", "x"],
+        )
+        assert result.exit_code == 5, result.output
+        combined = (result.output or "") + (result.stderr or "")
+        assert "no codec for column type 'doc'" in combined
+        assert "--raw" in combined
+
     def test_tag_names_resolved_to_ids(self, httpx_mock: HTTPXMock) -> None:
         # Context fetch
         httpx_mock.add_response(


### PR DESCRIPTION
Closes #11

## What

`mondo column set --item X --column name --value Y` previously failed with the generic `no codec for column type 'name'. Use --raw …` — a dead end, since `name` isn't a real column and `--raw` can't set it either. The no-codec error path now special-cases `name`:

```
error: 'name' is the item's title, not a settable column. Use: mondo item rename 2851314023 --board 5094861043 --name "<new name>"
```

- Includes the **exact, copy-pasteable** `item rename` invocation (item id and board id are both already resolved at that point; `item rename` requires `--board`).
- Exit code stays 5.
- The generic no-codec message (with the `--raw` suggestion) is unchanged for genuinely codec-less column types.
- `column set-many` takes raw JSON (no codec dispatch) and `item create --column` falls back to raw passthrough on unknown types, so neither reaches this path — left untouched.

## Docs

Added the gotcha to the bundled skill's `references/columns.md` (name is not settable → use `item rename`).

## Verification

- Unit tests: name special-case (asserts the exact rename invocation, no mutation attempted) + generic message regression test. Full unit suite: 1411 passed.
- Live check on the playground board: `mondo column set --item 2851314023 --column name --value X` → exit 5 with the targeted message.