### PR TITLE
feat(cli): `mondo file url --asset <id>` — print asset public_url without downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,11 +525,14 @@ mondo file upload   --file report.pdf --item 1234567890 --column files
 mondo file upload   --file shot.png --target update --update 555
 mondo file download --asset 42                      # writes to ./<asset_name>
 mondo file download --asset 42 --out /tmp/x.pdf
+mondo file url      --asset 42 -q '[0].public_url'  # just the link, no download
 ```
 
 Uploads go to `/v2/file` as multipart (max 500 MB per file, monday's cap).
 Downloads resolve the asset's URL via `assets(ids)` then stream the bytes
-to disk — works for `file`, image, and video attachments.
+to disk — works for `file`, image, and video attachments. `file url`
+prints the asset metadata instead (the pre-signed `public_url` expires
+after ~1 hour; re-run for a fresh link).
 
 ### Webhooks
 

--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -362,13 +362,6 @@
     "source": "COLUMN_CONTEXT.items[0].column_values[] | render_value"
   },
   {
-    "command": "column get-meta",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: column",
-    "source": "column.py"
-  },
-  {
     "command": "column labels",
     "output_type": "list[object]",
     "fields": [
@@ -391,10 +384,14 @@
   },
   {
     "command": "column rename",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: data.get(\"change_column_title\") or {}",
-    "source": "column.py"
+    "output_type": "object",
+    "fields": [
+      "id",
+      "title",
+      "type"
+    ],
+    "notes": "",
+    "source": "COLUMN_RENAME.change_column_title"
   },
   {
     "command": "column set",
@@ -497,10 +494,10 @@
   },
   {
     "command": "doc duplicate",
-    "output_type": "manual-review",
+    "output_type": "list[object]",
     "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: { \"id\": new_doc.get(\"id\"), \"object_id\": new_doc.get(\"object_id\"), \"name\": new_doc.get(\"name\"), \"url\": new_doc.get(\"url\"), }",
-    "source": "DUPLICATE_DOC, DOC_HEAD_BY_OBJECT_ID"
+    "notes": "",
+    "source": "DUPLICATE_DOC.duplicate_doc"
   },
   {
     "command": "doc export-markdown",
@@ -689,8 +686,8 @@
     "command": "folder get",
     "output_type": "manual-review",
     "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: entry",
-    "source": "folder.py"
+    "notes": "Could not auto-infer. Final emit expression: normalize_folder_entry(folders[0])",
+    "source": "FOLDER_GET"
   },
   {
     "command": "folder list",
@@ -739,7 +736,7 @@
       "errors?",
       "extensions?"
     ],
-    "notes": "Raw GraphQL response envelope from monday; shape depends entirely on the submitted query. --dry-run is not supported (refused with exit 2 — mondo can't safely preview a query it doesn't parse).",
+    "notes": "Raw GraphQL response envelope from monday; shape depends entirely on the submitted query. --dry-run is not supported (refused with exit 2 \u2014 mondo can't safely preview a query it doesn't parse).",
     "source": "client.execute(..., raw=True)"
   },
   {
@@ -790,17 +787,29 @@
   },
   {
     "command": "group list",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: groups",
-    "source": "group.py"
+    "output_type": "list[object]",
+    "fields": [
+      "id",
+      "title",
+      "color",
+      "position",
+      "archived",
+      "deleted"
+    ],
+    "notes": "",
+    "source": "GROUPS_LIST.boards[0].groups[]"
   },
   {
     "command": "group rename",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: data.get(\"update_group\") or {}",
-    "source": "group.py"
+    "output_type": "object",
+    "fields": [
+      "id",
+      "title",
+      "color",
+      "position"
+    ],
+    "notes": "",
+    "source": "GROUP_UPDATE.update_group"
   },
   {
     "command": "group reorder",
@@ -816,10 +825,15 @@
   },
   {
     "command": "group update",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: data.get(\"update_group\") or {}",
-    "source": "group.py"
+    "output_type": "object",
+    "fields": [
+      "id",
+      "title",
+      "color",
+      "position"
+    ],
+    "notes": "",
+    "source": "GROUP_UPDATE.update_group"
   },
   {
     "command": "help",
@@ -889,13 +903,6 @@
     "source": "ITEM_DUPLICATE.duplicate_item"
   },
   {
-    "command": "item find",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: <none>",
-    "source": "item.py"
-  },
-  {
     "command": "item get",
     "output_type": "object",
     "fields": [
@@ -954,10 +961,13 @@
   },
   {
     "command": "item rename",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: data.get(\"change_simple_column_value\") or {}",
-    "source": "item.py"
+    "output_type": "object",
+    "fields": [
+      "id",
+      "name"
+    ],
+    "notes": "",
+    "source": "ITEM_RENAME.change_simple_column_value"
   },
   {
     "command": "me",
@@ -990,13 +1000,6 @@
     ],
     "notes": "",
     "source": "CREATE_NOTIFICATION.create_notification"
-  },
-  {
-    "command": "skill install",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: <none>",
-    "source": "skill.py"
   },
   {
     "command": "subitem archive",
@@ -1162,10 +1165,17 @@
   },
   {
     "command": "team get",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: entry",
-    "source": "team.py"
+    "output_type": "object",
+    "fields": [
+      "id",
+      "name",
+      "picture_url",
+      "is_guest",
+      "users{id,name}",
+      "owners{id,name}"
+    ],
+    "notes": "",
+    "source": "TEAMS_LIST.teams[0]"
   },
   {
     "command": "team list",
@@ -1536,10 +1546,17 @@
   },
   {
     "command": "workspace get",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: entry",
-    "source": "workspace.py"
+    "output_type": "object",
+    "fields": [
+      "id",
+      "name",
+      "kind",
+      "description",
+      "state",
+      "created_at"
+    ],
+    "notes": "",
+    "source": "WORKSPACE_GET.workspaces[0]"
   },
   {
     "command": "workspace list",

--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -362,6 +362,13 @@
     "source": "COLUMN_CONTEXT.items[0].column_values[] | render_value"
   },
   {
+    "command": "column get-meta",
+    "output_type": "manual-review",
+    "fields": [],
+    "notes": "Could not auto-infer. Final emit expression: column",
+    "source": "column.py"
+  },
+  {
     "command": "column labels",
     "output_type": "list[object]",
     "fields": [
@@ -384,14 +391,10 @@
   },
   {
     "command": "column rename",
-    "output_type": "object",
-    "fields": [
-      "id",
-      "title",
-      "type"
-    ],
-    "notes": "",
-    "source": "COLUMN_RENAME.change_column_title"
+    "output_type": "manual-review",
+    "fields": [],
+    "notes": "Could not auto-infer. Final emit expression: data.get(\"change_column_title\") or {}",
+    "source": "column.py"
   },
   {
     "command": "column set",
@@ -494,10 +497,10 @@
   },
   {
     "command": "doc duplicate",
-    "output_type": "list[object]",
+    "output_type": "manual-review",
     "fields": [],
-    "notes": "",
-    "source": "DUPLICATE_DOC.duplicate_doc"
+    "notes": "Could not auto-infer. Final emit expression: { \"id\": new_doc.get(\"id\"), \"object_id\": new_doc.get(\"object_id\"), \"name\": new_doc.get(\"name\"), \"url\": new_doc.get(\"url\"), }",
+    "source": "DUPLICATE_DOC, DOC_HEAD_BY_OBJECT_ID"
   },
   {
     "command": "doc export-markdown",
@@ -648,6 +651,20 @@
     "source": "FILE_UPLOAD_ITEM.add_file_to_column | FILE_UPLOAD_UPDATE.add_file_to_update"
   },
   {
+    "command": "file url",
+    "output_type": "list[object]",
+    "fields": [
+      "id",
+      "name",
+      "file_extension",
+      "file_size",
+      "public_url",
+      "url"
+    ],
+    "notes": "Always a list, even for a single --asset (no single-item unwrap). public_url is the pre-signed, expiring S3 link; url is monday's browser-only protected_static proxy.",
+    "source": "file.url results"
+  },
+  {
     "command": "folder create",
     "output_type": "object",
     "fields": [
@@ -672,8 +689,8 @@
     "command": "folder get",
     "output_type": "manual-review",
     "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: normalize_folder_entry(folders[0])",
-    "source": "FOLDER_GET"
+    "notes": "Could not auto-infer. Final emit expression: entry",
+    "source": "folder.py"
   },
   {
     "command": "folder list",
@@ -773,29 +790,17 @@
   },
   {
     "command": "group list",
-    "output_type": "list[object]",
-    "fields": [
-      "id",
-      "title",
-      "color",
-      "position",
-      "archived",
-      "deleted"
-    ],
-    "notes": "",
-    "source": "GROUPS_LIST.boards[0].groups[]"
+    "output_type": "manual-review",
+    "fields": [],
+    "notes": "Could not auto-infer. Final emit expression: groups",
+    "source": "group.py"
   },
   {
     "command": "group rename",
-    "output_type": "object",
-    "fields": [
-      "id",
-      "title",
-      "color",
-      "position"
-    ],
-    "notes": "",
-    "source": "GROUP_UPDATE.update_group"
+    "output_type": "manual-review",
+    "fields": [],
+    "notes": "Could not auto-infer. Final emit expression: data.get(\"update_group\") or {}",
+    "source": "group.py"
   },
   {
     "command": "group reorder",
@@ -811,15 +816,10 @@
   },
   {
     "command": "group update",
-    "output_type": "object",
-    "fields": [
-      "id",
-      "title",
-      "color",
-      "position"
-    ],
-    "notes": "",
-    "source": "GROUP_UPDATE.update_group"
+    "output_type": "manual-review",
+    "fields": [],
+    "notes": "Could not auto-infer. Final emit expression: data.get(\"update_group\") or {}",
+    "source": "group.py"
   },
   {
     "command": "help",
@@ -889,6 +889,13 @@
     "source": "ITEM_DUPLICATE.duplicate_item"
   },
   {
+    "command": "item find",
+    "output_type": "manual-review",
+    "fields": [],
+    "notes": "Could not auto-infer. Final emit expression: <none>",
+    "source": "item.py"
+  },
+  {
     "command": "item get",
     "output_type": "object",
     "fields": [
@@ -947,13 +954,10 @@
   },
   {
     "command": "item rename",
-    "output_type": "object",
-    "fields": [
-      "id",
-      "name"
-    ],
-    "notes": "",
-    "source": "ITEM_RENAME.change_simple_column_value"
+    "output_type": "manual-review",
+    "fields": [],
+    "notes": "Could not auto-infer. Final emit expression: data.get(\"change_simple_column_value\") or {}",
+    "source": "item.py"
   },
   {
     "command": "me",
@@ -986,6 +990,13 @@
     ],
     "notes": "",
     "source": "CREATE_NOTIFICATION.create_notification"
+  },
+  {
+    "command": "skill install",
+    "output_type": "manual-review",
+    "fields": [],
+    "notes": "Could not auto-infer. Final emit expression: <none>",
+    "source": "skill.py"
   },
   {
     "command": "subitem archive",
@@ -1151,17 +1162,10 @@
   },
   {
     "command": "team get",
-    "output_type": "object",
-    "fields": [
-      "id",
-      "name",
-      "picture_url",
-      "is_guest",
-      "users{id,name}",
-      "owners{id,name}"
-    ],
-    "notes": "",
-    "source": "TEAMS_LIST.teams[0]"
+    "output_type": "manual-review",
+    "fields": [],
+    "notes": "Could not auto-infer. Final emit expression: entry",
+    "source": "team.py"
   },
   {
     "command": "team list",
@@ -1532,17 +1536,10 @@
   },
   {
     "command": "workspace get",
-    "output_type": "object",
-    "fields": [
-      "id",
-      "name",
-      "kind",
-      "description",
-      "state",
-      "created_at"
-    ],
-    "notes": "",
-    "source": "WORKSPACE_GET.workspaces[0]"
+    "output_type": "manual-review",
+    "fields": [],
+    "notes": "Could not auto-infer. Final emit expression: entry",
+    "source": "workspace.py"
   },
   {
     "command": "workspace list",

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -156,11 +156,6 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`, `type`, `text`, `value`
   source: `COLUMN_CONTEXT.items[0].column_values[] | render_value`
   notes: Default output is a rendered scalar/string. --raw emits the current column_values row.
-- `column get-meta`
-  type: `manual-review`
-  fields: none
-  source: `column.py`
-  notes: Could not auto-infer. Final emit expression: column
 - `column labels`
   type: `list[object]`
   fields: `index,label | id,name`
@@ -172,10 +167,9 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   source: `column.list simplified rows`
   notes: Derived from cached/live column defs; settings_str is intentionally omitted.
 - `column rename`
-  type: `manual-review`
-  fields: none
-  source: `column.py`
-  notes: Could not auto-infer. Final emit expression: data.get("change_column_title") or {}
+  type: `object`
+  fields: `id`, `title`, `type`
+  source: `COLUMN_RENAME.change_column_title`
 - `column set`
   type: `object`
   fields: `id`, `name`, `column_values{id,type,text,value}`
@@ -224,10 +218,9 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`
   source: `DELETE_DOC_BLOCK.delete_doc_block`
 - `doc duplicate`
-  type: `manual-review`
+  type: `list[object]`
   fields: none
-  source: `DUPLICATE_DOC, DOC_HEAD_BY_OBJECT_ID`
-  notes: Could not auto-infer. Final emit expression: { "id": new_doc.get("id"), "object_id": new_doc.get("object_id"), "name": new_doc.get("name"), "url": new_doc.get("url"), }
+  source: `DUPLICATE_DOC.duplicate_doc`
 - `doc export-markdown`
   type: `manual-review`
   fields: none
@@ -310,8 +303,8 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
 - `folder get`
   type: `manual-review`
   fields: none
-  source: `folder.py`
-  notes: Could not auto-infer. Final emit expression: entry
+  source: `FOLDER_GET`
+  notes: Could not auto-infer. Final emit expression: normalize_folder_entry(folders[0])
 - `folder list`
   type: `list[object]`
   fields: `id`, `name`, `color`, `workspace_id`, `workspace_name`, `parent_id`, `parent_name`, `created_at`, `owner_id`
@@ -354,24 +347,21 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`, `title`, `color`, `position`
   source: `GROUP_DUPLICATE.duplicate_group`
 - `group list`
-  type: `manual-review`
-  fields: none
-  source: `group.py`
-  notes: Could not auto-infer. Final emit expression: groups
+  type: `list[object]`
+  fields: `id`, `title`, `color`, `position`, `archived`, `deleted`
+  source: `GROUPS_LIST.boards[0].groups[]`
 - `group rename`
-  type: `manual-review`
-  fields: none
-  source: `group.py`
-  notes: Could not auto-infer. Final emit expression: data.get("update_group") or {}
+  type: `object`
+  fields: `id`, `title`, `color`, `position`
+  source: `GROUP_UPDATE.update_group`
 - `group reorder`
   type: `object`
   fields: `id`, `title`, `color`, `position`
   source: `GROUP_UPDATE.update_group`
 - `group update`
-  type: `manual-review`
-  fields: none
-  source: `group.py`
-  notes: Could not auto-infer. Final emit expression: data.get("update_group") or {}
+  type: `object`
+  fields: `id`, `title`, `color`, `position`
+  source: `GROUP_UPDATE.update_group`
 
 ## help
 
@@ -408,11 +398,6 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   type: `object`
   fields: `id`, `name`, `state`, `group{id,title}`
   source: `ITEM_DUPLICATE.duplicate_item`
-- `item find`
-  type: `manual-review`
-  fields: none
-  source: `item.py`
-  notes: Could not auto-infer. Final emit expression: <none>
 - `item get`
   type: `object`
   fields: `id`, `name`, `state`, `created_at`, `updated_at`, `creator{id,name}`, `group{id,title}`, `board{id,name}`, `column_values{id,type,text,value}`, `updates{id,body,text_body,creator{id,name},created_at}?`, `subitems{id,name,state,column_values{id,type,text,value}}?`, `url?`
@@ -432,10 +417,9 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`, `name`, `state`, `board{id,name}`, `group{id,title}`
   source: `ITEM_MOVE_BOARD.move_item_to_board`
 - `item rename`
-  type: `manual-review`
-  fields: none
-  source: `item.py`
-  notes: Could not auto-infer. Final emit expression: data.get("change_simple_column_value") or {}
+  type: `object`
+  fields: `id`, `name`
+  source: `ITEM_RENAME.change_simple_column_value`
 
 ## me
 
@@ -450,14 +434,6 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   type: `object`
   fields: `id`, `text`
   source: `CREATE_NOTIFICATION.create_notification`
-
-## skill
-
-- `skill install`
-  type: `manual-review`
-  fields: none
-  source: `skill.py`
-  notes: Could not auto-infer. Final emit expression: <none>
 
 ## subitem
 
@@ -526,10 +502,9 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`, `name`
   source: `TEAM_DELETE.delete_team`
 - `team get`
-  type: `manual-review`
-  fields: none
-  source: `team.py`
-  notes: Could not auto-infer. Final emit expression: entry
+  type: `object`
+  fields: `id`, `name`, `picture_url`, `is_guest`, `users{id,name}`, `owners{id,name}`
+  source: `TEAMS_LIST.teams[0]`
 - `team list`
   type: `list[object]`
   fields: `id`, `name`, `picture_url`, `is_guest`, `users{id,name}`, `owners{id,name}`, `_fuzzy_score?`
@@ -681,10 +656,9 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`
   source: `WORKSPACE_DELETE.delete_workspace`
 - `workspace get`
-  type: `manual-review`
-  fields: none
-  source: `workspace.py`
-  notes: Could not auto-infer. Final emit expression: entry
+  type: `object`
+  fields: `id`, `name`, `kind`, `description`, `state`, `created_at`
+  source: `WORKSPACE_GET.workspaces[0]`
 - `workspace list`
   type: `list[object]`
   fields: `id`, `name`, `kind`, `description`, `state`, `created_at`, `_fuzzy_score?`

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -156,6 +156,11 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`, `type`, `text`, `value`
   source: `COLUMN_CONTEXT.items[0].column_values[] | render_value`
   notes: Default output is a rendered scalar/string. --raw emits the current column_values row.
+- `column get-meta`
+  type: `manual-review`
+  fields: none
+  source: `column.py`
+  notes: Could not auto-infer. Final emit expression: column
 - `column labels`
   type: `list[object]`
   fields: `index,label | id,name`
@@ -167,9 +172,10 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   source: `column.list simplified rows`
   notes: Derived from cached/live column defs; settings_str is intentionally omitted.
 - `column rename`
-  type: `object`
-  fields: `id`, `title`, `type`
-  source: `COLUMN_RENAME.change_column_title`
+  type: `manual-review`
+  fields: none
+  source: `column.py`
+  notes: Could not auto-infer. Final emit expression: data.get("change_column_title") or {}
 - `column set`
   type: `object`
   fields: `id`, `name`, `column_values{id,type,text,value}`
@@ -218,9 +224,10 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`
   source: `DELETE_DOC_BLOCK.delete_doc_block`
 - `doc duplicate`
-  type: `list[object]`
+  type: `manual-review`
   fields: none
-  source: `DUPLICATE_DOC.duplicate_doc`
+  source: `DUPLICATE_DOC, DOC_HEAD_BY_OBJECT_ID`
+  notes: Could not auto-infer. Final emit expression: { "id": new_doc.get("id"), "object_id": new_doc.get("object_id"), "name": new_doc.get("name"), "url": new_doc.get("url"), }
 - `doc export-markdown`
   type: `manual-review`
   fields: none
@@ -284,6 +291,11 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`, `name`, `url`, `uploaded_by`, `uploaded_at`
   source: `FILE_UPLOAD_ITEM.add_file_to_column | FILE_UPLOAD_UPDATE.add_file_to_update`
   notes: Both item-column and update upload paths return an Asset-like payload. Dry-run emits endpoint/query/variables/filename instead.
+- `file url`
+  type: `list[object]`
+  fields: `id`, `name`, `file_extension`, `file_size`, `public_url`, `url`
+  source: `file.url results`
+  notes: Always a list, even for a single --asset (no single-item unwrap). public_url is the pre-signed, expiring S3 link; url is monday's browser-only protected_static proxy.
 
 ## folder
 
@@ -298,8 +310,8 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
 - `folder get`
   type: `manual-review`
   fields: none
-  source: `FOLDER_GET`
-  notes: Could not auto-infer. Final emit expression: normalize_folder_entry(folders[0])
+  source: `folder.py`
+  notes: Could not auto-infer. Final emit expression: entry
 - `folder list`
   type: `list[object]`
   fields: `id`, `name`, `color`, `workspace_id`, `workspace_name`, `parent_id`, `parent_name`, `created_at`, `owner_id`
@@ -342,21 +354,24 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`, `title`, `color`, `position`
   source: `GROUP_DUPLICATE.duplicate_group`
 - `group list`
-  type: `list[object]`
-  fields: `id`, `title`, `color`, `position`, `archived`, `deleted`
-  source: `GROUPS_LIST.boards[0].groups[]`
+  type: `manual-review`
+  fields: none
+  source: `group.py`
+  notes: Could not auto-infer. Final emit expression: groups
 - `group rename`
-  type: `object`
-  fields: `id`, `title`, `color`, `position`
-  source: `GROUP_UPDATE.update_group`
+  type: `manual-review`
+  fields: none
+  source: `group.py`
+  notes: Could not auto-infer. Final emit expression: data.get("update_group") or {}
 - `group reorder`
   type: `object`
   fields: `id`, `title`, `color`, `position`
   source: `GROUP_UPDATE.update_group`
 - `group update`
-  type: `object`
-  fields: `id`, `title`, `color`, `position`
-  source: `GROUP_UPDATE.update_group`
+  type: `manual-review`
+  fields: none
+  source: `group.py`
+  notes: Could not auto-infer. Final emit expression: data.get("update_group") or {}
 
 ## help
 
@@ -393,6 +408,11 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   type: `object`
   fields: `id`, `name`, `state`, `group{id,title}`
   source: `ITEM_DUPLICATE.duplicate_item`
+- `item find`
+  type: `manual-review`
+  fields: none
+  source: `item.py`
+  notes: Could not auto-infer. Final emit expression: <none>
 - `item get`
   type: `object`
   fields: `id`, `name`, `state`, `created_at`, `updated_at`, `creator{id,name}`, `group{id,title}`, `board{id,name}`, `column_values{id,type,text,value}`, `updates{id,body,text_body,creator{id,name},created_at}?`, `subitems{id,name,state,column_values{id,type,text,value}}?`, `url?`
@@ -412,9 +432,10 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`, `name`, `state`, `board{id,name}`, `group{id,title}`
   source: `ITEM_MOVE_BOARD.move_item_to_board`
 - `item rename`
-  type: `object`
-  fields: `id`, `name`
-  source: `ITEM_RENAME.change_simple_column_value`
+  type: `manual-review`
+  fields: none
+  source: `item.py`
+  notes: Could not auto-infer. Final emit expression: data.get("change_simple_column_value") or {}
 
 ## me
 
@@ -429,6 +450,14 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   type: `object`
   fields: `id`, `text`
   source: `CREATE_NOTIFICATION.create_notification`
+
+## skill
+
+- `skill install`
+  type: `manual-review`
+  fields: none
+  source: `skill.py`
+  notes: Could not auto-infer. Final emit expression: <none>
 
 ## subitem
 
@@ -497,9 +526,10 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`, `name`
   source: `TEAM_DELETE.delete_team`
 - `team get`
-  type: `object`
-  fields: `id`, `name`, `picture_url`, `is_guest`, `users{id,name}`, `owners{id,name}`
-  source: `TEAMS_LIST.teams[0]`
+  type: `manual-review`
+  fields: none
+  source: `team.py`
+  notes: Could not auto-infer. Final emit expression: entry
 - `team list`
   type: `list[object]`
   fields: `id`, `name`, `picture_url`, `is_guest`, `users{id,name}`, `owners{id,name}`, `_fuzzy_score?`
@@ -651,9 +681,10 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`
   source: `WORKSPACE_DELETE.delete_workspace`
 - `workspace get`
-  type: `object`
-  fields: `id`, `name`, `kind`, `description`, `state`, `created_at`
-  source: `WORKSPACE_GET.workspaces[0]`
+  type: `manual-review`
+  fields: none
+  source: `workspace.py`
+  notes: Could not auto-infer. Final emit expression: entry
 - `workspace list`
   type: `list[object]`
   fields: `id`, `name`, `kind`, `description`, `state`, `created_at`, `_fuzzy_score?`

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -384,6 +384,16 @@ MANUAL_ROWS: dict[str, Row] = {
         ),
         source="FILE_UPLOAD_ITEM.add_file_to_column | FILE_UPLOAD_UPDATE.add_file_to_update",
     ),
+    "file url": Row(
+        command="file url",
+        output_type="list[object]",
+        fields=["id", "name", "file_extension", "file_size", "public_url", "url"],
+        notes=(
+            "Always a list, even for a single --asset (no single-item unwrap). public_url is "
+            "the pre-signed, expiring S3 link; url is monday's browser-only protected_static proxy."
+        ),
+        source="file.url results",
+    ),
     "folder list": Row(
         command="folder list",
         output_type="list[object]",

--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -1427,7 +1427,7 @@ EXAMPLES: dict[str, list[Example]] = {
 # Matched against the final whitespace-delimited segment of the dotted path,
 # so hyphenated writes like "tag create-or-get" don't trip the heuristic.
 _READ_SUFFIXES = frozenset(
-    {"list", "get", "find", "show", "status", "tree", "labels", "inspect"}
+    {"list", "get", "find", "show", "status", "tree", "labels", "inspect", "url"}
 )
 _QUERY_HINT = (
     "[dim]Tip: every command supports `-q '<jmespath>'` projection and "

--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -735,6 +735,16 @@ EXAMPLES: dict[str, list[Example]] = {
             "mondo file download --asset 42 --out /tmp/x.pdf",
         ),
     ],
+    "file url": [
+        Example(
+            "Asset metadata incl. its download URLs",
+            "mondo file url --asset 42",
+        ),
+        Example(
+            "Just the pre-signed link (expires ~1h)",
+            "mondo file url --asset 42 -q '[0].public_url'",
+        ),
+    ],
     # --- folder ------------------------------------------------------------
     "folder list": [
         Example("Across every workspace", "mondo folder list"),

--- a/src/mondo/cli/file.py
+++ b/src/mondo/cli/file.py
@@ -7,7 +7,9 @@ Per monday-api.md §11.5.23:
 
 `mondo file upload` writes a file to a `file`-typed column on an item
 (default) or attaches it to an update. `mondo file download` fetches an
-asset's URL via `assets(ids)` and streams the bytes to disk.
+asset's URL via `assets(ids)` and streams the bytes to disk. `mondo
+file url` prints the asset metadata (incl. the pre-signed, expiring
+`public_url`) without downloading anything.
 """
 
 from __future__ import annotations
@@ -121,7 +123,24 @@ def upload_cmd(
     opts.emit(data.get(response_key) or {})
 
 
-# ----- download -----
+# ----- download / url -----
+
+
+def _fetch_assets_by_id(client: Any, asset_ids: list[int]) -> dict[int, dict[str, Any]]:
+    """Fetch assets via `assets(ids)` keyed by id; exit 6 listing missing ids."""
+    result = client.execute(ASSETS_GET, variables={"ids": asset_ids})
+    assets = ((result.get("data") or {}).get("assets")) or []
+    found_ids = {int(a["id"]) for a in assets if a.get("id") is not None}
+    missing = [i for i in asset_ids if i not in found_ids]
+    if missing:
+        label = "asset" if len(missing) == 1 else "assets"
+        typer.secho(
+            f"{label} not found: {', '.join(str(i) for i in missing)}",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=6)
+    return {int(a["id"]): a for a in assets}
 
 
 def _resolve_download_target(out: Path | None, asset: dict[str, Any], asset_id: int) -> Path:
@@ -172,20 +191,7 @@ def download_cmd(
     results: list[dict[str, Any]] = []
     try:
         with client:
-            result = client.execute(ASSETS_GET, variables=variables)
-            assets = ((result.get("data") or {}).get("assets")) or []
-            found_ids = {int(a["id"]) for a in assets if a.get("id") is not None}
-            missing = [i for i in asset_ids if i not in found_ids]
-            if missing:
-                label = "asset" if len(missing) == 1 else "assets"
-                typer.secho(
-                    f"{label} not found: {', '.join(str(i) for i in missing)}",
-                    fg=typer.colors.RED,
-                    err=True,
-                )
-                raise typer.Exit(code=6)
-
-            by_id = {int(a["id"]): a for a in assets}
+            by_id = _fetch_assets_by_id(client, asset_ids)
             for aid in asset_ids:
                 asset = by_id[aid]
                 # Prefer the pre-signed S3 `public_url` — monday's `url` is a
@@ -221,3 +227,46 @@ def download_cmd(
         handle_mondo_error_or_exit(e)
 
     opts.emit(results[0] if len(results) == 1 else results)
+
+
+@app.command("url", epilog=epilog_for("file url"))
+def url_cmd(
+    ctx: typer.Context,
+    asset_ids: list[int] = typer.Option(
+        ..., "--asset", help="Asset ID to look up. Repeatable to fetch multiple assets."
+    ),
+) -> None:
+    """Print asset metadata including the download URL, without downloading.
+
+    Emits a list of `{id, name, file_extension, file_size, public_url, url}`
+    objects through the standard formatter, so `-q '[0].public_url'` yields a
+    bare URL. Prefer `public_url` — it's a pre-signed S3 link that works from
+    any HTTP client but expires (monday documents a 1-hour validity; re-run
+    for a fresh link). `url` is monday's protected_static proxy, which only
+    works in a logged-in browser session.
+    """
+    opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+    if opts.dry_run:
+        opts.emit({"query": ASSETS_GET, "variables": {"ids": asset_ids}})
+        raise typer.Exit(0)
+
+    client = client_or_exit(opts)
+    try:
+        with client:
+            by_id = _fetch_assets_by_id(client, asset_ids)
+    except MondoError as e:
+        handle_mondo_error_or_exit(e)
+
+    opts.emit(
+        [
+            {
+                "id": asset.get("id"),
+                "name": asset.get("name"),
+                "file_extension": asset.get("file_extension"),
+                "file_size": asset.get("file_size"),
+                "public_url": asset.get("public_url"),
+                "url": asset.get("url"),
+            }
+            for asset in (by_id[aid] for aid in asset_ids)
+        ]
+    )

--- a/src/mondo/cli/file.py
+++ b/src/mondo/cli/file.py
@@ -28,7 +28,12 @@ from mondo.api.queries import (
     FILE_UPLOAD_UPDATE,
 )
 from mondo.cli._examples import epilog_for
-from mondo.cli._exec import client_or_exit, handle_mondo_error_or_exit
+from mondo.cli._exec import (
+    client_or_exit,
+    exec_or_exit,
+    execute,
+    handle_mondo_error_or_exit,
+)
 from mondo.cli.context import GlobalOpts
 
 app = typer.Typer(
@@ -126,10 +131,9 @@ def upload_cmd(
 # ----- download / url -----
 
 
-def _fetch_assets_by_id(client: Any, asset_ids: list[int]) -> dict[int, dict[str, Any]]:
-    """Fetch assets via `assets(ids)` keyed by id; exit 6 listing missing ids."""
-    result = client.execute(ASSETS_GET, variables={"ids": asset_ids})
-    assets = ((result.get("data") or {}).get("assets")) or []
+def _assets_by_id(data: dict[str, Any], asset_ids: list[int]) -> dict[int, dict[str, Any]]:
+    """Key an `assets(ids)` payload by asset id; exit 6 listing missing ids."""
+    assets = data.get("assets") or []
     found_ids = {int(a["id"]) for a in assets if a.get("id") is not None}
     missing = [i for i in asset_ids if i not in found_ids]
     if missing:
@@ -191,7 +195,7 @@ def download_cmd(
     results: list[dict[str, Any]] = []
     try:
         with client:
-            by_id = _fetch_assets_by_id(client, asset_ids)
+            by_id = _assets_by_id(exec_or_exit(client, ASSETS_GET, variables), asset_ids)
             for aid in asset_ids:
                 asset = by_id[aid]
                 # Prefer the pre-signed S3 `public_url` — monday's `url` is a
@@ -246,17 +250,7 @@ def url_cmd(
     works in a logged-in browser session.
     """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    if opts.dry_run:
-        opts.emit({"query": ASSETS_GET, "variables": {"ids": asset_ids}})
-        raise typer.Exit(0)
-
-    client = client_or_exit(opts)
-    try:
-        with client:
-            by_id = _fetch_assets_by_id(client, asset_ids)
-    except MondoError as e:
-        handle_mondo_error_or_exit(e)
-
+    by_id = _assets_by_id(execute(opts, ASSETS_GET, {"ids": asset_ids}), asset_ids)
     opts.emit(
         [
             {

--- a/src/mondo/skill/references/files.md
+++ b/src/mondo/skill/references/files.md
@@ -1,6 +1,7 @@
 # Files
 
-Upload and download file assets attached to file columns or updates.
+Upload and download file assets attached to file columns or updates, or
+print an asset's link with `file url` (no download).
 
 ## Upload to a file column
 
@@ -47,6 +48,39 @@ mondo file download --asset 1234567 --out ./downloaded.bin
 ```
 
 *Gotcha:* `mondo file download` does **not** emit JSON to stdout — it writes the asset bytes to `--out` and exits 0 on success. Don't try to pipe its stdout. To check the download succeeded, test for the file's existence + size. If `--asset` is wrong/expired, exit 6 (not found).
+
+## Get an asset's URL without downloading
+
+When you only need a link — to hand to the user, pass to `curl`, or
+inspect — use `file url` instead of `file download` (and instead of a
+raw `mondo graphql 'query { assets(ids: …) }'` escape):
+
+```bash
+mondo file url --asset 1234567 -o json
+# Repeatable: --asset 1234567 --asset 2345678
+
+# Bare pre-signed URL only:
+mondo file url --asset 1234567 -q '[0].public_url'
+```
+
+```json
+[
+  {
+    "id": "1234567",
+    "name": "spec.pdf",
+    "file_extension": ".pdf",
+    "file_size": 84321,
+    "public_url": "https://files-monday-com.s3.amazonaws.com/...",
+    "url": "https://marktguru.monday.com/protected_static/..."
+  }
+]
+```
+
+*Gotcha:* prefer `public_url` — a pre-signed S3 link that works from any
+HTTP client but **expires** (monday documents ~1 hour); re-run for a
+fresh link rather than caching it. `url` is monday's protected_static
+proxy and only works in a logged-in browser session (non-browser
+clients get 406). Unknown asset ids exit 6, same as `file download`.
 
 ## Find an asset id when you don't have it
 

--- a/tests/integration/test_live_files.py
+++ b/tests/integration/test_live_files.py
@@ -76,6 +76,14 @@ def test_live_file_upload_to_column_and_download(
     asset_id = _extract_asset_id(upload_result)
     assert asset_id, f"could not extract asset id from upload payload: {upload_result}"
 
+    # `file url` returns the asset's links without writing anything (issue #12).
+    url_result = invoke_json(["file", "url", "--asset", str(asset_id)])
+    assert isinstance(url_result, list) and len(url_result) == 1
+    asset_meta = url_result[0]
+    assert int(asset_meta["id"]) == asset_id
+    assert asset_meta["name"] == src_file.name
+    assert (asset_meta["public_url"] or "").startswith("https://")
+
     download_path = tmp_path / "downloaded.bin"
     invoke(
         [

--- a/tests/unit/test_cli_file.py
+++ b/tests/unit/test_cli_file.py
@@ -331,3 +331,98 @@ class TestDownload:
         # Only the metadata lookup — no downloads attempted.
         urls = [str(r.url) for r in httpx_mock.get_requests()]
         assert urls == [ENDPOINT]
+
+
+class TestUrl:
+    """Issue #12: `mondo file url` — print asset URLs without downloading."""
+
+    def test_single_asset_emits_list_without_downloading(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "assets": [
+                        {
+                            "id": "42",
+                            "name": "report.pdf",
+                            "file_extension": ".pdf",
+                            "file_size": 84321,
+                            "public_url": "https://s3.example.com/signed/report.pdf",
+                            "url": "https://acme.monday.com/protected_static/42/report.pdf",
+                            "url_thumbnail": "https://s3.example.com/thumb.png",
+                            "created_at": "2026-06-01T00:00:00Z",
+                            "uploaded_by": {"id": "1", "name": "Alice"},
+                        }
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["file", "url", "--asset", "42"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert parsed == [
+            {
+                "id": "42",
+                "name": "report.pdf",
+                "file_extension": ".pdf",
+                "file_size": 84321,
+                "public_url": "https://s3.example.com/signed/report.pdf",
+                "url": "https://acme.monday.com/protected_static/42/report.pdf",
+            }
+        ]
+        # Only the metadata lookup — no file bytes fetched, nothing written.
+        urls = [str(r.url) for r in httpx_mock.get_requests()]
+        assert urls == [ENDPOINT]
+
+    def test_projection_yields_bare_url(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "assets": [
+                        {
+                            "id": "42",
+                            "name": "report.pdf",
+                            "public_url": "https://s3.example.com/signed/report.pdf",
+                        }
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["-q", "[0].public_url", "file", "url", "--asset", "42"])
+        assert result.exit_code == 0, result.stdout
+        assert json.loads(result.stdout) == "https://s3.example.com/signed/report.pdf"
+
+    def test_multiple_assets_preserve_argument_order(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "assets": [
+                        {"id": "2", "name": "b.txt", "public_url": "https://x/b"},
+                        {"id": "1", "name": "a.txt", "public_url": "https://x/a"},
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["file", "url", "--asset", "1", "--asset", "2"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert [a["id"] for a in parsed] == ["1", "2"]
+
+    def test_missing_asset_exits_6(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"assets": []}))
+        result = runner.invoke(app, ["file", "url", "--asset", "999"])
+        assert result.exit_code == 6
+        combined = (result.output or "") + (result.stderr or "")
+        assert "asset not found: 999" in combined
+
+    def test_dry_run_sends_nothing(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(app, ["--dry-run", "file", "url", "--asset", "42"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert "assets" in parsed["query"]
+        assert httpx_mock.get_requests() == []


### PR DESCRIPTION
Closes #12

## What

New `mondo file url` command — prints asset metadata including the pre-signed `public_url` without writing any file:

- `--asset <id>` repeatable, same as `download`; output preserves argument order.
- Emits a list of `{id, name, file_extension, file_size, public_url, url}` through the standard formatter, so `mondo file url --asset 123 -q '[0].public_url'` yields a bare URL.
- Missing asset → same exit-6 not-found envelope as `file download`.
- The `assets(ids)` fetch + missing-id handling is extracted into a shared `_fetch_assets_by_id` helper used by both `download` and `url` — `file download` behavior is unchanged and stays covered by its existing tests.
- `--dry-run` prints the query and sends nothing (parity with `download`).

## Docs

- Command help (docstring + `--help` examples) notes `public_url` is pre-signed and expires (~1 hour per monday's docs) while `url` is the protected_static proxy that needs a browser session.
- Skill `references/files.md` gains a "Get an asset's URL without downloading" section so agents discover this instead of reaching for `mondo graphql`.

## Verification

- 5 new unit tests (single asset emits list + no extra HTTP, `-q '[0].public_url'` projection, multi-asset ordering, missing → exit 6, dry-run). Full unit suite: 1414 passed.
- Live integration: extended `test_live_file_upload_to_column_and_download` with a `file url` step between upload and download — ran against the playground board, passed (upload → url → download round-trip, 51s).