### PR TITLE
feat(cli): add --with-url to `board create` (and `doc create`) for single-call create + link

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ mondo board list       [--state active|archived|deleted|all] [--kind public|priv
                        [--limit 100] [--max-items 500]
 mondo board get        --id 1234567890
 mondo board create     --name "Roadmap" --kind public [--workspace 42] [--description …] \
-                       [--owner 7] [--subscriber 8] [--empty]
+                       [--owner 7] [--subscriber 8] [--empty] [--with-url]
 mondo board update     --id 1234567890 --attribute name --value "Renamed"
 mondo board archive    --id 1234567890                   # reversible (30 days)
 mondo board delete     --id 1234567890 --hard --yes      # permanent

--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -112,9 +112,10 @@
       "state",
       "board_kind",
       "workspace_id",
-      "board_folder_id"
+      "board_folder_id",
+      "url?"
     ],
-    "notes": "",
+    "notes": "url is present only when --with-url is passed (stripped otherwise).",
     "source": "BOARD_CREATE.create_board"
   },
   {

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -59,8 +59,9 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   source: `BOARD_ARCHIVE.archive_board`
 - `board create`
   type: `object`
-  fields: `id`, `name`, `description`, `state`, `board_kind`, `workspace_id`, `board_folder_id`
+  fields: `id`, `name`, `description`, `state`, `board_kind`, `workspace_id`, `board_folder_id`, `url?`
   source: `BOARD_CREATE.create_board`
+  notes: url is present only when --with-url is passed (stripped otherwise).
 - `board delete`
   type: `object`
   fields: `id`, `name`, `state`

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -120,6 +120,22 @@ MANUAL_ROWS: dict[str, Row] = {
         notes="Custom flattened identity/status payload.",
         source="auth.status payload",
     ),
+    "board create": Row(
+        command="board create",
+        output_type="object",
+        fields=[
+            "id",
+            "name",
+            "description",
+            "state",
+            "board_kind",
+            "workspace_id",
+            "board_folder_id",
+            "url?",
+        ],
+        notes="url is present only when --with-url is passed (stripped otherwise).",
+        source="BOARD_CREATE.create_board",
+    ),
     "board duplicate": Row(
         command="board duplicate",
         output_type="object",

--- a/src/mondo/api/queries.py
+++ b/src/mondo/api/queries.py
@@ -1356,6 +1356,7 @@ mutation (
     board_kind
     workspace_id
     board_folder_id
+    url
   }
 }
 """.strip()

--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -176,6 +176,10 @@ EXAMPLES: dict[str, list[Example]] = {
             "Create an empty board (no starter items/groups)",
             'mondo board create --name "Scratch" --kind public --empty',
         ),
+        Example(
+            "Create and get the board's URL in one call",
+            'mondo board create --name "Roadmap" --kind public --with-url -q url -o none',
+        ),
     ],
     "board update": [
         Example(

--- a/src/mondo/cli/board.py
+++ b/src/mondo/cli/board.py
@@ -707,6 +707,11 @@ def create_cmd(
     empty: bool = typer.Option(
         False, "--empty", help="Create without the default group/column structure."
     ),
+    with_url: bool = typer.Option(
+        False,
+        "--with-url",
+        help="Include the new board's canonical monday.com URL in the emitted payload.",
+    ),
 ) -> None:
     """Create a new board."""
     from mondo.cli._cache_invalidate import invalidate_entity
@@ -728,7 +733,10 @@ def create_cmd(
     }
     data = execute(opts, BOARD_CREATE, variables)
     invalidate_entity(opts, "boards")
-    opts.emit(normalize_board_entry(data.get("create_board") or {}))
+    payload = data.get("create_board") or {}
+    if not with_url:
+        payload.pop("url", None)
+    opts.emit(normalize_board_entry(payload))
 
 
 @app.command("update", epilog=epilog_for("board update"))

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -727,11 +727,17 @@ def create_cmd(
     kind: DocKind | None = typer.Option(
         None, "--kind", help="public / private / share.", case_sensitive=False
     ),
+    with_url: bool = typer.Option(
+        False,
+        "--with-url",
+        help="(No-op for docs — `url` is always present in the payload.)",
+    ),
 ) -> None:
     """Create a new doc inside a workspace."""
     from mondo.cli._normalize import normalize_doc_entry
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+    del with_url  # docs always carry `url` from monday; flag kept for symmetry
     variables = {
         "workspace": workspace,
         "name": name,

--- a/src/mondo/help/agent-tips.md
+++ b/src/mondo/help/agent-tips.md
@@ -57,12 +57,14 @@ graphql`:
 |-------------------|-----------------------------------------------------|
 | `board list`      | `--with-item-counts`, `--with-url`, `--with-tags`   |
 | `board get`       | `--with-url`, `--with-views`                        |
+| `board create`    | `--with-url` (returns the new board's URL without a follow-up GET) |
 | `item get`        | `--with-url`                                        |
 | `item create`     | `--with-url` (returns the new item's URL without a follow-up GET) |
 | `item duplicate`  | `--with-updates`                                    |
 | `subitem get`     | `--with-url`                                        |
 | `doc list`        | `--with-url`                                        |
 | `doc get`         | `--with-url`                                        |
+| `doc create`      | `--with-url` (no-op: the create payload always carries `url`; accepted for symmetry) |
 
 Some of these (e.g. `--with-item-counts`, `--with-tags`) bypass the
 local cache because the extra fields aren't cached — read each

--- a/src/mondo/help/boards-vs-docs.md
+++ b/src/mondo/help/boards-vs-docs.md
@@ -35,8 +35,9 @@ board portion of the URL is discarded — the pulse id is globally unique.
 
 ## Get a URL back out of a payload
 
-Pass `--with-url` on `board get`, `item get`, `subitem get`, or
-`item create` to include a canonical monday URL in the emitted payload:
+Pass `--with-url` on `board get`, `board create`, `item get`,
+`subitem get`, or `item create` to include a canonical monday URL in
+the emitted payload:
 
     $ mondo item get 12345 --with-url -q url -o none
     https://<tenant>.monday.com/boards/42/pulses/12345
@@ -46,7 +47,9 @@ Pass `--with-url` on `board get`, `item get`, `subitem get`, or
     https://<tenant>.monday.com/boards/42/pulses/99
 
 `mondo doc get` always includes `url` (monday's `docs()` endpoint returns
-it); `--with-url` there is accepted but has no effect.
+it); `--with-url` there is accepted but has no effect. `mondo doc create`
+behaves the same way: its payload always includes `url`, so the flag is
+a no-op there too.
 
 On `board list` and `doc list`, `--with-url` is opt-in: the default output
 has no `url` / `relative_url` so the two commands emit the same core shape.

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -70,7 +70,7 @@ Consult these *before* improvising. Each is a Goal / Command / Output / Gotcha s
 - **Stable exit codes:** 0 ok · 2 usage · 3 auth · 4 rate/complexity (retry after 60s) · 5 validation · 6 not-found · 7 network.
 - **Dry-run writes first:** every typed mutating command takes `--dry-run` (prints GraphQL + variables, sends nothing). Use it when the task is unfamiliar. Not supported on `mondo graphql` — the raw passthrough refuses `--dry-run` with exit 2 because mondo can't safely preview a query it doesn't parse.
 - **Batch:** `--batch <file.json>` on bulk operations (`item create`, `column set`, `import board`). Returns a per-row envelope; partial failure → exit 1, full success → exit 0.
-- **URLs:** pass `--with-url` on `board get`, `board list`, `item get`, `item create` (NEW — single-call create + URL retrieval), `subitem get`, `doc get`, `doc list` to return a clickable monday.com link to the user.
+- **URLs:** pass `--with-url` on `board get`, `board list`, `board create`, `item get`, `item create`, `subitem get`, `doc get`, `doc list`, `doc create` to return a clickable monday.com link to the user. On the create commands this is single-call create + URL retrieval (no extra request).
 - **Wait for async state changes** with `--poll-until '<jmespath>'` + `--poll-interval` + `--poll-timeout` on `item list`, `item get`, `board get` — replaces hand-rolled bash `until/sleep` loops.
 - **Find items by column value** with `mondo item find --board X --column COL --value VAL` (sugar over `item list --filter`, with the same codec dispatch).
 - **Inspect a single column's metadata** with `mondo column get-meta --board X --column COL` (returns one column with `settings_str` preserved; `column list` strips it).

--- a/src/mondo/skill/references/boards.md
+++ b/src/mondo/skill/references/boards.md
@@ -60,6 +60,13 @@ mondo board create \
 
 *Gotcha:* `--empty` creates a fresh board with **no** template columns/items. Drop it to use monday's default template (Item / Subitems / People / Status / Date columns auto-added). `--kind` is `public | private | share`. `--folder` is optional but typical.
 
+```bash
+# Create + clickable link in one call (no extra API request):
+mondo board create --workspace 592446 --name "Roadmap" --kind public --with-url -q url -o none
+```
+
+Without `--with-url` the output is unchanged (no `url` field).
+
 ## Duplicate a board
 
 Three modes:

--- a/src/mondo/skill/references/docs.md
+++ b/src/mondo/skill/references/docs.md
@@ -66,7 +66,7 @@ mondo doc create --workspace 592446 --name "Spec — Q3 launch"
 {"id": 5095668850, "object_id": "abcd1239", "name": "Spec — Q3 launch", "blocks": []}
 ```
 
-*Gotcha:* the new doc starts empty. Add content with `add-markdown`, `add-content`, or per-block `add-block`.
+*Gotcha:* the new doc starts empty. Add content with `add-markdown`, `add-content`, or per-block `add-block`. The create payload always carries `url` (`--with-url` is accepted for symmetry with `board create` / `item create` but is a no-op).
 
 ## Add markdown to a doc
 

--- a/src/mondo/skill/references/docs.md
+++ b/src/mondo/skill/references/docs.md
@@ -63,7 +63,7 @@ mondo doc create --workspace 592446 --name "Spec — Q3 launch"
 ```
 
 ```json
-{"id": 5095668850, "object_id": "abcd1239", "name": "Spec — Q3 launch", "blocks": []}
+{"id": 5095668850, "object_id": "abcd1239", "name": "Spec — Q3 launch", "url": "https://acct.monday.com/docs/abcd1239"}
 ```
 
 *Gotcha:* the new doc starts empty. Add content with `add-markdown`, `add-content`, or per-block `add-block`. The create payload always carries `url` (`--with-url` is accepted for symmetry with `board create` / `item create` but is a no-op).

--- a/tests/integration/test_live_writes.py
+++ b/tests/integration/test_live_writes.py
@@ -688,3 +688,39 @@ def test_live_doc_create_add_blocks_delete(
         return blocks
 
     wait_for("doc blocks landed", _blocks_landed)
+
+
+@pytest.mark.integration
+def test_live_board_and_doc_create_with_url(
+    live_workspace_id: int, cleanup_plan: CleanupPlan
+) -> None:
+    """Issue #10: `board create --with-url` / `doc create --with-url` return
+    the new entity's monday.com URL in the single create call."""
+    suffix = uuid.uuid4().hex[:8]
+
+    board = invoke_json(
+        [
+            "board", "create",
+            "--workspace", str(live_workspace_id),
+            "--name", f"E2E WithUrl Board {suffix}",
+            "--kind", "private",
+            "--empty",
+            "--with-url",
+        ]
+    )
+    board_id = int(board["id"])
+    cleanup_plan.add("board", "board", "delete", "--id", str(board_id), "--hard")
+    assert board.get("url", "").startswith("https://")
+    assert f"/boards/{board_id}" in board["url"]
+
+    doc = invoke_json(
+        [
+            "doc", "create",
+            "--workspace", str(live_workspace_id),
+            "--name", f"E2E WithUrl Doc {suffix}",
+            "--with-url",
+        ]
+    )
+    doc_id = int(doc["id"])
+    cleanup_plan.add(f"doc E2E WithUrl Doc {suffix}", "doc", "delete", "--doc", str(doc_id))
+    assert doc.get("url", "").startswith("https://")

--- a/tests/unit/test_cli_board.py
+++ b/tests/unit/test_cli_board.py
@@ -690,6 +690,8 @@ class TestBoardCreate:
         assert parsed["url"] == "https://acme.monday.com/boards/99"
         # Single HTTP call — the create mutation itself carried the url.
         assert len(httpx_mock.get_requests()) == 1
+        # The outgoing mutation selection set must include url.
+        assert "url" in _last_body(httpx_mock)["query"]
 
     def test_without_with_url_strips_url(self, httpx_mock: HTTPXMock) -> None:
         """Without the flag, output is unchanged: no `url` key even though

--- a/tests/unit/test_cli_board.py
+++ b/tests/unit/test_cli_board.py
@@ -667,6 +667,53 @@ class TestBoardCreate:
         assert parsed["variables"]["name"] == "X"
         assert httpx_mock.get_requests() == []
 
+    def test_with_url_emits_url_in_single_call(self, httpx_mock: HTTPXMock) -> None:
+        """Issue #10: `board create --with-url` returns the new board's URL
+        without a second API call (url is part of the mutation selection)."""
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "create_board": {
+                        "id": "99",
+                        "name": "New",
+                        "board_kind": "public",
+                        "url": "https://acme.monday.com/boards/99",
+                    }
+                }
+            ),
+        )
+        result = runner.invoke(app, ["board", "create", "--name", "New", "--with-url"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert parsed["url"] == "https://acme.monday.com/boards/99"
+        # Single HTTP call — the create mutation itself carried the url.
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_without_with_url_strips_url(self, httpx_mock: HTTPXMock) -> None:
+        """Without the flag, output is unchanged: no `url` key even though
+        the mutation selection now includes it."""
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "create_board": {
+                        "id": "99",
+                        "name": "New",
+                        "board_kind": "public",
+                        "url": "https://acme.monday.com/boards/99",
+                    }
+                }
+            ),
+        )
+        result = runner.invoke(app, ["board", "create", "--name", "New"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert "url" not in parsed
+        assert len(httpx_mock.get_requests()) == 1
+
 
 # --- update ---
 

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -823,6 +823,32 @@ class TestCreate:
         assert parsed["id"] == "10"
         assert parsed["object_id"] == "100"
 
+    def test_with_url_flag_accepted_url_always_present(self, httpx_mock: HTTPXMock) -> None:
+        """Issue #10: `doc create --with-url` is accepted for symmetry with
+        `board create` / `item create`; docs always carry `url` anyway."""
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "create_doc": {
+                        "id": "10",
+                        "object_id": "100",
+                        "name": "New",
+                        "url": "https://acme.monday.com/docs/100",
+                    }
+                }
+            ),
+        )
+        result = runner.invoke(
+            app,
+            ["doc", "create", "--workspace", "42", "--name", "New", "--with-url"],
+        )
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert parsed["url"] == "https://acme.monday.com/docs/100"
+        assert len(httpx_mock.get_requests()) == 1
+
 
 # --- blocks ---
 


### PR DESCRIPTION
Closes #10

## What

- **`board create --with-url`** returns the created board including a `url` field in one command. Implementation mirrors `item create`: `url` is added to the `BOARD_CREATE` mutation selection set and popped from the payload unless the flag is given — so there's **no extra API call** in either case, and default output is byte-identical to before.
- **`doc create --with-url`** is accepted for symmetry. The `create_doc` mutation already selects and emits `url` unconditionally, so the flag is a documented no-op — the exact convention `doc get` already uses (`"(No-op for docs — url is always present in the payload.)"`).

## Docs

- Skill `SKILL.md` URLs bullet now lists `board create` / `doc create`; `references/boards.md` gains a create+link example; `references/docs.md` notes the doc behavior.
- `--help` examples updated (`board create … --with-url -q url -o none`); the flag lands in `--dump-spec` automatically.

## Verification

- Unit tests: with-url emits `url` in a single HTTP call; without the flag `url` is stripped (despite being in the selection); doc create accepts the flag. Full unit suite: 1412 passed.
- Live integration: new `test_live_board_and_doc_create_with_url` ran against the playground workspace — board url contains `/boards/<id>`, doc url present; both cleaned up. Passed in 10s.

Note: pre-existing (not from this PR) — `ruff check` I001 on `tests/integration/test_live_writes.py` imports and two strict-mypy bare-`dict` hits in `board.py` exist on `main` as well; left untouched.