### PR TITLE
feat(cli): extend hidden `-id`-suffix flag aliases (--item-id, --column-id, --group-id, --workspace-id, --board-id) to all commands

### DIFF
--- a/src/mondo/cli/_alias.py
+++ b/src/mondo/cli/_alias.py
@@ -55,6 +55,7 @@ def rewrite_id_aliases(cmd: click.Command, args: list[str]) -> list[str]:
         return args
 
     declared = _declared_opts(cmd)
+    present = {a.partition("=")[0] for a in args}
     out: list[str] = []
     i = 0
     while i < len(args):
@@ -65,8 +66,7 @@ def rewrite_id_aliases(cmd: click.Command, args: list[str]) -> list[str]:
             out.append(token)
             i += 1
             continue
-        canonical_present = any(a == canonical or a.startswith(f"{canonical}=") for a in args)
-        if canonical_present:
+        if canonical in present:
             # Canonical wins: drop the alias and its value.
             i += 1 if eq else 2
             continue

--- a/src/mondo/cli/_alias.py
+++ b/src/mondo/cli/_alias.py
@@ -1,0 +1,75 @@
+"""Hidden `--<entity>-id` aliases for canonical entity flags (issue #9).
+
+Agents coming from `az`/`gh` (or mirroring GraphQL field names) guess
+`--item-id` / `--column-id` / `--board-id` / … and get rejected with
+`No such option`, costing a failed round-trip per guess — invisible when
+stderr is suppressed. 414a180 fixed this for `--board-id` on the list
+commands with per-command hidden Typer params; this module generalizes
+that to every command, without touching each signature.
+
+`rewrite_id_aliases` runs in `MondoCommand.parse_args` (the class every
+leaf command is re-classed to — see `_help_format.patch_help_classes`).
+It rewrites an alias token to its canonical flag only when the command
+actually declares the canonical option and doesn't declare the alias
+itself. Because the alias never exists as a real parameter, it stays
+out of `--help` and `--dump-spec` for free, and commands without the
+canonical flag still produce the original `No such option '--item-id'`
+error (with the `_errors.FLAG_ALIAS_HINTS` suggestion).
+
+When both the canonical flag and the alias are passed, the canonical
+wins: alias occurrences (and their values) are dropped — the same
+semantics the old `coalesce_board_flag` helper had.
+"""
+
+from __future__ import annotations
+
+import click
+
+# Alias -> canonical long option. Extend with one line per new alias.
+ID_ALIAS_MAP: dict[str, str] = {
+    "--item-id": "--item",
+    "--column-id": "--column",
+    "--group-id": "--group",
+    "--workspace-id": "--workspace",
+    "--board-id": "--board",
+}
+
+
+def _declared_opts(cmd: click.Command) -> set[str]:
+    """Every long/short option name declared on `cmd` (incl. secondary names)."""
+    opts: set[str] = set()
+    for param in cmd.params:
+        opts.update(getattr(param, "opts", []))
+        opts.update(getattr(param, "secondary_opts", []))
+    return opts
+
+
+def rewrite_id_aliases(cmd: click.Command, args: list[str]) -> list[str]:
+    """Return `args` with applicable `--<entity>-id` tokens rewritten.
+
+    Handles both `--item-id 5` and `--item-id=5` forms. No-op unless an
+    alias token is present, the command declares the canonical option,
+    and the command doesn't declare the alias as a real flag.
+    """
+    if not any(arg.partition("=")[0] in ID_ALIAS_MAP for arg in args):
+        return args
+
+    declared = _declared_opts(cmd)
+    out: list[str] = []
+    i = 0
+    while i < len(args):
+        token = args[i]
+        name, eq, value = token.partition("=")
+        canonical = ID_ALIAS_MAP.get(name)
+        if canonical is None or canonical not in declared or name in declared:
+            out.append(token)
+            i += 1
+            continue
+        canonical_present = any(a == canonical or a.startswith(f"{canonical}=") for a in args)
+        if canonical_present:
+            # Canonical wins: drop the alias and its value.
+            i += 1 if eq else 2
+            continue
+        out.append(f"{canonical}={value}" if eq else canonical)
+        i += 1
+    return out

--- a/src/mondo/cli/_help_format.py
+++ b/src/mondo/cli/_help_format.py
@@ -23,6 +23,8 @@ import copy
 import click
 import typer.core
 
+from mondo.cli._alias import rewrite_id_aliases
+
 _GLOBAL_PANEL_TITLE = "Global Options"
 _OUTPUT_PANEL_TITLE = "Output / Query"
 _PANEL_ATTR = "rich_help_panel"
@@ -144,8 +146,6 @@ class MondoCommand(typer.core.TyperCommand):
         when this command declares the canonical option, so az/gh-style
         guesses don't cost a failed round-trip.
         """
-        from mondo.cli._alias import rewrite_id_aliases
-
         return super().parse_args(ctx, rewrite_id_aliases(self, args))
 
 

--- a/src/mondo/cli/_help_format.py
+++ b/src/mondo/cli/_help_format.py
@@ -137,6 +137,17 @@ class MondoCommand(typer.core.TyperCommand):
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         _format_help_with_globals(self, ctx, formatter, super().format_help)
 
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        """Accept hidden `--<entity>-id` aliases for canonical entity flags.
+
+        See `mondo.cli._alias` — rewrites e.g. `--item-id` to `--item`
+        when this command declares the canonical option, so az/gh-style
+        guesses don't cost a failed round-trip.
+        """
+        from mondo.cli._alias import rewrite_id_aliases
+
+        return super().parse_args(ctx, rewrite_id_aliases(self, args))
+
 
 def _assert_output_params_exist(root_cmd: click.Command) -> None:
     """Fail loudly if `_OUTPUT_PARAM_NAMES` drifts from the root's option names.

--- a/src/mondo/cli/_resolve.py
+++ b/src/mondo/cli/_resolve.py
@@ -23,16 +23,6 @@ from mondo.api.errors import NotFoundError, UsageError
 from mondo.cli._filters import apply_fuzzy, compile_name_filter, name_matches
 
 
-def coalesce_board_flag(board_flag: int | None, board_id_alias: int | None) -> int | None:
-    """Pick `--board-id` (hidden alias) only when `--board` was not given.
-
-    All commands that accept a board id expose the same hidden `--board-id`
-    alias for users coming from az/gh CLIs. This collapses the repeated
-    `board_flag = board_flag if board_flag is not None else board_id_alias`.
-    """
-    return board_flag if board_flag is not None else board_id_alias
-
-
 def resolve_required_id[T: (int, str)](
     positional: T | None,
     flag_value: T | None,

--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -39,7 +39,7 @@ from mondo.cli._exec import (
     handle_mondo_error_or_exit,
 )
 from mondo.cli._json_flag import parse_json_flag
-from mondo.cli._resolve import coalesce_board_flag, resolve_by_filters, resolve_required_id
+from mondo.cli._resolve import resolve_by_filters, resolve_required_id
 from mondo.cli.column_doc import app as doc_app
 from mondo.cli.context import GlobalOpts
 from mondo.columns import (
@@ -122,9 +122,6 @@ def list_cmd(
         None, metavar="[BOARD_ID]", help="Board ID (positional)."
     ),
     board_flag: int | None = typer.Option(None, "--board", help="Board ID (flag form)."),
-    board_id_alias: int | None = typer.Option(
-        None, "--board-id", help="(hidden alias for --board)", hidden=True,
-    ),
     no_cache: bool = typer.Option(
         False,
         "--no-cache",
@@ -140,7 +137,6 @@ def list_cmd(
 ) -> None:
     """List all columns on a board with id, title, type."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    board_flag = coalesce_board_flag(board_flag, board_id_alias)
     board_id = resolve_required_id(board_pos, board_flag, flag_name="--board", resource="board")
     reject_mutually_exclusive(no_cache, refresh_cache)
     client = client_or_exit(opts)
@@ -174,9 +170,6 @@ def get_meta_cmd(
         None, metavar="[BOARD_ID]", help="Board ID (positional)."
     ),
     board_flag: int | None = typer.Option(None, "--board", help="Board ID (flag form)."),
-    board_id_alias: int | None = typer.Option(
-        None, "--board-id", help="(hidden alias for --board)", hidden=True,
-    ),
     column_id: str = typer.Option(..., "--column", help="Column ID to inspect."),
     no_cache: bool = typer.Option(
         False,
@@ -199,7 +192,6 @@ def get_meta_cmd(
     `column list`, the full `settings_str` is preserved in the output.
     """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    board_flag = coalesce_board_flag(board_flag, board_id_alias)
     board_id = resolve_required_id(board_pos, board_flag, flag_name="--board", resource="board")
     reject_mutually_exclusive(no_cache, refresh_cache)
     client = client_or_exit(opts)
@@ -231,9 +223,6 @@ def labels_cmd(
         None, metavar="[BOARD_ID]", help="Board ID (positional)."
     ),
     board_flag: int | None = typer.Option(None, "--board", help="Board ID (flag form)."),
-    board_id_alias: int | None = typer.Option(
-        None, "--board-id", help="(hidden alias for --board)", hidden=True,
-    ),
     column_id: str = typer.Option(..., "--column", help="Column ID (status or dropdown)."),
 ) -> None:
     """List the known labels for a status or dropdown column on a board.
@@ -243,7 +232,6 @@ def labels_cmd(
     error.
     """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    board_flag = coalesce_board_flag(board_flag, board_id_alias)
     board_id = resolve_required_id(board_pos, board_flag, flag_name="--board", resource="board")
     client = client_or_exit(opts)
     try:

--- a/src/mondo/cli/group.py
+++ b/src/mondo/cli/group.py
@@ -31,7 +31,7 @@ from mondo.cli._exec import (
     handle_mondo_error_or_exit,
 )
 from mondo.cli._group_cache import fetch_board_groups, invalidate_groups_cache
-from mondo.cli._resolve import coalesce_board_flag, resolve_by_filters, resolve_required_id
+from mondo.cli._resolve import resolve_by_filters, resolve_required_id
 from mondo.cli.context import GlobalOpts
 
 if TYPE_CHECKING:
@@ -112,9 +112,6 @@ def list_cmd(
         None, metavar="[BOARD_ID]", help="Board ID (positional)."
     ),
     board_flag: int | None = typer.Option(None, "--board", help="Board ID (flag form)."),
-    board_id_alias: int | None = typer.Option(
-        None, "--board-id", help="(hidden alias for --board)", hidden=True,
-    ),
     no_cache: bool = typer.Option(
         False,
         "--no-cache",
@@ -130,7 +127,6 @@ def list_cmd(
 ) -> None:
     """List all groups on a board (nested query — no standalone groups root)."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    board_flag = coalesce_board_flag(board_flag, board_id_alias)
     board_id = resolve_required_id(board_pos, board_flag, flag_name="--board", resource="board")
     reject_mutually_exclusive(no_cache, refresh_cache)
     client = client_or_exit(opts)

--- a/src/mondo/cli/item.py
+++ b/src/mondo/cli/item.py
@@ -42,7 +42,7 @@ from mondo.cli._exec import (
     handle_mondo_error_or_exit,
     poll_or_exit,
 )
-from mondo.cli._resolve import coalesce_board_flag, resolve_by_filters, resolve_required_id
+from mondo.cli._resolve import resolve_by_filters, resolve_required_id
 from mondo.cli._url import MondayIdParam
 from mondo.cli.context import GlobalOpts
 from mondo.util.kvparse import parse_column_kv
@@ -373,9 +373,6 @@ def list_cmd(
         None, metavar="[BOARD_ID]", help="Board ID (positional)."
     ),
     board_flag: int | None = typer.Option(None, "--board", help="Board ID (flag form)."),
-    board_id_alias: int | None = typer.Option(
-        None, "--board-id", help="(hidden alias for --board)", hidden=True,
-    ),
     group_id: str | None = typer.Option(
         None,
         "--group",
@@ -437,7 +434,6 @@ def list_cmd(
     --order-by col[,asc|desc] to sort.
     """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    board_flag = coalesce_board_flag(board_flag, board_id_alias)
     _list_items_impl(
         opts,
         board_pos=board_pos,
@@ -575,9 +571,6 @@ def find_cmd(
         None, metavar="[BOARD_ID]", help="Board ID (positional)."
     ),
     board_flag: int | None = typer.Option(None, "--board", help="Board ID (flag form)."),
-    board_id_alias: int | None = typer.Option(
-        None, "--board-id", help="(hidden alias for --board)", hidden=True,
-    ),
     column_id: str = typer.Option(
         ..., "--column", help="Column ID to match on (e.g. 'status')."
     ),
@@ -593,7 +586,6 @@ def find_cmd(
     `mondo column labels` pointer on unknown labels are inherited.
     """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    board_flag = coalesce_board_flag(board_flag, board_id_alias)
     _list_items_impl(
         opts,
         board_pos=board_pos,

--- a/src/mondo/cli/validation.py
+++ b/src/mondo/cli/validation.py
@@ -15,7 +15,7 @@ import typer
 from mondo.api.queries import VALIDATIONS_LIST
 from mondo.cli._examples import epilog_for
 from mondo.cli._exec import execute
-from mondo.cli._resolve import coalesce_board_flag, resolve_required_id
+from mondo.cli._resolve import resolve_required_id
 from mondo.cli.context import GlobalOpts
 
 app = typer.Typer(
@@ -43,13 +43,9 @@ def list_cmd(
         None, metavar="[BOARD_ID]", help="Board ID (positional)."
     ),
     board_flag: int | None = typer.Option(None, "--board", help="Board ID (flag form)."),
-    board_id_alias: int | None = typer.Option(
-        None, "--board-id", help="(hidden alias for --board)", hidden=True,
-    ),
 ) -> None:
     """List validation rules on a board (required columns + rules JSON)."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    board_flag = coalesce_board_flag(board_flag, board_id_alias)
     board_id = resolve_required_id(board_pos, board_flag, flag_name="--board", resource="board")
     variables = {"id": board_id}
     data = execute(opts, VALIDATIONS_LIST, variables)

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mondo
 description: Use when the user wants to do anything against monday.com via the `mondo` CLI — reading or writing workspaces, folders, boards, groups, items, subitems, columns, updates, docs, files, users, teams, webhooks, or when they paste a monday.com URL.
-version: "1.1.0"
+version: "1.2.0"
 ---
 
 # mondo

--- a/tests/unit/test_cli_id_aliases.py
+++ b/tests/unit/test_cli_id_aliases.py
@@ -1,0 +1,200 @@
+"""Hidden `--<entity>-id` aliases are accepted everywhere the canonical
+flag exists (issue #9).
+
+`MondoCommand.parse_args` rewrites `--item-id` / `--column-id` /
+`--group-id` / `--workspace-id` / `--board-id` to their canonical flags
+when the command declares the canonical option (see `mondo.cli._alias`).
+The aliases never exist as real Click parameters, so they stay out of
+`--help` and `--dump-spec` by construction; `--board-id` coverage for
+that lives in test_cli_board_id_alias.py and applies to the shared
+mechanism.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from mondo.cli._alias import ID_ALIAS_MAP
+from mondo.cli.main import app
+
+ENDPOINT = "https://api.monday.com/v2"
+FILE_ENDPOINT = "https://api.monday.com/v2/file"
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("MONDO_PROFILE", raising=False)
+    monkeypatch.delenv("MONDAY_API_VERSION", raising=False)
+    monkeypatch.setenv("MONDO_CONFIG", str(tmp_path / "nope.yaml"))
+    monkeypatch.setenv("MONDAY_API_TOKEN", "env-token-abcdef-long-enough")
+    monkeypatch.setenv("MONDO_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MONDO_CACHE_ENABLED", "false")
+
+
+def _ok(data: dict) -> dict:
+    return {"data": data, "extensions": {"request_id": "r"}}
+
+
+def _column_context(board_id: int = 42) -> dict:
+    return _ok(
+        {
+            "items": [
+                {
+                    "id": "1",
+                    "name": "item",
+                    "board": {
+                        "id": str(board_id),
+                        "columns": [
+                            {
+                                "id": "status",
+                                "title": "S",
+                                "type": "status",
+                                "settings_str": json.dumps({"labels": {"1": "Done"}}),
+                            }
+                        ],
+                    },
+                    "column_values": [
+                        {"id": "status", "type": "status", "text": "Done", "value": None}
+                    ],
+                }
+            ]
+        }
+    )
+
+
+# Each row: (argv, dry_run) — argv uses only alias forms of the flags under
+# test. `dry_run=True` rows exercise mutating commands offline; the rest get
+# a permissive mocked response. The assertion is parse-level: the alias must
+# not be rejected with "No such option".
+ALIAS_ACCEPTANCE: list[tuple[list[str], bool]] = [
+    # --item-id → --item
+    (["column", "get", "--item-id", "1", "--column-id", "status"], False),
+    (["column", "set", "--item-id", "1", "--column-id", "status", "--value", "Done"], False),
+    (["column", "set-many", "--item-id", "1", "--values", '{"status":{"label":"x"}}'], False),
+    (["column", "clear", "--item-id", "1", "--column-id", "status"], False),
+    (["update", "list", "--item-id", "1"], False),
+    (["update", "create", "--item-id", "1", "--body", "hi"], True),
+    # --column-id → --column
+    (["column", "get-meta", "--board", "42", "--column-id", "status"], False),
+    (["column", "labels", "--board", "42", "--column-id", "status"], False),
+    (["item", "find", "--board", "42", "--column-id", "status", "--value", "Done"], False),
+    # --group-id → --group
+    (["item", "list", "--board", "42", "--group-id", "g1"], False),
+    (["item", "create", "--board", "42", "--name", "X", "--group-id", "g1"], True),
+    (["item", "move", "--id", "1", "--group-id", "g1"], True),
+    (["group", "rename", "--board", "42", "--group-id", "g1", "--title", "New"], True),
+    (["-y", "group", "delete", "--board", "42", "--group-id", "g1"], True),
+    # --workspace-id → --workspace
+    (["board", "create", "--name", "X", "--workspace-id", "7"], True),
+    (["doc", "create", "--name", "X", "--workspace-id", "7"], True),
+    (["folder", "create", "--name", "X", "--workspace-id", "7"], True),
+    (["workspace", "get", "--workspace-id", "7"], False),
+    # --board-id → --board beyond the list commands
+    (["item", "create", "--board-id", "42", "--name", "X"], True),
+    (["item", "rename", "--item-id", "1", "--board-id", "42", "--name", "New"], True),
+    (["column", "create", "--board-id", "42", "--title", "T", "--type", "text"], True),
+    (["group", "create", "--board-id", "42", "--name", "G"], True),
+]
+
+
+@pytest.mark.parametrize("argv,dry_run", ALIAS_ACCEPTANCE)
+def test_alias_is_accepted(argv: list[str], dry_run: bool, httpx_mock: HTTPXMock) -> None:
+    if not dry_run:
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_column_context(), is_optional=True, is_reusable=True
+        )
+    full = (["--dry-run", *argv]) if dry_run else argv
+    result = runner.invoke(app, full)
+    combined = (result.output or "") + (result.stderr or "")
+    assert "No such option" not in combined, f"{' '.join(argv)} rejected: {combined!r}"
+
+
+def test_column_get_item_id_column_id_end_to_end(httpx_mock: HTTPXMock) -> None:
+    """The exact session-log repro: `column get --item-id X --column-id Y`
+    behaves identically to the canonical flags."""
+    httpx_mock.add_response(url=ENDPOINT, method="POST", json=_column_context())
+    result = runner.invoke(app, ["column", "get", "--item-id", "1", "--column-id", "status"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == "Done"
+
+
+def test_alias_and_canonical_send_identical_requests(httpx_mock: HTTPXMock) -> None:
+    for _ in range(2):
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"boards": [{"columns": []}]})
+        )
+    r1 = runner.invoke(app, ["-o", "json", "column", "list", "--board", "42"])
+    r2 = runner.invoke(app, ["-o", "json", "column", "list", "--board-id", "42"])
+    assert r1.exit_code == 0 and r2.exit_code == 0
+    bodies = [json.loads(r.content) for r in httpx_mock.get_requests()]
+    assert bodies[0]["variables"] == bodies[1]["variables"]
+
+
+def test_canonical_wins_when_both_given(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"boards": [{"columns": []}]}))
+    result = runner.invoke(app, ["column", "list", "--board", "42", "--board-id", "99"])
+    assert result.exit_code == 0, result.output
+    body = json.loads(httpx_mock.get_request().content)
+    assert body["variables"]["board"] == 42
+
+
+def test_equals_form_is_rewritten(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"boards": [{"columns": []}]}))
+    result = runner.invoke(app, ["column", "list", "--board-id=42"])
+    assert result.exit_code == 0, result.output
+    body = json.loads(httpx_mock.get_request().content)
+    assert body["variables"]["board"] == 42
+
+
+def test_alias_without_canonical_keeps_original_error(httpx_mock: HTTPXMock) -> None:
+    """`subitem list` takes --parent, not --item: the alias must NOT be
+    rewritten there, so the error names the flag the user actually typed
+    (and the `_errors.FLAG_ALIAS_HINTS` suggestion still applies)."""
+    result = runner.invoke(app, ["subitem", "list", "--item-id", "1"])
+    assert result.exit_code == 2
+    combined = (result.output or "") + (result.stderr or "")
+    assert "--item-id" in combined
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ["column", "get"],
+        ["column", "set"],
+        ["item", "create"],
+        ["update", "list"],
+        ["board", "create"],
+        ["workspace", "get"],
+    ],
+)
+def test_aliases_hidden_from_help(path: list[str]) -> None:
+    result = runner.invoke(app, [*path, "--help"])
+    assert result.exit_code == 0, result.output
+    for alias in ID_ALIAS_MAP:
+        assert alias not in result.output, f"{' '.join(path)}: {alias} leaked into --help"
+
+
+def test_dump_spec_exposes_no_aliases() -> None:
+    """--dump-spec is the agent contract; no alias flag may appear anywhere."""
+    result = runner.invoke(app, ["-o", "json", "help", "--dump-spec"])
+    assert result.exit_code == 0
+    spec = json.loads(result.output)
+    offenders: list[str] = []
+
+    def walk(node: dict) -> None:
+        for param in node.get("params", []):
+            for flag in param.get("flags") or []:
+                if flag in ID_ALIAS_MAP:
+                    offenders.append(f"{node.get('path', '<?>')}: {flag}")
+        for child in node.get("commands", []):
+            walk(child)
+
+    walk(spec["root"])
+    assert not offenders, f"alias flags leaked into --dump-spec: {offenders}"


### PR DESCRIPTION
Closes #9

## What

Every command now accepts hidden `--item-id` / `--column-id` / `--group-id` / `--workspace-id` / `--board-id` aliases wherever it declares the canonical flag (`--item`, `--column`, `--group`, `--workspace`, `--board` — including as a secondary name, e.g. `--id/--item`).

## Design note — one mechanism instead of ~70 signature edits

The issue suggested generalizing `coalesce_board_flag()` into `coalesce_alias()` and adding a hidden Typer param per command. While implementing I found a simpler route with the same observable behavior: every leaf command is already re-classed to `MondoCommand` (`_help_format.patch_help_classes`), so a single `parse_args` override (new `src/mondo/cli/_alias.py`, ~40 lines + a 5-entry map) rewrites alias tokens before Click parses. Compared to per-command params this avoids ~70 signature changes, avoids converting required options (`--item`, `--column`, …) to optional-with-manual-checks (which would have changed their missing-flag error semantics), and makes future aliases a one-line map entry. The five existing per-command hidden `--board-id` params and `coalesce_board_flag` are removed — the generic mechanism covers them (their tests in `test_cli_board_id_alias.py` pass unchanged).

Properties (each tested):
- Alias behaves identically to the canonical flag (same GraphQL request), incl. `--board-id=42` equals-form.
- Passing both: **canonical wins** (alias + value dropped) — same semantics as `coalesce_board_flag`.
- Aliases never exist as Click params → absent from `--help` and `mondo help --dump-spec` **by construction**; the canonical surface (help, spec, skill) stays clean.
- Commands without the canonical flag are untouched: `subitem list --item-id` still errors with `No such option '--item-id'` (naming the flag the user typed), and the `_errors.py` `FLAG_ALIAS_HINTS` suggestion map keeps working.
- `--dry-run` paths confirm mutating commands parse the aliases without sending anything.

## Verification

- 34 new unit tests (`tests/unit/test_cli_id_aliases.py`): a 22-row acceptance matrix across all five aliases (incl. `column get/set/set-many/clear`, `update list/create`, `item list/create/move/find/rename`, `group create/rename/delete`, `board create`, `doc create`, `folder create`, `workspace get`, `column create/get-meta/labels`), the exact session-log repro end-to-end, identical-request equivalence, canonical-wins, equals-form, no-canonical error preservation, help/dump-spec cleanliness. Full unit suite: **1443 passed** (existing `--board-id` tests pass against the new mechanism unchanged).
- Live against the playground workspace through the real entry point: `column list --board-id 5094861043`, `column get --item-id 2851314023 --column-id person`, `workspace get --workspace-id 592446`, and `--dry-run board create --workspace-id 592446` all work.

## Also in this PR

- Bundled skill version bumped 1.1.0 → 1.2.0 so installed copies get the freshness warning for the reference updates landing in #14/#15/#16/#17 (done here because this PR touches no skill prose — no conflicts whichever merge order you pick).
- Intentionally **not** documented in the skill/help: the aliases are a forgiveness mechanism; the canonical flags remain the advertised surface.