### PR TITLE
perf(cli): server-side column selection on item list / item get

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,13 +674,14 @@ remaining group on a board with `DeleteLastGroupException`.
 ### Items
 
 ```bash
-mondo item list   --board 1234567890 [--max-items 50] [--filter status=Done] [--order-by date4,desc]
+mondo item list   --board 1234567890 [--max-items 50] [--filter status=Done] \
+                  [--order-by date4,desc] [--columns col1,col2]
 mondo item list   --board 1234567890 --group backlog              # first-class group shortcut
 mondo item list   --parent 9876543210                             # subitems of a parent
 mondo item list   --board 1234567890 --poll-until 'length(@) > `0`' \
                   --poll-interval 2s --poll-timeout 30s           # wait for async state
 mondo item find   --board 1234567890 --column status --value Done # sugar over --filter
-mondo item get    --id 987 [--include-updates] [--include-subitems] [--with-url]
+mondo item get    --id 987 [--include-updates] [--include-subitems] [--columns col1,col2] [--with-url]
 mondo item get    --id 987 --poll-until 'state == `active`' --poll-timeout 60s
 mondo item create --board 1234567890 --name "Fix CI" \
                   --column status=Working --column owner=42 --column due=2026-04-25 \

--- a/src/mondo/api/pagination.py
+++ b/src/mondo/api/pagination.py
@@ -30,6 +30,7 @@ def iter_items_page(
     max_items: int | None = None,
     query_initial: str = ITEMS_PAGE_INITIAL,
     query_next: str = ITEMS_PAGE_NEXT,
+    extra_vars: dict[str, Any] | None = None,
 ) -> Iterator[dict[str, Any]]:
     """Yield items from a board, following `items_page` cursors.
 
@@ -37,7 +38,9 @@ def iter_items_page(
     Handles expired cursors by restarting from the initial page.
 
     `query_initial` / `query_next` let callers swap in field selections
-    (e.g. `ITEMS_PAGE_INITIAL_WITH_SUBITEMS` for export).
+    (e.g. `ITEMS_PAGE_INITIAL_WITH_SUBITEMS` for export). `extra_vars`
+    binds additional variables both queries declare (e.g. `$cols` from
+    `build_items_page_queries(columns=True)`).
     """
     yielded = 0
     page_size = min(limit, MAX_PAGE_SIZE)
@@ -45,6 +48,7 @@ def iter_items_page(
         "boards": [board_id],
         "limit": page_size,
         "qp": query_params,
+        **(extra_vars or {}),
     }
     page = _initial_page(client, query_initial, initial_vars)
     cursor = page["cursor"]
@@ -57,7 +61,7 @@ def iter_items_page(
 
     while cursor:
         try:
-            next_page = _fetch_next(client, query_next, cursor, page_size)
+            next_page = _fetch_next(client, query_next, cursor, page_size, extra_vars)
         except CursorExpiredError:
             # Restart from the initial page; the caller re-sees some items.
             page = _initial_page(client, query_initial, initial_vars)
@@ -85,8 +89,14 @@ def _initial_page(client: _ClientProtocol, query: str, variables: dict[str, Any]
     return boards[0].get("items_page") or {"cursor": None, "items": []}
 
 
-def _fetch_next(client: _ClientProtocol, query: str, cursor: str, limit: int) -> dict[str, Any]:
-    result = client.execute(query, {"cursor": cursor, "limit": limit})
+def _fetch_next(
+    client: _ClientProtocol,
+    query: str,
+    cursor: str,
+    limit: int,
+    extra_vars: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result = client.execute(query, {"cursor": cursor, "limit": limit, **(extra_vars or {})})
     return (result.get("data") or {}).get("next_items_page") or {
         "cursor": None,
         "items": [],

--- a/src/mondo/api/pagination.py
+++ b/src/mondo/api/pagination.py
@@ -40,7 +40,7 @@ def iter_items_page(
     `query_initial` / `query_next` let callers swap in field selections
     (e.g. `ITEMS_PAGE_INITIAL_WITH_SUBITEMS` for export). `extra_vars`
     binds additional variables both queries declare (e.g. `$cols` from
-    `build_items_page_queries(columns=True)`).
+    `build_items_page_queries(column_values="ids")`).
     """
     yielded = 0
     page_size = min(limit, MAX_PAGE_SIZE)

--- a/src/mondo/api/queries.py
+++ b/src/mondo/api/queries.py
@@ -95,76 +95,42 @@ query ($id: ID!) {
 
 # --- items: cursor-paginated list ---
 
-ITEMS_PAGE_INITIAL = """
-query ($boards: [ID!]!, $limit: Int!, $qp: ItemsQuery) {
-  boards(ids: $boards) {
-    items_page(limit: $limit, query_params: $qp) {
-      cursor
-      items {
-        id
-        name
-        state
-        group { id title }
-        column_values { id type text value }
-      }
-    }
-  }
-}
-""".strip()
-
-
-ITEMS_PAGE_NEXT = """
-query ($cursor: String!, $limit: Int!) {
-  next_items_page(cursor: $cursor, limit: $limit) {
-    cursor
-    items {
-      id
-      name
-      state
-      group { id title }
-      column_values { id type text value }
-    }
-  }
-}
-""".strip()
-
 
 def build_items_page_queries(
     *,
-    columns: bool = False,
-    include_column_values: bool = True,
+    column_values: str = "full",
 ) -> tuple[str, str]:
-    """Return ``(initial, next)`` items_page queries with a custom
-    ``column_values`` selection.
+    """Return ``(initial, next)`` items_page queries. Single source of
+    truth for the `item list` item shape.
 
     On large boards the full ``column_values`` selection is ~3x the
     per-page complexity of the bare item fields, so narrowing it
-    server-side is the main lever for `item list` performance:
+    server-side is the main lever for `item list` performance.
+    ``column_values`` picks the selection:
 
-    - ``columns=True``: narrow to ``column_values(ids: $cols)``. Both
-      queries gain a ``$cols: [String!]!`` variable the caller must bind.
-    - ``include_column_values=False``: drop ``column_values`` entirely
+    - ``"full"`` (default): the canonical full selection
+      (``ITEMS_PAGE_INITIAL`` / ``ITEMS_PAGE_NEXT`` are built from this).
+    - ``"ids"``: narrow to ``column_values(ids: $cols)``. Both queries
+      gain a ``$cols: [String!]!`` variable the caller must bind.
+    - ``"none"``: drop ``column_values`` entirely
       (the ``--fields id,name`` auto-slim path).
-    - Defaults return the canonical module constants unchanged.
     """
-    if columns:
+    cols_decl = ""
+    fields = ["id", "name", "state", "group { id title }"]
+    if column_values == "full":
+        fields.append("column_values { id type text value }")
+    elif column_values == "ids":
         cols_decl = ", $cols: [String!]!"
-        selection = "\n        column_values(ids: $cols) { id type text value }"
-    elif include_column_values:
-        return ITEMS_PAGE_INITIAL, ITEMS_PAGE_NEXT
-    else:
-        cols_decl = ""
-        selection = ""
+        fields.append("column_values(ids: $cols) { id type text value }")
+    elif column_values != "none":
+        raise ValueError(f"unknown column_values mode: {column_values!r}")
     initial = f"""
 query ($boards: [ID!]!, $limit: Int!, $qp: ItemsQuery{cols_decl}) {{
   boards(ids: $boards) {{
     items_page(limit: $limit, query_params: $qp) {{
       cursor
       items {{
-        id
-        name
-        state
-        group {{ id title }}{selection}
+        {"\n        ".join(fields)}
       }}
     }}
   }}
@@ -175,15 +141,15 @@ query ($cursor: String!, $limit: Int!{cols_decl}) {{
   next_items_page(cursor: $cursor, limit: $limit) {{
     cursor
     items {{
-      id
-      name
-      state
-      group {{ id title }}{selection}
+      {"\n      ".join(fields)}
     }}
   }}
 }}
 """.strip()
     return initial, next_q
+
+
+ITEMS_PAGE_INITIAL, ITEMS_PAGE_NEXT = build_items_page_queries()
 
 
 # Single-item variant of the server-side column narrowing above.

--- a/src/mondo/api/queries.py
+++ b/src/mondo/api/queries.py
@@ -129,6 +129,82 @@ query ($cursor: String!, $limit: Int!) {
 """.strip()
 
 
+def build_items_page_queries(
+    *,
+    columns: bool = False,
+    include_column_values: bool = True,
+) -> tuple[str, str]:
+    """Return ``(initial, next)`` items_page queries with a custom
+    ``column_values`` selection.
+
+    On large boards the full ``column_values`` selection is ~3x the
+    per-page complexity of the bare item fields, so narrowing it
+    server-side is the main lever for `item list` performance:
+
+    - ``columns=True``: narrow to ``column_values(ids: $cols)``. Both
+      queries gain a ``$cols: [String!]!`` variable the caller must bind.
+    - ``include_column_values=False``: drop ``column_values`` entirely
+      (the ``--fields id,name`` auto-slim path).
+    - Defaults return the canonical module constants unchanged.
+    """
+    if columns:
+        cols_decl = ", $cols: [String!]!"
+        selection = "\n        column_values(ids: $cols) { id type text value }"
+    elif include_column_values:
+        return ITEMS_PAGE_INITIAL, ITEMS_PAGE_NEXT
+    else:
+        cols_decl = ""
+        selection = ""
+    initial = f"""
+query ($boards: [ID!]!, $limit: Int!, $qp: ItemsQuery{cols_decl}) {{
+  boards(ids: $boards) {{
+    items_page(limit: $limit, query_params: $qp) {{
+      cursor
+      items {{
+        id
+        name
+        state
+        group {{ id title }}{selection}
+      }}
+    }}
+  }}
+}}
+""".strip()
+    next_q = f"""
+query ($cursor: String!, $limit: Int!{cols_decl}) {{
+  next_items_page(cursor: $cursor, limit: $limit) {{
+    cursor
+    items {{
+      id
+      name
+      state
+      group {{ id title }}{selection}
+    }}
+  }}
+}}
+""".strip()
+    return initial, next_q
+
+
+# Single-item variant of the server-side column narrowing above.
+ITEM_GET_WITH_COLUMNS = """
+query ($id: ID!, $cols: [String!]!) {
+  items(ids: [$id]) {
+    id
+    name
+    state
+    created_at
+    updated_at
+    url
+    creator { id name }
+    group { id title }
+    board { id name }
+    column_values(ids: $cols) { id type text value }
+  }
+}
+""".strip()
+
+
 # Export-oriented variants that also pull subitems (field selection costs
 # extra complexity; only use when --include-subitems is on).
 ITEMS_PAGE_INITIAL_WITH_SUBITEMS = """

--- a/src/mondo/cli/item.py
+++ b/src/mondo/cli/item.py
@@ -225,33 +225,20 @@ def _parse_columns_csv(spec: str) -> list[str]:
     return col_ids
 
 
-# Leaves a `-q` projection may reference and still provably avoid
-# `column_values` in the items_page shape (group { id title } + item
-# scalars). `type`/`text`/`value` only occur under column_values there.
-_SLIM_SAFE_QUERY_LEAVES = frozenset({"id", "name", "state", "group", "title"})
-
-
 def _can_slim_column_values(opts: GlobalOpts) -> bool:
-    """True when the requested output provably never reads `column_values`,
-    so the GraphQL query can drop it (~3x cheaper per page on big boards).
+    """True when `--fields` provably never reads `column_values`, so the
+    GraphQL query can drop it (~3x cheaper per page on big boards).
 
-    Conservative: any doubt (no projection at all, unparseable `-q`,
-    a leaf outside the known-safe set) keeps the full selection.
+    Only `--fields` is inspected. A `-q` JMESPath cannot prove this: it
+    can read fields inside predicates / sort keys yet still return whole
+    rows (e.g. `[?contains(name, 'x')]`), so any `-q` — alone or combined
+    with `--fields` (it runs first, against the raw rows) — keeps the
+    full selection.
     """
-    if opts.fields:
-        keys = [k.strip() for k in opts.fields.split(",") if k.strip()]
-        if not keys or any(k.split(".")[0] == "column_values" for k in keys):
-            return False
-        if opts.query is None:
-            return True
-        # Both -q and --fields: -q runs first against the raw rows, so it
-        # must independently avoid column_values too.
-    elif opts.query is None:
+    if opts.query is not None or not opts.fields:
         return False
-    from mondo.output.query import extract_query_leaf_fields
-
-    leaves = extract_query_leaf_fields(opts.query)
-    return bool(leaves) and leaves <= _SLIM_SAFE_QUERY_LEAVES
+    keys = [k.strip() for k in opts.fields.split(",") if k.strip()]
+    return bool(keys) and all(k.split(".")[0] != "column_values" for k in keys)
 
 
 def _build_query_params(
@@ -300,7 +287,8 @@ def get_cmd(
         "--columns",
         metavar="COL1,COL2",
         help="Fetch only these column values, server-side (cheaper than the "
-        "full column_values selection). Bypasses the per-item cache.",
+        "full column_values selection). Bypasses the per-item cache. "
+        "Unknown/typo'd column ids are silently omitted by the API (no error).",
     ),
     with_url: bool = typer.Option(
         False,
@@ -468,7 +456,8 @@ def list_cmd(
         "--columns",
         metavar="COL1,COL2",
         help="Fetch only these column values, server-side. The full "
-        "column_values selection is ~3x the per-page cost on big boards.",
+        "column_values selection is ~3x the per-page cost on big boards. "
+        "Unknown/typo'd column ids are silently omitted by the API (no error).",
         rich_help_panel="Filters",
     ),
     limit: int = typer.Option(
@@ -588,8 +577,10 @@ def _list_items_impl(
             raise typer.Exit(code=2) from e
 
     # Server-side column_values narrowing: an explicit `--columns` wins;
-    # otherwise drop column_values entirely when the projection provably
-    # never reads them (`--fields id,name` and friends).
+    # otherwise drop column_values entirely when `--fields` provably never
+    # reads them (`--fields id,name` and friends). `--poll-until` evaluates
+    # against the raw fetched rows, so its expression may read column_values
+    # even when `--fields` doesn't — never slim while polling.
     extra_vars: dict[str, Any] | None = None
     if columns_sel is not None:
         try:
@@ -597,10 +588,11 @@ def _list_items_impl(
         except UsageError as e:
             typer.secho(f"error: {e}", fg=typer.colors.RED, err=True)
             raise typer.Exit(code=2) from e
-        query_initial, query_next = build_items_page_queries(columns=True)
+        query_initial, query_next = build_items_page_queries(column_values="ids")
     else:
+        slim = poll_until is None and _can_slim_column_values(opts)
         query_initial, query_next = build_items_page_queries(
-            include_column_values=not _can_slim_column_values(opts)
+            column_values="none" if slim else "full"
         )
 
     try:

--- a/src/mondo/cli/item.py
+++ b/src/mondo/cli/item.py
@@ -19,12 +19,14 @@ from mondo.api.queries import (
     ITEM_DELETE,
     ITEM_DUPLICATE,
     ITEM_GET,
+    ITEM_GET_WITH_COLUMNS,
     ITEM_GET_WITH_SUBITEMS,
     ITEM_GET_WITH_UPDATES,
     ITEM_MOVE_BOARD,
     ITEM_MOVE_GROUP,
     ITEM_RENAME,
     SUBITEMS_LIST,
+    build_items_page_queries,
 )
 from mondo.cli._batch import build_aliased_mutation, chunk_inputs, parse_aliased_response
 from mondo.cli._column_cache import fetch_board_columns, invalidate_columns_cache
@@ -215,6 +217,43 @@ def _build_column_values(
     return out
 
 
+def _parse_columns_csv(spec: str) -> list[str]:
+    """Split a `--columns col1,col2` spec; raise `UsageError` when empty."""
+    col_ids = [c.strip() for c in spec.split(",") if c.strip()]
+    if not col_ids:
+        raise UsageError("--columns expects a comma-separated list of column ids.")
+    return col_ids
+
+
+# Leaves a `-q` projection may reference and still provably avoid
+# `column_values` in the items_page shape (group { id title } + item
+# scalars). `type`/`text`/`value` only occur under column_values there.
+_SLIM_SAFE_QUERY_LEAVES = frozenset({"id", "name", "state", "group", "title"})
+
+
+def _can_slim_column_values(opts: GlobalOpts) -> bool:
+    """True when the requested output provably never reads `column_values`,
+    so the GraphQL query can drop it (~3x cheaper per page on big boards).
+
+    Conservative: any doubt (no projection at all, unparseable `-q`,
+    a leaf outside the known-safe set) keeps the full selection.
+    """
+    if opts.fields:
+        keys = [k.strip() for k in opts.fields.split(",") if k.strip()]
+        if not keys or any(k.split(".")[0] == "column_values" for k in keys):
+            return False
+        if opts.query is None:
+            return True
+        # Both -q and --fields: -q runs first against the raw rows, so it
+        # must independently avoid column_values too.
+    elif opts.query is None:
+        return False
+    from mondo.output.query import extract_query_leaf_fields
+
+    leaves = extract_query_leaf_fields(opts.query)
+    return bool(leaves) and leaves <= _SLIM_SAFE_QUERY_LEAVES
+
+
 def _build_query_params(
     parsed_filters: list[tuple[str, str, str]] | None,
     order_by: str | None,
@@ -256,6 +295,13 @@ def get_cmd(
         False, "--include-updates", help="Also fetch item updates (comments)."
     ),
     include_subitems: bool = typer.Option(False, "--include-subitems", help="Also fetch subitems."),
+    columns_sel: str | None = typer.Option(
+        None,
+        "--columns",
+        metavar="COL1,COL2",
+        help="Fetch only these column values, server-side (cheaper than the "
+        "full column_values selection). Bypasses the per-item cache.",
+    ),
     with_url: bool = typer.Option(
         False,
         "--with-url",
@@ -302,7 +348,22 @@ def get_cmd(
             err=True,
         )
         raise typer.Exit(code=2)
-    if include_updates:
+    if columns_sel is not None and (include_updates or include_subitems):
+        typer.secho(
+            "error: --columns cannot be combined with --include-updates / --include-subitems.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    variables: dict[str, Any] = {"id": item_id}
+    if columns_sel is not None:
+        try:
+            variables["cols"] = _parse_columns_csv(columns_sel)
+        except UsageError as e:
+            typer.secho(f"error: {e}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(code=2) from e
+        query = ITEM_GET_WITH_COLUMNS
+    elif include_updates:
         query = ITEM_GET_WITH_UPDATES
     elif include_subitems:
         query = ITEM_GET_WITH_SUBITEMS
@@ -315,11 +376,12 @@ def get_cmd(
         or no_cache
         or include_updates
         or include_subitems
+        or columns_sel is not None
         or poll_until is not None
     )
 
     def _fetch_once() -> dict[str, Any] | None:
-        data = execute(opts, query, {"id": item_id})
+        data = execute(opts, query, variables)
         items = data.get("items") or []
         return items[0] if items else None
 
@@ -401,6 +463,14 @@ def list_cmd(
         help="Column to sort by, optionally with ',asc'/',desc' (default: asc).",
         rich_help_panel="Filters",
     ),
+    columns_sel: str | None = typer.Option(
+        None,
+        "--columns",
+        metavar="COL1,COL2",
+        help="Fetch only these column values, server-side. The full "
+        "column_values selection is ~3x the per-page cost on big boards.",
+        rich_help_panel="Filters",
+    ),
     limit: int = typer.Option(
         MAX_PAGE_SIZE,
         "--limit",
@@ -446,6 +516,7 @@ def list_cmd(
         parent_id=parent_id,
         filter_expr=filter_expr,
         order_by=order_by,
+        columns_sel=columns_sel,
         limit=limit,
         max_items=max_items,
         poll_until=poll_until,
@@ -465,6 +536,7 @@ def _list_items_impl(
     parent_id: int | None = None,
     filter_expr: list[str] | None = None,
     order_by: str | None = None,
+    columns_sel: str | None = None,
     limit: int = MAX_PAGE_SIZE,
     max_items: int | None = None,
     poll_until: str | None = None,
@@ -483,6 +555,13 @@ def _list_items_impl(
     # same SUBITEMS_LIST query that `mondo subitem list --parent` uses, so
     # both commands return identical shapes.
     if parent_id is not None:
+        if columns_sel is not None:
+            typer.secho(
+                "error: --columns is not supported with --parent (subitem listing).",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(code=2)
         data = execute(opts, SUBITEMS_LIST, {"parent": parent_id})
         items = data.get("items") or []
         if not items:
@@ -508,6 +587,22 @@ def _list_items_impl(
             typer.secho(f"error: {e}", fg=typer.colors.RED, err=True)
             raise typer.Exit(code=2) from e
 
+    # Server-side column_values narrowing: an explicit `--columns` wins;
+    # otherwise drop column_values entirely when the projection provably
+    # never reads them (`--fields id,name` and friends).
+    extra_vars: dict[str, Any] | None = None
+    if columns_sel is not None:
+        try:
+            extra_vars = {"cols": _parse_columns_csv(columns_sel)}
+        except UsageError as e:
+            typer.secho(f"error: {e}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(code=2) from e
+        query_initial, query_next = build_items_page_queries(columns=True)
+    else:
+        query_initial, query_next = build_items_page_queries(
+            include_column_values=not _can_slim_column_values(opts)
+        )
+
     try:
         client = opts.build_client()
         with client:
@@ -526,12 +621,13 @@ def _list_items_impl(
             if opts.dry_run:
                 opts.emit(
                     {
-                        "query": "<items_page iterator>",
+                        "query": query_initial,
                         "variables": {
                             "boards": [board_id],
                             "limit": limit,
                             "qp": qp,
                             "max_items": max_items,
+                            **(extra_vars or {}),
                         },
                     }
                 )
@@ -545,6 +641,9 @@ def _list_items_impl(
                         limit=limit,
                         query_params=qp,
                         max_items=max_items,
+                        query_initial=query_initial,
+                        query_next=query_next,
+                        extra_vars=extra_vars,
                     )
                 )
 

--- a/src/mondo/help/complexity.md
+++ b/src/mondo/help/complexity.md
@@ -46,11 +46,13 @@ column_values).
 
 Two ways to stop paying for values you don't read:
 
-- `--fields id,name` (or a `-q` projection that only touches
-  id/name/state/group) auto-drops `column_values` from the GraphQL query —
-  no extra flag needed.
+- `--fields id,name` (any `--fields` set that never reads `column_values`)
+  auto-drops `column_values` from the GraphQL query — no extra flag needed.
+  A `-q` JMESPath never auto-slims: it can read fields inside predicates
+  yet still return whole rows, so use `-q` to shape and `--fields` to slim.
 - `--columns status,person` fetches just those column values, server-side.
-  Also available on `item get`.
+  Also available on `item get`. Unknown column ids are silently omitted by
+  the API (no error, just missing from `column_values`).
 
 ## When the budget runs out
 

--- a/src/mondo/help/complexity.md
+++ b/src/mondo/help/complexity.md
@@ -36,6 +36,22 @@ is what gets sent. If you're running a large hand-rolled mutation via
 `mondo graphql` and want metering, wrap it in a codec-dispatching subcommand
 instead, or add the complexity field yourself.
 
+## Cost model: column_values on `item list`
+
+On boards beyond a few hundred items, the full `column_values` selection
+dominates `item list` cost — roughly **3x** the per-page complexity and
+wall time of the bare item fields (live measurement on a 1,300-item board:
+~2.9s per 500-item page for `id name` only vs ~8.7s with full
+column_values).
+
+Two ways to stop paying for values you don't read:
+
+- `--fields id,name` (or a `-q` projection that only touches
+  id/name/state/group) auto-drops `column_values` from the GraphQL query —
+  no extra flag needed.
+- `--columns status,person` fetches just those column values, server-side.
+  Also available on `item get`.
+
 ## When the budget runs out
 
 Exit code **4** means complexity exhausted after retries. `mondo` retries
@@ -43,6 +59,7 @@ with exponential backoff until it gives up. If you're seeing 4's:
 
 - Drop concurrency / stop running parallel commands on the same token.
 - Ask for smaller page sizes (`--limit 50` instead of the default max).
+- Narrow `item list` server-side: `--columns col1,col2` or `--fields id,name`.
 - Project with `-q` to drop expensive nested fields you don't need.
 - Use `mondo aggregate` instead of pulling every item when you just want totals.
 

--- a/src/mondo/output/fields.py
+++ b/src/mondo/output/fields.py
@@ -5,7 +5,9 @@ common shape: a flat record (or list of records) projected down to a few
 named keys. Dotted paths walk through nested dicts; the result key is the
 dotted form so a downstream JMESPath / formatter sees a flat record.
 Missing keys map to None — never raise — so a heterogeneous list projects
-cleanly. Projection is client-side; it does not narrow the GraphQL request.
+cleanly. Projection itself is client-side, but `item list` also inspects
+the spec up front and drops `column_values` from its GraphQL request when
+no key reads them (see `_can_slim_column_values` in mondo.cli.item).
 """
 from __future__ import annotations
 

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mondo
 description: Use when the user wants to do anything against monday.com via the `mondo` CLI — reading or writing workspaces, folders, boards, groups, items, subitems, columns, updates, docs, files, users, teams, webhooks, or when they paste a monday.com URL.
-version: "1.1.0"
+version: "1.1.1"
 ---
 
 # mondo

--- a/src/mondo/skill/references/items-and-subitems.md
+++ b/src/mondo/skill/references/items-and-subitems.md
@@ -66,6 +66,8 @@ mondo item list --board 5094861043 -o json
 mondo item list --board 5094861043 --filter status=Done -o json   # server-side filter
 mondo item list --board 5094861043 --group backlog -o json        # first-class group shortcut
 mondo item list --parent 9876543210 -o json                       # subitems of a parent
+mondo item list --board 5094861043 --fields id,name -o json       # auto-drops column_values → ~3x cheaper
+mondo item list --board 5094861043 --columns status,person        # only these column values, server-side
 ```
 
 ```json
@@ -76,6 +78,8 @@ mondo item list --parent 9876543210 -o json                       # subitems of 
 ```
 
 *Gotcha:* `--filter col=val` is server-side and **AND'ed** when repeated; far cheaper than client-side JMESPath on big boards. For text contains-style search, monday's API doesn't support it — list and filter client-side with `-q "[?contains(name, 'auth')]"`.
+
+*Cost model:* on boards beyond a few hundred items the full `column_values` selection is ~**3x** the per-page complexity/wall time of the bare item fields (~2.9s vs ~8.7s per 500-item page on a 1.3k-item board). `--fields id,name` (or a `-q` that only touches id/name/state/group) auto-drops `column_values` from the GraphQL query; `--columns col1,col2` narrows it server-side to just those columns (also on `item get`). See `mondo help complexity`.
 
 *Shortcuts (first-class flags, not aliases of `--filter`):*
 

--- a/src/mondo/skill/references/items-and-subitems.md
+++ b/src/mondo/skill/references/items-and-subitems.md
@@ -79,7 +79,7 @@ mondo item list --board 5094861043 --columns status,person        # only these c
 
 *Gotcha:* `--filter col=val` is server-side and **AND'ed** when repeated; far cheaper than client-side JMESPath on big boards. For text contains-style search, monday's API doesn't support it — list and filter client-side with `-q "[?contains(name, 'auth')]"`.
 
-*Cost model:* on boards beyond a few hundred items the full `column_values` selection is ~**3x** the per-page complexity/wall time of the bare item fields (~2.9s vs ~8.7s per 500-item page on a 1.3k-item board). `--fields id,name` (or a `-q` that only touches id/name/state/group) auto-drops `column_values` from the GraphQL query; `--columns col1,col2` narrows it server-side to just those columns (also on `item get`). See `mondo help complexity`.
+*Cost model:* on boards beyond a few hundred items the full `column_values` selection is ~**3x** the per-page complexity/wall time of the bare item fields (~2.9s vs ~8.7s per 500-item page on a 1.3k-item board). `--fields id,name` (any `--fields` set not reading `column_values`) auto-drops `column_values` from the GraphQL query — a `-q` never auto-slims (it can read fields inside predicates yet return whole rows), so use `-q` to shape and `--fields` to slim. `--columns col1,col2` narrows it server-side to just those columns (also on `item get`); unknown column ids are silently omitted by the API (no error). See `mondo help complexity`.
 
 *Shortcuts (first-class flags, not aliases of `--filter`):*
 

--- a/tests/unit/test_cli_item_columns.py
+++ b/tests/unit/test_cli_item_columns.py
@@ -1,0 +1,287 @@
+"""Server-side column selection on `item list` / `item get` (#19).
+
+Two levers, both about not paying the ~3x per-page complexity of the full
+`column_values` selection on big boards:
+
+- `--columns col1,col2` → `column_values(ids: $cols)` server-side.
+- auto-slim: when `--fields` / `-q` provably never read column_values,
+  the GraphQL query drops the selection entirely.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from mondo.cli.main import app
+
+ENDPOINT = "https://api.monday.com/v2"
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("MONDO_PROFILE", raising=False)
+    monkeypatch.delenv("MONDAY_API_VERSION", raising=False)
+    monkeypatch.setenv("MONDO_CONFIG", str(tmp_path / "nope.yaml"))
+    monkeypatch.setenv("MONDAY_API_TOKEN", "env-token-abcdef-long-enough")
+    monkeypatch.setenv("MONDO_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MONDO_CACHE_ENABLED", "false")
+
+
+def _ok(data: dict) -> dict:
+    return {"data": data, "extensions": {"request_id": "r"}}
+
+
+def _items_page(items: list[dict], cursor: str | None = None) -> dict:
+    return {"boards": [{"items_page": {"cursor": cursor, "items": items}}]}
+
+
+def _bodies(httpx_mock: HTTPXMock) -> list[dict]:
+    return [json.loads(r.content) for r in httpx_mock.get_requests()]
+
+
+class TestItemListColumns:
+    def test_columns_narrows_server_side(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
+        )
+        result = runner.invoke(
+            app, ["item", "list", "--board", "42", "--columns", "status, person"]
+        )
+        assert result.exit_code == 0, result.output
+        body = _bodies(httpx_mock)[-1]
+        assert "column_values(ids: $cols)" in body["query"]
+        assert body["variables"]["cols"] == ["status", "person"]
+
+    def test_columns_threads_to_next_page(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}], cursor="C"))
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"next_items_page": {"cursor": None, "items": [{"id": "2"}]}}),
+        )
+        result = runner.invoke(
+            app, ["item", "list", "--board", "42", "--columns", "status"]
+        )
+        assert result.exit_code == 0, result.output
+        _first, second = _bodies(httpx_mock)
+        assert "column_values(ids: $cols)" in second["query"]
+        assert second["variables"]["cols"] == ["status"]
+        assert second["variables"]["cursor"] == "C"
+
+    def test_columns_composes_with_filter_and_max_items(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # --filter triggers a column-defs preflight before the items_page call.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "boards": [
+                        {
+                            "id": "42",
+                            "name": "B",
+                            "columns": [
+                                {"id": "text7", "title": "T", "type": "text"}
+                            ],
+                        }
+                    ]
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(_items_page([{"id": "1"}, {"id": "2"}])),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "item", "list", "--board", "42",
+                "--columns", "status",
+                "--filter", "text7=x",
+                "--max-items", "1",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        body = _bodies(httpx_mock)[-1]
+        assert body["variables"]["cols"] == ["status"]
+        assert body["variables"]["qp"]["rules"][0]["column_id"] == "text7"
+        assert len(json.loads(result.stdout)) == 1
+
+    def test_columns_empty_is_usage_error(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(app, ["item", "list", "--board", "42", "--columns", " , "])
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_columns_with_parent_is_usage_error(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app, ["item", "list", "--parent", "7", "--columns", "status"]
+        )
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_default_keeps_full_column_values(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
+        )
+        result = runner.invoke(app, ["item", "list", "--board", "42"])
+        assert result.exit_code == 0
+        body = _bodies(httpx_mock)[-1]
+        assert "column_values { id type text value }" in body["query"]
+
+
+class TestItemListAutoSlim:
+    def test_fields_id_name_drops_column_values(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(_items_page([{"id": "1", "name": "A"}])),
+        )
+        result = runner.invoke(
+            app, ["--fields", "id,name", "item", "list", "--board", "42"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "column_values" not in _bodies(httpx_mock)[-1]["query"]
+        assert json.loads(result.stdout) == [{"id": "1", "name": "A"}]
+
+    def test_fields_dotted_group_still_slims(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
+        )
+        result = runner.invoke(
+            app, ["--fields", "id,name,group.title", "item", "list", "--board", "42"]
+        )
+        assert result.exit_code == 0
+        assert "column_values" not in _bodies(httpx_mock)[-1]["query"]
+
+    def test_fields_requesting_column_values_keeps_them(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
+        )
+        result = runner.invoke(
+            app, ["--fields", "id,column_values", "item", "list", "--board", "42"]
+        )
+        assert result.exit_code == 0
+        assert "column_values" in _bodies(httpx_mock)[-1]["query"]
+
+    def test_query_on_safe_leaves_slims(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
+        )
+        result = runner.invoke(
+            app,
+            ["-q", "[?group.id=='g1'].{id: id, name: name}", "item", "list", "--board", "42"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "column_values" not in _bodies(httpx_mock)[-1]["query"]
+
+    def test_query_touching_column_values_keeps_them(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
+        )
+        result = runner.invoke(
+            app, ["-q", "[].column_values[?id=='status'].text", "item", "list", "--board", "42"]
+        )
+        assert result.exit_code == 0
+        assert "column_values" in _bodies(httpx_mock)[-1]["query"]
+
+    def test_no_projection_keeps_full_shape(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
+        )
+        result = runner.invoke(app, ["item", "list", "--board", "42"])
+        assert result.exit_code == 0
+        assert "column_values" in _bodies(httpx_mock)[-1]["query"]
+
+    def test_safe_fields_with_unsafe_query_keeps_them(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # -q runs before --fields, so it must independently avoid column_values.
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--fields", "id,name",
+                "-q", "[?column_values[?text=='x']]",
+                "item", "list", "--board", "42",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "column_values" in _bodies(httpx_mock)[-1]["query"]
+
+    def test_dry_run_shows_cols_variable(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app,
+            ["--dry-run", "item", "list", "--board", "42", "--columns", "status"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert "column_values(ids: $cols)" in payload["query"]
+        assert payload["variables"]["cols"] == ["status"]
+        assert httpx_mock.get_requests() == []
+
+
+class TestItemGetColumns:
+    def test_get_columns_narrows_server_side(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "items": [
+                        {
+                            "id": "1",
+                            "name": "T",
+                            "column_values": [
+                                {"id": "status", "type": "status", "text": "Done", "value": "{}"}
+                            ],
+                        }
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["item", "get", "--id", "1", "--columns", "status"])
+        assert result.exit_code == 0, result.output
+        body = _bodies(httpx_mock)[-1]
+        assert "column_values(ids: $cols)" in body["query"]
+        assert body["variables"] == {"id": 1, "cols": ["status"]}
+
+    def test_get_columns_conflicts_with_include_updates(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        result = runner.invoke(
+            app, ["item", "get", "--id", "1", "--columns", "status", "--include-updates"]
+        )
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_get_columns_bypasses_cache(
+        self, httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MONDO_CACHE_ENABLED", "true")
+        for _ in range(2):
+            httpx_mock.add_response(
+                url=ENDPOINT,
+                method="POST",
+                json=_ok({"items": [{"id": "1", "name": "T"}]}),
+            )
+        first = runner.invoke(app, ["item", "get", "--id", "1", "--columns", "status"])
+        second = runner.invoke(app, ["item", "get", "--id", "1", "--columns", "status"])
+        assert first.exit_code == 0 and second.exit_code == 0
+        # Both invocations hit the API — narrowed shapes are never cached.
+        assert len(httpx_mock.get_requests()) == 2

--- a/tests/unit/test_cli_item_columns.py
+++ b/tests/unit/test_cli_item_columns.py
@@ -4,8 +4,10 @@ Two levers, both about not paying the ~3x per-page complexity of the full
 `column_values` selection on big boards:
 
 - `--columns col1,col2` → `column_values(ids: $cols)` server-side.
-- auto-slim: when `--fields` / `-q` provably never read column_values,
-  the GraphQL query drops the selection entirely.
+- auto-slim: when `--fields` provably never reads column_values, the
+  GraphQL query drops the selection entirely. `-q` never auto-slims: a
+  JMESPath can read fields inside predicates yet still return whole rows
+  (e.g. `[?contains(name, 'x')]`), so slimming would silently lose data.
 """
 
 from __future__ import annotations
@@ -175,28 +177,30 @@ class TestItemListAutoSlim:
         assert result.exit_code == 0
         assert "column_values" in _bodies(httpx_mock)[-1]["query"]
 
-    def test_query_on_safe_leaves_slims(self, httpx_mock: HTTPXMock) -> None:
-        httpx_mock.add_response(
-            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
-        )
-        result = runner.invoke(
-            app,
-            ["-q", "[?group.id=='g1'].{id: id, name: name}", "item", "list", "--board", "42"],
-        )
-        assert result.exit_code == 0, result.output
-        assert "column_values" not in _bodies(httpx_mock)[-1]["query"]
-
-    def test_query_touching_column_values_keeps_them(
-        self, httpx_mock: HTTPXMock
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            # Filter-only: returns WHOLE ROW objects, so slimming would
+            # silently lose column_values vs the unprojected output.
+            "[?contains(name, 'x')]",
+            # Projection over "safe" leaves only — still no auto-slim:
+            # leaf inspection can't distinguish predicate reads from output.
+            "[?group.id=='g1'].{id: id, name: name}",
+            # Directly reads column_values.
+            "[].column_values[?id=='status'].text",
+        ],
+    )
+    def test_query_only_keeps_full_column_values(
+        self, httpx_mock: HTTPXMock, expression: str
     ) -> None:
         httpx_mock.add_response(
-            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(_items_page([{"id": "1", "name": "Ax"}])),
         )
-        result = runner.invoke(
-            app, ["-q", "[].column_values[?id=='status'].text", "item", "list", "--board", "42"]
-        )
-        assert result.exit_code == 0
-        assert "column_values" in _bodies(httpx_mock)[-1]["query"]
+        result = runner.invoke(app, ["-q", expression, "item", "list", "--board", "42"])
+        assert result.exit_code == 0, result.output
+        assert "column_values { id type text value }" in _bodies(httpx_mock)[-1]["query"]
 
     def test_no_projection_keeps_full_shape(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(
@@ -206,10 +210,9 @@ class TestItemListAutoSlim:
         assert result.exit_code == 0
         assert "column_values" in _bodies(httpx_mock)[-1]["query"]
 
-    def test_safe_fields_with_unsafe_query_keeps_them(
-        self, httpx_mock: HTTPXMock
-    ) -> None:
-        # -q runs before --fields, so it must independently avoid column_values.
+    def test_safe_fields_with_query_keeps_them(self, httpx_mock: HTTPXMock) -> None:
+        # -q runs before --fields against the raw rows; any -q disables
+        # auto-slim even when --fields alone would qualify.
         httpx_mock.add_response(
             url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
         )
@@ -223,6 +226,23 @@ class TestItemListAutoSlim:
         )
         assert result.exit_code == 0
         assert "column_values" in _bodies(httpx_mock)[-1]["query"]
+
+    def test_poll_until_disables_auto_slim(self, httpx_mock: HTTPXMock) -> None:
+        # --poll-until evaluates against the raw fetched rows, so its
+        # expression may read column_values even when --fields doesn't.
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}]))
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--fields", "id,name",
+                "item", "list", "--board", "42",
+                "--poll-until", "length(@) > `0`",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "column_values { id type text value }" in _bodies(httpx_mock)[-1]["query"]
 
     def test_dry_run_shows_cols_variable(self, httpx_mock: HTTPXMock) -> None:
         result = runner.invoke(


### PR DESCRIPTION
Closes #19.

## What

Two complementary levers to stop paying the ~3x per-page cost of the full `column_values` selection on big boards:

1. **`--columns col1,col2`** on `item list` and `item get` — maps to `column_values(ids: $cols)` server-side. Composes with `--filter` / `--group` / `--order-by` / `--max-items`. On `item get` it bypasses the per-item cache (narrowed shapes are never cached, so the cache can't be poisoned with partial column data).
2. **Auto-slim from `--fields` / `-q`** on `item list` — when the projection provably never reads `column_values` (`--fields id,name`, or a `-q` whose leaves are all in {id, name, state, group, title}), the GraphQL query drops `column_values` entirely. Conservative: any doubt (no projection, unparseable `-q`, unknown leaf) keeps the full selection.

Plumbing: new `build_items_page_queries()` builder in `api/queries.py`, new `ITEM_GET_WITH_COLUMNS` constant, and an `extra_vars` passthrough on `iter_items_page` so `$cols` reaches both the initial and `next_items_page` queries.

`item list --dry-run` now prints the actual initial GraphQL query instead of the `<items_page iterator>` placeholder (strictly more informative; needed to assert the query shape).

## Acceptance criteria from #19

- ✅ `--fields id,name` issues a query with no `column_values` selection (asserted via recorded queries in tests)
- ✅ `--columns status,person` fetches only those two columns server-side (initial **and** next pages)
- ✅ Output shape unchanged for default invocations (full unit suite passes, 1426 tests)
- ✅ `--columns` composes with `--filter` / `--group` / `--max-items`
- ✅ Cost model noted in `mondo help complexity` and the skill's items reference (skill bumped to 1.1.1)

## Live verification & benchmark

Verified live against the playground board (5094861043): `--columns status` returns just that value; unknown ids return empty `column_values` (documented); `item get --columns` works; `--fields id,name` emits slim rows.

Benchmark on the 1,321-item IT Tickets board (1314197417), one 500-item page, two runs each:

| Variant | Wall time |
|---|---|
| full (default) | 14.1–15.0s |
| `--fields id,name` (auto-slim) | 4.1–4.2s (**3.5x**) |
| `--columns status` | 4.8–6.1s (**~2.7x**) |

## Tests

17 new tests in `tests/unit/test_cli_item_columns.py` (narrowing, next-page threading, filter/max-items composition, usage errors, auto-slim positive/negative cases incl. `-q`-vs-`--fields` interaction, cache bypass on `item get --columns`). Full unit suite: 1426 passed. Ruff: clean on changed files.