### PR TITLE
fix(cli): accept --object-id on all doc subcommands; targeted hint when --doc gets an object id

### DIFF
--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -712,8 +712,126 @@ def _emit_doc_not_found(
                 err=True,
             )
             return
+    if doc_id is not None:
+        hint = _object_id_hint_with_client(client, doc_id)
+        if hint is not None:
+            typer.secho(f"doc id={doc_id} not found.\n{hint}", fg=typer.colors.RED, err=True)
+            return
     ref = f"id={doc_id}" if doc_id is not None else f"object_id={object_id}"
     typer.secho(f"doc {ref} not found.", fg=typer.colors.RED, err=True)
+
+
+# Exit codes worth the object-id probe: generic server failure, validation,
+# not-found. Auth / rate-limit / network failures would just re-fail the probe.
+_OBJECT_ID_HINT_EXIT_CODES = frozenset({1, 5, 6})
+
+
+def _object_id_hint_with_client(client: MondayClient, doc_id: int) -> str | None:
+    """Probe whether a failing `--doc` id is actually a URL-visible object_id
+    (the id a human copies out of a `/docs/<id>` URL). Returns the targeted
+    hint when it resolves; never raises — the probe must not mask the
+    original error.
+    """
+    try:
+        result = client.execute(DOC_HEAD_BY_OBJECT_ID, {"objs": [doc_id]})
+        docs = (result.get("data") or {}).get("docs") or []
+    except Exception:
+        return None
+    if not docs:
+        return None
+    return (
+        f"hint: {doc_id} looks like a URL-visible object id, not an internal "
+        f"doc id — retry with --object-id {doc_id}"
+    )
+
+
+def _emit_doc_id_not_found(client: MondayClient, doc_id: int, *, probe: bool) -> None:
+    """Standard `doc id=X not found.` line, plus the object-id retry hint
+    when the id was user-supplied via `--doc` (`probe=True`)."""
+    line = f"doc id={doc_id} not found."
+    if probe:
+        hint = _object_id_hint_with_client(client, doc_id)
+        if hint is not None:
+            line = f"{line}\n{hint}"
+    typer.secho(line, fg=typer.colors.RED, err=True)
+
+
+def _object_id_hint(opts: GlobalOpts, doc_id: int) -> str | None:
+    """`_object_id_hint_with_client` with a fresh short-lived client."""
+    try:
+        client = opts.build_client()
+        with client:
+            return _object_id_hint_with_client(client, doc_id)
+    except Exception:
+        return None
+
+
+def _resolve_object_id_live(client: MondayClient, object_id: int) -> int | None:
+    """Map a URL-visible `object_id` to the internal doc id via a head query."""
+    data = exec_or_exit(client, DOC_HEAD_BY_OBJECT_ID, {"objs": [object_id]})
+    docs = data.get("docs") or []
+    if not docs:
+        return None
+    try:
+        return int(docs[0]["id"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _resolve_doc_target(
+    opts: GlobalOpts, *, doc_id: int | None, object_id: int | None
+) -> int:
+    """Return the internal doc id for a command taking `--doc` XOR `--object-id`.
+
+    `--object-id` costs one cheap head query (`docs(object_ids: ...) { id }`);
+    a miss exits 6. Runs even under `--dry-run` (read-side resolution, same
+    as codec preflights).
+    """
+    if (doc_id is None) == (object_id is None):
+        typer.secho(
+            "error: pass exactly one of --doc or --object-id.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    if doc_id is not None:
+        return doc_id
+    assert object_id is not None
+    client = client_or_exit(opts)
+    resolved: int | None = None
+    try:
+        with client:
+            resolved = _resolve_object_id_live(client, object_id)
+    except MondoError as e:
+        handle_mondo_error_or_exit(e)
+    if resolved is None:
+        typer.secho(f"doc object_id={object_id} not found.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=6)
+    return resolved
+
+
+def _execute_doc_command(
+    opts: GlobalOpts,
+    query: str,
+    variables: dict[str, Any],
+    *,
+    hint_doc_id: int | None,
+) -> dict[str, Any]:
+    """`execute()` plus the object-id-vs-internal-id guardrail: when a
+    `--doc`-addressed call fails server-side and the id resolves as an
+    object_id, append the targeted retry hint to the error output."""
+    if opts.dry_run:
+        dry_run_and_exit(opts, query, variables)
+    client = client_or_exit(opts)
+    try:
+        with client:
+            result = client.execute(query, variables=variables)
+            return result.get("data") or {}
+    except MondoError as e:
+        suffix = None
+        if hint_doc_id is not None and int(e.exit_code) in _OBJECT_ID_HINT_EXIT_CODES:
+            suffix = _object_id_hint(opts, hint_doc_id)
+        handle_mondo_error_or_exit(e, human_suffix=suffix)
 
 
 # ----- write commands -----
@@ -744,7 +862,15 @@ def create_cmd(
 @app.command("add-block", epilog=epilog_for("doc add-block"))
 def add_block_cmd(
     ctx: typer.Context,
-    doc_id: int = typer.Option(..., "--doc", help="Doc ID (internal id, NOT object_id)."),
+    doc_id: int | None = typer.Option(
+        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
+    ),
+    object_id: int | None = typer.Option(
+        None,
+        "--object-id",
+        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
+        click_type=MondayIdParam(),
+    ),
     block_type: str = typer.Option(
         ...,
         "--type",
@@ -765,13 +891,14 @@ def add_block_cmd(
 ) -> None:
     """Append a single block to a doc."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
     parsed_content = parse_json_flag(content, flag_name="--content")
     if opts.dry_run:
         dry_run_and_exit(
             opts,
             CREATE_DOC_BLOCK,
             {
-                "doc": doc_id,
+                "doc": resolved_doc,
                 "type": block_type,
                 "content": json.dumps(parsed_content),
                 "after": after,
@@ -783,16 +910,16 @@ def add_block_cmd(
         with client:
             effective_after = after
             if effective_after is None:
-                existing_doc = _fetch_doc_by_id_all_blocks(client, doc_id)
+                existing_doc = _fetch_doc_by_id_all_blocks(client, resolved_doc)
                 if existing_doc is None:
-                    typer.secho(f"doc id={doc_id} not found.", fg=typer.colors.RED, err=True)
+                    _emit_doc_id_not_found(client, resolved_doc, probe=doc_id is not None)
                     raise typer.Exit(code=6)
                 effective_after = _last_block_id(existing_doc)
             data = exec_or_exit(
                 client,
                 CREATE_DOC_BLOCK,
                 {
-                    "doc": doc_id,
+                    "doc": resolved_doc,
                     "type": block_type,
                     "content": json.dumps(parsed_content),
                     "after": effective_after,
@@ -802,14 +929,22 @@ def add_block_cmd(
     except MondoError as e:
         handle_mondo_error_or_exit(e)
 
-    invalidate_entity(opts, "docs_blocks", scope=str(doc_id))
+    invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
     opts.emit(data.get("create_doc_block") or {})
 
 
 @app.command("add-content", epilog=epilog_for("doc add-content"))
 def add_content_cmd(
     ctx: typer.Context,
-    doc_id: int = typer.Option(..., "--doc", help="Doc ID (internal id)."),
+    doc_id: int | None = typer.Option(
+        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
+    ),
+    object_id: int | None = typer.Option(
+        None,
+        "--object-id",
+        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
+        click_type=MondayIdParam(),
+    ),
     markdown: str | None = typer.Option(None, "--markdown", help="Markdown source."),
     from_file: Path | None = typer.Option(None, "--from-file", help="Load markdown from a file."),
     from_stdin: bool = typer.Option(False, "--from-stdin", help="Load markdown from stdin."),
@@ -826,6 +961,7 @@ def add_content_cmd(
     from mondo.docs import markdown_to_blocks
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
     md = _load_markdown(markdown, from_file, from_stdin)
     blocks = markdown_to_blocks(md)
     if not blocks:
@@ -839,7 +975,7 @@ def add_content_cmd(
         dry_run_and_exit(
             opts,
             f"{CREATE_DOC_BLOCK} (looped per block)",
-            {"doc": doc_id, "blocks": blocks},
+            {"doc": resolved_doc, "blocks": blocks},
         )
     from mondo.cli.column_doc import create_blocks
 
@@ -849,23 +985,31 @@ def add_content_cmd(
         with client:
             # Seed `after_block_id` from the doc's current last block so blocks
             # land at the end (monday's default for `after=null` is TOP insert).
-            existing_doc = _fetch_doc_by_id_all_blocks(client, doc_id)
+            existing_doc = _fetch_doc_by_id_all_blocks(client, resolved_doc)
             if existing_doc is None:
-                typer.secho(f"doc id={doc_id} not found.", fg=typer.colors.RED, err=True)
+                _emit_doc_id_not_found(client, resolved_doc, probe=doc_id is not None)
                 raise typer.Exit(code=6)
             prev_id = _last_block_id(existing_doc)
-            created = create_blocks(client, doc_id, blocks, after_block_id=prev_id)
+            created = create_blocks(client, resolved_doc, blocks, after_block_id=prev_id)
     except MondoError as e:
         handle_mondo_error_or_exit(e)
 
-    invalidate_entity(opts, "docs_blocks", scope=str(doc_id))
+    invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
     opts.emit(created)
 
 
 @app.command("add-markdown", epilog=epilog_for("doc add-markdown"))
 def add_markdown_cmd(
     ctx: typer.Context,
-    doc_id: int = typer.Option(..., "--doc", help="Doc ID (internal id)."),
+    doc_id: int | None = typer.Option(
+        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
+    ),
+    object_id: int | None = typer.Option(
+        None,
+        "--object-id",
+        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
+        click_type=MondayIdParam(),
+    ),
     markdown: str | None = typer.Option(None, "--markdown", help="Markdown source."),
     from_file: Path | None = typer.Option(None, "--from-file", help="Load markdown from a file."),
     from_stdin: bool = typer.Option(False, "--from-stdin", help="Load markdown from stdin."),
@@ -874,10 +1018,13 @@ def add_markdown_cmd(
     """Append markdown using monday's server-side markdown parser."""
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
     md = _load_markdown(markdown, from_file, from_stdin)
-    variables = {"doc": doc_id, "md": md, "after": after}
-    data = execute(opts, ADD_CONTENT_TO_DOC_FROM_MARKDOWN, variables)
-    invalidate_entity(opts, "docs_blocks", scope=str(doc_id))
+    variables = {"doc": resolved_doc, "md": md, "after": after}
+    data = _execute_doc_command(
+        opts, ADD_CONTENT_TO_DOC_FROM_MARKDOWN, variables, hint_doc_id=doc_id
+    )
+    invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
     opts.emit(data.get("add_content_to_doc_from_markdown") or {})
 
 
@@ -918,14 +1065,25 @@ def import_html_cmd(
 @app.command("rename", epilog=epilog_for("doc rename"))
 def rename_cmd(
     ctx: typer.Context,
-    doc_id: int = typer.Option(..., "--doc", help="Doc ID (internal id)."),
+    doc_id: int | None = typer.Option(
+        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
+    ),
+    object_id: int | None = typer.Option(
+        None,
+        "--object-id",
+        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
+        click_type=MondayIdParam(),
+    ),
     name: str = typer.Option(..., "--name", help="New document title."),
 ) -> None:
     """Rename a doc."""
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    data = execute(opts, UPDATE_DOC_NAME, {"doc": doc_id, "name": name})
-    invalidate_entity(opts, "docs_blocks", scope=str(doc_id))
+    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
+    data = _execute_doc_command(
+        opts, UPDATE_DOC_NAME, {"doc": resolved_doc, "name": name}, hint_doc_id=doc_id
+    )
+    invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
     invalidate_entity(opts, "docs")
     opts.emit(data.get("update_doc_name"))
 
@@ -933,7 +1091,15 @@ def rename_cmd(
 @app.command("duplicate", epilog=epilog_for("doc duplicate"))
 def duplicate_cmd(
     ctx: typer.Context,
-    doc_id: int = typer.Option(..., "--doc", help="Doc ID (internal id)."),
+    doc_id: int | None = typer.Option(
+        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
+    ),
+    object_id: int | None = typer.Option(
+        None,
+        "--object-id",
+        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
+        click_type=MondayIdParam(),
+    ),
     duplicate_type: DuplicateDocType = typer.Option(
         DuplicateDocType.duplicate_doc_with_content,
         "--duplicate-type",
@@ -943,15 +1109,21 @@ def duplicate_cmd(
 ) -> None:
     """Duplicate a doc."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    data = execute(
+    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
+    data = _execute_doc_command(
         opts,
         DUPLICATE_DOC,
-        {"doc": doc_id, "dup": duplicate_type.value},
+        {"doc": resolved_doc, "dup": duplicate_type.value},
+        hint_doc_id=doc_id,
     )
     result = data.get("duplicate_doc") or {}
     if not result.get("success"):
         err = result.get("error") or "duplicate_doc failed"
-        typer.secho(f"error: {err}", fg=typer.colors.RED, err=True)
+        line = f"error: {err}"
+        hint = _object_id_hint(opts, doc_id) if doc_id is not None else None
+        if hint:
+            line = f"{line}\n{hint}"
+        typer.secho(line, fg=typer.colors.RED, err=True)
         raise typer.Exit(code=5)
     new_object_id = result.get("id")
     if new_object_id is None:
@@ -985,13 +1157,24 @@ def duplicate_cmd(
 @app.command("delete", epilog=epilog_for("doc delete"))
 def delete_cmd(
     ctx: typer.Context,
-    doc_id: int = typer.Option(..., "--doc", help="Doc ID (internal id)."),
+    doc_id: int | None = typer.Option(
+        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
+    ),
+    object_id: int | None = typer.Option(
+        None,
+        "--object-id",
+        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
+        click_type=MondayIdParam(),
+    ),
 ) -> None:
     """Delete a doc."""
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    data = execute(opts, DELETE_DOC, {"doc": doc_id})
-    invalidate_entity(opts, "docs_blocks", scope=str(doc_id))
+    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
+    data = _execute_doc_command(
+        opts, DELETE_DOC, {"doc": resolved_doc}, hint_doc_id=doc_id
+    )
+    invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
     invalidate_entity(opts, "docs")
     opts.emit(data.get("delete_doc"))
 
@@ -999,7 +1182,15 @@ def delete_cmd(
 @app.command("export-markdown", epilog=epilog_for("doc export-markdown"))
 def export_markdown_cmd(
     ctx: typer.Context,
-    doc_id: int = typer.Option(..., "--doc", help="Doc ID (internal id)."),
+    doc_id: int | None = typer.Option(
+        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
+    ),
+    object_id: int | None = typer.Option(
+        None,
+        "--object-id",
+        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
+        click_type=MondayIdParam(),
+    ),
     block_id: list[str] | None = typer.Option(
         None,
         "--block",
@@ -1013,10 +1204,12 @@ def export_markdown_cmd(
 ) -> None:
     """Export doc content as markdown."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    data = execute(
+    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
+    data = _execute_doc_command(
         opts,
         EXPORT_MARKDOWN_FROM_DOC,
-        {"doc": doc_id, "blocks": block_id or None},
+        {"doc": resolved_doc, "blocks": block_id or None},
+        hint_doc_id=doc_id,
     )
     result = data.get("export_markdown_from_doc") or {}
     if raw:
@@ -1024,7 +1217,14 @@ def export_markdown_cmd(
         return
     if not result.get("success"):
         err = result.get("error") or "export_markdown_from_doc failed"
-        typer.secho(f"error: {err}", fg=typer.colors.RED, err=True)
+        line = f"error: {err}"
+        # The observed failure mode for an object id sent as --doc is an
+        # opaque mutation-level 500 ("Fetcher response returned NON-OK
+        # status=500") — probe before giving up.
+        hint = _object_id_hint(opts, doc_id) if doc_id is not None else None
+        if hint:
+            line = f"{line}\n{hint}"
+        typer.secho(line, fg=typer.colors.RED, err=True)
         raise typer.Exit(code=5)
     typer.echo(result.get("markdown") or "")
 
@@ -1032,7 +1232,15 @@ def export_markdown_cmd(
 @app.command("version-history", epilog=epilog_for("doc version-history"))
 def version_history_cmd(
     ctx: typer.Context,
-    doc_id: int = typer.Option(..., "--doc", help="Doc ID (internal id)."),
+    doc_id: int | None = typer.Option(
+        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
+    ),
+    object_id: int | None = typer.Option(
+        None,
+        "--object-id",
+        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
+        click_type=MondayIdParam(),
+    ),
     since: str | None = typer.Option(
         None,
         "--since",
@@ -1046,14 +1254,28 @@ def version_history_cmd(
 ) -> None:
     """Fetch restoring points for a doc (API 2026-04+)."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    data = execute(opts, DOC_VERSION_HISTORY, {"doc": doc_id, "since": since, "until": until})
+    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
+    data = _execute_doc_command(
+        opts,
+        DOC_VERSION_HISTORY,
+        {"doc": resolved_doc, "since": since, "until": until},
+        hint_doc_id=doc_id,
+    )
     opts.emit(data.get("doc_version_history") or {})
 
 
 @app.command("version-diff", epilog=epilog_for("doc version-diff"))
 def version_diff_cmd(
     ctx: typer.Context,
-    doc_id: int = typer.Option(..., "--doc", help="Doc ID (internal id)."),
+    doc_id: int | None = typer.Option(
+        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
+    ),
+    object_id: int | None = typer.Option(
+        None,
+        "--object-id",
+        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
+        click_type=MondayIdParam(),
+    ),
     date: str = typer.Option(..., "--date", help="Newer restoring-point ISO8601 timestamp."),
     prev_date: str = typer.Option(
         ...,
@@ -1063,7 +1285,13 @@ def version_diff_cmd(
 ) -> None:
     """Fetch block-level diff between two restoring points (API 2026-04+)."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    data = execute(opts, DOC_VERSION_DIFF, {"doc": doc_id, "date": date, "prev": prev_date})
+    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
+    data = _execute_doc_command(
+        opts,
+        DOC_VERSION_DIFF,
+        {"doc": resolved_doc, "date": date, "prev": prev_date},
+        hint_doc_id=doc_id,
+    )
     opts.emit(data.get("doc_version_diff") or {})
 
 

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -21,7 +21,7 @@ import re
 import sys
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any, NoReturn
 
 import typer
 
@@ -90,6 +90,24 @@ class DuplicateDocType(StrEnum):
 # ----- helpers -----
 
 _DOC_BLOCKS_PAGE_SIZE = 100
+
+# The `--doc` XOR `--object-id` pair shared by every doc-targeting subcommand
+# (same shared-option pattern as the Poll*Opt trio in `mondo.cli._exec`).
+DocIdOpt = Annotated[
+    int | None,
+    typer.Option(
+        "--doc",
+        help="Internal doc ID (not the URL-visible object_id).",
+    ),
+]
+DocObjectIdOpt = Annotated[
+    int | None,
+    typer.Option(
+        "--object-id",
+        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
+        click_type=MondayIdParam(),
+    ),
+]
 
 
 def _load_markdown(inline: str | None, path: Path | None, from_stdin: bool) -> str:
@@ -713,17 +731,16 @@ def _emit_doc_not_found(
             )
             return
     if doc_id is not None:
-        hint = _object_id_hint_with_client(client, doc_id)
-        if hint is not None:
-            typer.secho(f"doc id={doc_id} not found.\n{hint}", fg=typer.colors.RED, err=True)
-            return
-    ref = f"id={doc_id}" if doc_id is not None else f"object_id={object_id}"
-    typer.secho(f"doc {ref} not found.", fg=typer.colors.RED, err=True)
+        _emit_doc_id_not_found(client, doc_id, probe=True)
+        return
+    typer.secho(f"doc object_id={object_id} not found.", fg=typer.colors.RED, err=True)
 
 
 # Exit codes worth the object-id probe: generic server failure, validation,
-# not-found. Auth / rate-limit / network failures would just re-fail the probe.
-_OBJECT_ID_HINT_EXIT_CODES = frozenset({1, 5, 6})
+# not-found, service error (a monday HTTP 5xx — the canonical symptom of an
+# object id sent as --doc — maps to exit 7; the probe degrades safely if it
+# also fails). Auth / rate-limit failures would just re-fail the probe.
+_OBJECT_ID_HINT_EXIT_CODES = frozenset({1, 5, 6, 7})
 
 
 def _object_id_hint_with_client(client: MondayClient, doc_id: int) -> str | None:
@@ -766,6 +783,22 @@ def _object_id_hint(opts: GlobalOpts, doc_id: int) -> str | None:
         return None
 
 
+def _fail_with_object_id_hint(opts: GlobalOpts, err_line: str, doc_id: int | None) -> NoReturn:
+    """Emit a mutation-envelope failure and exit 5, appending the object-id
+    retry hint when the failing id came from `--doc`.
+
+    The observed failure mode for an object id sent as --doc is an opaque
+    mutation-level 500 ("Fetcher response returned NON-OK status=500") —
+    probe before giving up.
+    """
+    line = f"error: {err_line}"
+    hint = _object_id_hint(opts, doc_id) if doc_id is not None else None
+    if hint:
+        line = f"{line}\n{hint}"
+    typer.secho(line, fg=typer.colors.RED, err=True)
+    raise typer.Exit(code=5)
+
+
 def _resolve_object_id_live(client: MondayClient, object_id: int) -> int | None:
     """Map a URL-visible `object_id` to the internal doc id via a head query."""
     data = exec_or_exit(client, DOC_HEAD_BY_OBJECT_ID, {"objs": [object_id]})
@@ -778,15 +811,8 @@ def _resolve_object_id_live(client: MondayClient, object_id: int) -> int | None:
         return None
 
 
-def _resolve_doc_target(
-    opts: GlobalOpts, *, doc_id: int | None, object_id: int | None
-) -> int:
-    """Return the internal doc id for a command taking `--doc` XOR `--object-id`.
-
-    `--object-id` costs one cheap head query (`docs(object_ids: ...) { id }`);
-    a miss exits 6. Runs even under `--dry-run` (read-side resolution, same
-    as codec preflights).
-    """
+def _require_one_doc_flag(doc_id: int | None, object_id: int | None) -> None:
+    """Usage gate for commands taking `--doc` XOR `--object-id`."""
     if (doc_id is None) == (object_id is None):
         typer.secho(
             "error: pass exactly one of --doc or --object-id.",
@@ -794,16 +820,29 @@ def _resolve_doc_target(
             err=True,
         )
         raise typer.Exit(code=2)
+
+
+def _resolve_doc_in_client(
+    opts: GlobalOpts,
+    client: MondayClient,
+    *,
+    doc_id: int | None,
+    object_id: int | None,
+) -> int:
+    """Return the internal doc id, resolving `--object-id` on the given
+    (already-open) client — docs directory cache first (when enabled),
+    then the cheap live head query on a miss. A miss in both exits 6.
+    A stale cache hit fails downstream identically to a live hit gone
+    stale, so cache-first is safe.
+    """
     if doc_id is not None:
         return doc_id
     assert object_id is not None
-    client = client_or_exit(opts)
     resolved: int | None = None
-    try:
-        with client:
-            resolved = _resolve_object_id_live(client, object_id)
-    except MondoError as e:
-        handle_mondo_error_or_exit(e)
+    if opts.resolve_cache_config().enabled:
+        resolved = _resolve_doc_id_from_object_id(opts, client, object_id)
+    if resolved is None:
+        resolved = _resolve_object_id_live(client, object_id)
     if resolved is None:
         typer.secho(f"doc object_id={object_id} not found.", fg=typer.colors.RED, err=True)
         raise typer.Exit(code=6)
@@ -815,23 +854,38 @@ def _execute_doc_command(
     query: str,
     variables: dict[str, Any],
     *,
-    hint_doc_id: int | None,
-) -> dict[str, Any]:
-    """`execute()` plus the object-id-vs-internal-id guardrail: when a
-    `--doc`-addressed call fails server-side and the id resolves as an
-    object_id, append the targeted retry hint to the error output."""
-    if opts.dry_run:
-        dry_run_and_exit(opts, query, variables)
+    doc_id: int | None,
+    object_id: int | None,
+) -> tuple[dict[str, Any], int]:
+    """Resolve `--doc` XOR `--object-id` and `execute()` on one shared client,
+    plus the object-id-vs-internal-id guardrail: when a `--doc`-addressed call
+    fails server-side and the id resolves as an object_id, append the targeted
+    retry hint to the error output (probed on the still-open client).
+
+    `variables` is the query payload minus `doc`; the resolved id is injected.
+    Returns `(data, resolved_doc_id)`. Resolution runs even under `--dry-run`
+    (read-side, same as codec preflights).
+    """
+    _require_one_doc_flag(doc_id, object_id)
+    if doc_id is not None and opts.dry_run:
+        dry_run_and_exit(opts, query, {"doc": doc_id, **variables})
     client = client_or_exit(opts)
     try:
         with client:
-            result = client.execute(query, variables=variables)
-            return result.get("data") or {}
+            resolved = _resolve_doc_in_client(opts, client, doc_id=doc_id, object_id=object_id)
+            full_variables = {"doc": resolved, **variables}
+            if opts.dry_run:
+                dry_run_and_exit(opts, query, full_variables)
+            try:
+                result = client.execute(query, variables=full_variables)
+            except MondoError as e:
+                suffix = None
+                if doc_id is not None and int(e.exit_code) in _OBJECT_ID_HINT_EXIT_CODES:
+                    suffix = _object_id_hint_with_client(client, doc_id)
+                handle_mondo_error_or_exit(e, human_suffix=suffix)
+            return (result.get("data") or {}), resolved
     except MondoError as e:
-        suffix = None
-        if hint_doc_id is not None and int(e.exit_code) in _OBJECT_ID_HINT_EXIT_CODES:
-            suffix = _object_id_hint(opts, hint_doc_id)
-        handle_mondo_error_or_exit(e, human_suffix=suffix)
+        handle_mondo_error_or_exit(e)
 
 
 # ----- write commands -----
@@ -862,15 +916,8 @@ def create_cmd(
 @app.command("add-block", epilog=epilog_for("doc add-block"))
 def add_block_cmd(
     ctx: typer.Context,
-    doc_id: int | None = typer.Option(
-        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
-    ),
-    object_id: int | None = typer.Option(
-        None,
-        "--object-id",
-        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
-        click_type=MondayIdParam(),
-    ),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
     block_type: str = typer.Option(
         ...,
         "--type",
@@ -891,23 +938,28 @@ def add_block_cmd(
 ) -> None:
     """Append a single block to a doc."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
+    _require_one_doc_flag(doc_id, object_id)
     parsed_content = parse_json_flag(content, flag_name="--content")
-    if opts.dry_run:
-        dry_run_and_exit(
-            opts,
-            CREATE_DOC_BLOCK,
-            {
-                "doc": resolved_doc,
-                "type": block_type,
-                "content": json.dumps(parsed_content),
-                "after": after,
-                "parent": parent_block,
-            },
-        )
+
+    def _variables(doc: int, after_id: str | None) -> dict[str, Any]:
+        return {
+            "doc": doc,
+            "type": block_type,
+            "content": json.dumps(parsed_content),
+            "after": after_id,
+            "parent": parent_block,
+        }
+
+    if doc_id is not None and opts.dry_run:
+        dry_run_and_exit(opts, CREATE_DOC_BLOCK, _variables(doc_id, after))
     client = client_or_exit(opts)
     try:
         with client:
+            resolved_doc = _resolve_doc_in_client(
+                opts, client, doc_id=doc_id, object_id=object_id
+            )
+            if opts.dry_run:
+                dry_run_and_exit(opts, CREATE_DOC_BLOCK, _variables(resolved_doc, after))
             effective_after = after
             if effective_after is None:
                 existing_doc = _fetch_doc_by_id_all_blocks(client, resolved_doc)
@@ -916,15 +968,7 @@ def add_block_cmd(
                     raise typer.Exit(code=6)
                 effective_after = _last_block_id(existing_doc)
             data = exec_or_exit(
-                client,
-                CREATE_DOC_BLOCK,
-                {
-                    "doc": resolved_doc,
-                    "type": block_type,
-                    "content": json.dumps(parsed_content),
-                    "after": effective_after,
-                    "parent": parent_block,
-                },
+                client, CREATE_DOC_BLOCK, _variables(resolved_doc, effective_after)
             )
     except MondoError as e:
         handle_mondo_error_or_exit(e)
@@ -936,15 +980,8 @@ def add_block_cmd(
 @app.command("add-content", epilog=epilog_for("doc add-content"))
 def add_content_cmd(
     ctx: typer.Context,
-    doc_id: int | None = typer.Option(
-        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
-    ),
-    object_id: int | None = typer.Option(
-        None,
-        "--object-id",
-        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
-        click_type=MondayIdParam(),
-    ),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
     markdown: str | None = typer.Option(None, "--markdown", help="Markdown source."),
     from_file: Path | None = typer.Option(None, "--from-file", help="Load markdown from a file."),
     from_stdin: bool = typer.Option(False, "--from-stdin", help="Load markdown from stdin."),
@@ -961,7 +998,7 @@ def add_content_cmd(
     from mondo.docs import markdown_to_blocks
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
+    _require_one_doc_flag(doc_id, object_id)
     md = _load_markdown(markdown, from_file, from_stdin)
     blocks = markdown_to_blocks(md)
     if not blocks:
@@ -971,11 +1008,11 @@ def add_content_cmd(
             err=True,
         )
         raise typer.Exit(code=5)
-    if opts.dry_run:
+    if doc_id is not None and opts.dry_run:
         dry_run_and_exit(
             opts,
             f"{CREATE_DOC_BLOCK} (looped per block)",
-            {"doc": resolved_doc, "blocks": blocks},
+            {"doc": doc_id, "blocks": blocks},
         )
     from mondo.cli.column_doc import create_blocks
 
@@ -983,6 +1020,15 @@ def add_content_cmd(
     created: list[dict[str, Any]] = []
     try:
         with client:
+            resolved_doc = _resolve_doc_in_client(
+                opts, client, doc_id=doc_id, object_id=object_id
+            )
+            if opts.dry_run:
+                dry_run_and_exit(
+                    opts,
+                    f"{CREATE_DOC_BLOCK} (looped per block)",
+                    {"doc": resolved_doc, "blocks": blocks},
+                )
             # Seed `after_block_id` from the doc's current last block so blocks
             # land at the end (monday's default for `after=null` is TOP insert).
             existing_doc = _fetch_doc_by_id_all_blocks(client, resolved_doc)
@@ -1001,15 +1047,8 @@ def add_content_cmd(
 @app.command("add-markdown", epilog=epilog_for("doc add-markdown"))
 def add_markdown_cmd(
     ctx: typer.Context,
-    doc_id: int | None = typer.Option(
-        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
-    ),
-    object_id: int | None = typer.Option(
-        None,
-        "--object-id",
-        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
-        click_type=MondayIdParam(),
-    ),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
     markdown: str | None = typer.Option(None, "--markdown", help="Markdown source."),
     from_file: Path | None = typer.Option(None, "--from-file", help="Load markdown from a file."),
     from_stdin: bool = typer.Option(False, "--from-stdin", help="Load markdown from stdin."),
@@ -1018,14 +1057,21 @@ def add_markdown_cmd(
     """Append markdown using monday's server-side markdown parser."""
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
     md = _load_markdown(markdown, from_file, from_stdin)
-    variables = {"doc": resolved_doc, "md": md, "after": after}
-    data = _execute_doc_command(
-        opts, ADD_CONTENT_TO_DOC_FROM_MARKDOWN, variables, hint_doc_id=doc_id
+    data, resolved_doc = _execute_doc_command(
+        opts,
+        ADD_CONTENT_TO_DOC_FROM_MARKDOWN,
+        {"md": md, "after": after},
+        doc_id=doc_id,
+        object_id=object_id,
     )
+    result = data.get("add_content_to_doc_from_markdown") or {}
+    if not result.get("success"):
+        _fail_with_object_id_hint(
+            opts, result.get("error") or "add_content_to_doc_from_markdown failed", doc_id
+        )
     invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
-    opts.emit(data.get("add_content_to_doc_from_markdown") or {})
+    opts.emit(result)
 
 
 @app.command("import-html", epilog=epilog_for("doc import-html"))
@@ -1065,23 +1111,15 @@ def import_html_cmd(
 @app.command("rename", epilog=epilog_for("doc rename"))
 def rename_cmd(
     ctx: typer.Context,
-    doc_id: int | None = typer.Option(
-        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
-    ),
-    object_id: int | None = typer.Option(
-        None,
-        "--object-id",
-        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
-        click_type=MondayIdParam(),
-    ),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
     name: str = typer.Option(..., "--name", help="New document title."),
 ) -> None:
     """Rename a doc."""
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
-    data = _execute_doc_command(
-        opts, UPDATE_DOC_NAME, {"doc": resolved_doc, "name": name}, hint_doc_id=doc_id
+    data, resolved_doc = _execute_doc_command(
+        opts, UPDATE_DOC_NAME, {"name": name}, doc_id=doc_id, object_id=object_id
     )
     invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
     invalidate_entity(opts, "docs")
@@ -1091,15 +1129,8 @@ def rename_cmd(
 @app.command("duplicate", epilog=epilog_for("doc duplicate"))
 def duplicate_cmd(
     ctx: typer.Context,
-    doc_id: int | None = typer.Option(
-        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
-    ),
-    object_id: int | None = typer.Option(
-        None,
-        "--object-id",
-        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
-        click_type=MondayIdParam(),
-    ),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
     duplicate_type: DuplicateDocType = typer.Option(
         DuplicateDocType.duplicate_doc_with_content,
         "--duplicate-type",
@@ -1109,22 +1140,16 @@ def duplicate_cmd(
 ) -> None:
     """Duplicate a doc."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
-    data = _execute_doc_command(
+    data, _ = _execute_doc_command(
         opts,
         DUPLICATE_DOC,
-        {"doc": resolved_doc, "dup": duplicate_type.value},
-        hint_doc_id=doc_id,
+        {"dup": duplicate_type.value},
+        doc_id=doc_id,
+        object_id=object_id,
     )
     result = data.get("duplicate_doc") or {}
     if not result.get("success"):
-        err = result.get("error") or "duplicate_doc failed"
-        line = f"error: {err}"
-        hint = _object_id_hint(opts, doc_id) if doc_id is not None else None
-        if hint:
-            line = f"{line}\n{hint}"
-        typer.secho(line, fg=typer.colors.RED, err=True)
-        raise typer.Exit(code=5)
+        _fail_with_object_id_hint(opts, result.get("error") or "duplicate_doc failed", doc_id)
     new_object_id = result.get("id")
     if new_object_id is None:
         typer.secho(
@@ -1157,22 +1182,14 @@ def duplicate_cmd(
 @app.command("delete", epilog=epilog_for("doc delete"))
 def delete_cmd(
     ctx: typer.Context,
-    doc_id: int | None = typer.Option(
-        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
-    ),
-    object_id: int | None = typer.Option(
-        None,
-        "--object-id",
-        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
-        click_type=MondayIdParam(),
-    ),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
 ) -> None:
     """Delete a doc."""
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
-    data = _execute_doc_command(
-        opts, DELETE_DOC, {"doc": resolved_doc}, hint_doc_id=doc_id
+    data, resolved_doc = _execute_doc_command(
+        opts, DELETE_DOC, {}, doc_id=doc_id, object_id=object_id
     )
     invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
     invalidate_entity(opts, "docs")
@@ -1182,15 +1199,8 @@ def delete_cmd(
 @app.command("export-markdown", epilog=epilog_for("doc export-markdown"))
 def export_markdown_cmd(
     ctx: typer.Context,
-    doc_id: int | None = typer.Option(
-        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
-    ),
-    object_id: int | None = typer.Option(
-        None,
-        "--object-id",
-        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
-        click_type=MondayIdParam(),
-    ),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
     block_id: list[str] | None = typer.Option(
         None,
         "--block",
@@ -1204,43 +1214,29 @@ def export_markdown_cmd(
 ) -> None:
     """Export doc content as markdown."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
-    data = _execute_doc_command(
+    data, _ = _execute_doc_command(
         opts,
         EXPORT_MARKDOWN_FROM_DOC,
-        {"doc": resolved_doc, "blocks": block_id or None},
-        hint_doc_id=doc_id,
+        {"blocks": block_id or None},
+        doc_id=doc_id,
+        object_id=object_id,
     )
     result = data.get("export_markdown_from_doc") or {}
     if raw:
         opts.emit(result)
         return
     if not result.get("success"):
-        err = result.get("error") or "export_markdown_from_doc failed"
-        line = f"error: {err}"
-        # The observed failure mode for an object id sent as --doc is an
-        # opaque mutation-level 500 ("Fetcher response returned NON-OK
-        # status=500") — probe before giving up.
-        hint = _object_id_hint(opts, doc_id) if doc_id is not None else None
-        if hint:
-            line = f"{line}\n{hint}"
-        typer.secho(line, fg=typer.colors.RED, err=True)
-        raise typer.Exit(code=5)
+        _fail_with_object_id_hint(
+            opts, result.get("error") or "export_markdown_from_doc failed", doc_id
+        )
     typer.echo(result.get("markdown") or "")
 
 
 @app.command("version-history", epilog=epilog_for("doc version-history"))
 def version_history_cmd(
     ctx: typer.Context,
-    doc_id: int | None = typer.Option(
-        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
-    ),
-    object_id: int | None = typer.Option(
-        None,
-        "--object-id",
-        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
-        click_type=MondayIdParam(),
-    ),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
     since: str | None = typer.Option(
         None,
         "--since",
@@ -1254,12 +1250,12 @@ def version_history_cmd(
 ) -> None:
     """Fetch restoring points for a doc (API 2026-04+)."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
-    data = _execute_doc_command(
+    data, _ = _execute_doc_command(
         opts,
         DOC_VERSION_HISTORY,
-        {"doc": resolved_doc, "since": since, "until": until},
-        hint_doc_id=doc_id,
+        {"since": since, "until": until},
+        doc_id=doc_id,
+        object_id=object_id,
     )
     opts.emit(data.get("doc_version_history") or {})
 
@@ -1267,15 +1263,8 @@ def version_history_cmd(
 @app.command("version-diff", epilog=epilog_for("doc version-diff"))
 def version_diff_cmd(
     ctx: typer.Context,
-    doc_id: int | None = typer.Option(
-        None, "--doc", help="Internal doc ID (not the URL-visible object_id)."
-    ),
-    object_id: int | None = typer.Option(
-        None,
-        "--object-id",
-        help="URL-visible doc object_id (or monday.com /docs/<id> URL).",
-        click_type=MondayIdParam(),
-    ),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
     date: str = typer.Option(..., "--date", help="Newer restoring-point ISO8601 timestamp."),
     prev_date: str = typer.Option(
         ...,
@@ -1285,12 +1274,12 @@ def version_diff_cmd(
 ) -> None:
     """Fetch block-level diff between two restoring points (API 2026-04+)."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    resolved_doc = _resolve_doc_target(opts, doc_id=doc_id, object_id=object_id)
-    data = _execute_doc_command(
+    data, _ = _execute_doc_command(
         opts,
         DOC_VERSION_DIFF,
-        {"doc": resolved_doc, "date": date, "prev": prev_date},
-        hint_doc_id=doc_id,
+        {"date": date, "prev": prev_date},
+        doc_id=doc_id,
+        object_id=object_id,
     )
     opts.emit(data.get("doc_version_diff") or {})
 

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mondo
 description: Use when the user wants to do anything against monday.com via the `mondo` CLI — reading or writing workspaces, folders, boards, groups, items, subitems, columns, updates, docs, files, users, teams, webhooks, or when they paste a monday.com URL.
-version: "1.1.0"
+version: "1.1.1"
 ---
 
 # mondo

--- a/src/mondo/skill/references/docs.md
+++ b/src/mondo/skill/references/docs.md
@@ -38,7 +38,8 @@ mondo doc get --id 5095668848 --format json -o json
 # Or address by object_id (the URL form):
 mondo doc get --object-id abcd1234 --format json -o json
 
-# Render to Markdown:
+# Render to Markdown (--object-id for the URL-visible id, --doc for the internal id):
+mondo doc export-markdown --object-id abcd1234
 mondo doc export-markdown --doc 5095668848
 ```
 
@@ -54,7 +55,7 @@ mondo doc export-markdown --doc 5095668848
 }
 ```
 
-*Gotcha:* `--id` is the numeric, `--object-id` is the UUID. Block types use `snake_case` on input (`normal_text`, `medium_title`, `bulleted_list`); read paths sometimes return them with spaces — match either form.
+*Gotcha:* `--id`/`--doc` is monday's internal id; `--object-id` is the id you see in `/docs/<id>` URLs. **Every** doc subcommand that targets a doc (`get`, `export-markdown`, `add-block`, `add-content`, `add-markdown`, `rename`, `duplicate`, `delete`, `version-history`, `version-diff`) accepts `--object-id` — when a URL or a human gave you the id, that's the flag to use. Sending an object id through `--doc` fails (historically as an opaque 500); mondo now detects it and tells you to retry with `--object-id`. Block types use `snake_case` on input (`normal_text`, `medium_title`, `bulleted_list`); read paths sometimes return them with spaces — match either form.
 
 ## Create a doc
 

--- a/src/mondo/skill/references/docs.md
+++ b/src/mondo/skill/references/docs.md
@@ -22,12 +22,12 @@ mondo doc list --workspace 592446 --workspace 699169 -o json   # multiple worksp
 
 ```json
 [
-  {"id": 5095668848, "object_id": "abcd1234", "name": "Spec — login flow"},
-  {"id": 5095668849, "object_id": "abcd1235", "name": "Spec — auth middleware"}
+  {"id": 5095668848, "object_id": "5098297247", "name": "Spec — login flow"},
+  {"id": 5095668849, "object_id": "5098297248", "name": "Spec — auth middleware"}
 ]
 ```
 
-*Gotcha:* `id` is monday's internal numeric doc id; `object_id` is the UUID-style doc id used in URLs (`/docs/<object_id>`). `--no-cache` is a good idea immediately after a write — the docs directory cache TTL is 8h, and `doc get` has its own short-TTL per-doc cache (`docs_blocks/<id>.json`, 5m) which is invalidated by every doc-write path (`add-block`, `add-content`, `add-markdown`, `import-html`, `rename`, `delete`, `update-block`, `delete-block`, plus `column doc set/append/clear`). Name filters (`--name-contains`, `--name-matches`, `--name-fuzzy`) are client-side and work with or without `--workspace`.
+*Gotcha:* `id` is monday's internal numeric doc id; `object_id` is the (also numeric) URL-visible doc id (`/docs/<object_id>`). `--no-cache` is a good idea immediately after a write — the docs directory cache TTL is 8h, and `doc get` has its own short-TTL per-doc cache (`docs_blocks/<id>.json`, 5m) which is invalidated by every doc-write path (`add-block`, `add-content`, `add-markdown`, `import-html`, `rename`, `delete`, `update-block`, `delete-block`, plus `column doc set/append/clear`). Name filters (`--name-contains`, `--name-matches`, `--name-fuzzy`) are client-side and work with or without `--workspace`.
 
 ## Get a doc — JSON or Markdown
 
@@ -36,17 +36,17 @@ mondo doc list --workspace 592446 --workspace 699169 -o json   # multiple worksp
 mondo doc get --id 5095668848 --format json -o json
 
 # Or address by object_id (the URL form):
-mondo doc get --object-id abcd1234 --format json -o json
+mondo doc get --object-id 5098297247 --format json -o json
 
 # Render to Markdown (--object-id for the URL-visible id, --doc for the internal id):
-mondo doc export-markdown --object-id abcd1234
+mondo doc export-markdown --object-id 5098297247
 mondo doc export-markdown --doc 5095668848
 ```
 
 ```json
 {
   "id": 5095668848,
-  "object_id": "abcd1234",
+  "object_id": "5098297247",
   "name": "Spec — login flow",
   "blocks": [
     {"type": "large_title",  "content": {"deltaFormat": [{"insert": "Section A"}]}},
@@ -64,7 +64,7 @@ mondo doc create --workspace 592446 --name "Spec — Q3 launch"
 ```
 
 ```json
-{"id": 5095668850, "object_id": "abcd1239", "name": "Spec — Q3 launch", "blocks": []}
+{"id": 5095668850, "object_id": "5098297249", "name": "Spec — Q3 launch", "blocks": []}
 ```
 
 *Gotcha:* the new doc starts empty. Add content with `add-markdown`, `add-content`, or per-block `add-block`.

--- a/tests/integration/test_live_writes.py
+++ b/tests/integration/test_live_writes.py
@@ -634,6 +634,32 @@ def test_live_doc_read_with_notice_box(live_test_doc_id: int) -> None:
 
 
 @pytest.mark.integration
+def test_live_doc_export_markdown_object_id(live_test_doc_id: int) -> None:
+    """Read-only #24 coverage: `export-markdown --object-id` works directly,
+    and the same id passed as `--doc` fails with the targeted retry hint
+    instead of an opaque server 500."""
+    md_result = invoke(["doc", "export-markdown", "--object-id", str(live_test_doc_id)])
+    assert md_result.stdout.strip(), "export-markdown --object-id produced no output"
+
+    wrong = invoke(
+        ["doc", "export-markdown", "--doc", str(live_test_doc_id)],
+        expect_exit=None,
+    )
+    assert wrong.exit_code != 0, format_failure(["doc", "export-markdown"], wrong)
+    assert f"--object-id {live_test_doc_id}" in wrong.stderr, wrong.stderr
+
+    both = invoke(
+        [
+            "doc", "export-markdown",
+            "--doc", str(live_test_doc_id),
+            "--object-id", str(live_test_doc_id),
+        ],
+        expect_exit=2,
+    )
+    assert "exactly one of" in both.stderr
+
+
+@pytest.mark.integration
 def test_live_doc_create_add_blocks_delete(
     live_workspace_id: int, cleanup_plan: CleanupPlan
 ) -> None:

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -697,6 +697,8 @@ class TestGet:
 
     def test_missing_exits_6(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
+        # Object-id probe on the --id miss (the #24 guardrail) — misses too.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
         result = runner.invoke(app, ["doc", "get", "--id", "999"])
         assert result.exit_code == 6
 
@@ -779,10 +781,16 @@ class TestGet:
         self, httpx_mock: HTTPXMock
     ) -> None:
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
+        # Object-id probe on the --id miss (the #24 guardrail) — misses too.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
         result = runner.invoke(app, ["doc", "get", "--id", "999"])
         assert result.exit_code == 6
-        # Only one HTTP call — no BOARD_GET probe on --id path.
-        assert len(httpx_mock.get_requests()) == 1
+        # Two HTTP calls: the fetch and the object-id probe — but no
+        # BOARD_GET probe on the --id path.
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+        assert "object_ids" in json.loads(requests[-1].content)["query"]
+        assert "boards" not in json.loads(requests[-1].content)["query"]
 
 
 # --- create ---
@@ -1273,6 +1281,8 @@ class TestDocNewOps:
             method="POST",
             json=_ok({"duplicate_doc": {"success": False, "error": "Unknown error"}}),
         )
+        # Object-id probe on the success=False failure (the #24 guardrail).
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
         result = runner.invoke(
             app,
             [
@@ -1320,6 +1330,8 @@ class TestDocNewOps:
                 }
             ),
         )
+        # Object-id probe on the success=False failure (the #24 guardrail).
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
         result = runner.invoke(app, ["doc", "export-markdown", "--doc", "10"])
         assert result.exit_code == 5
 

--- a/tests/unit/test_cli_doc_object_id.py
+++ b/tests/unit/test_cli_doc_object_id.py
@@ -1,0 +1,294 @@
+"""`--object-id` on doc subcommands + the object-id-vs-internal-id guardrail (#24).
+
+The URL-visible `object_id` (the `/docs/<id>` URL segment) is the only id a
+human or a pasted URL ever provides; sending it where the internal id belongs
+historically produced an opaque monday 500. Every doc subcommand that targets
+a doc now accepts `--object-id` (resolved via a cheap head query), and `--doc`
+failures probe whether the id is actually an object id.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from mondo.cli.main import app
+
+ENDPOINT = "https://api.monday.com/v2"
+runner = CliRunner()
+
+OBJECT_ID = "5098297247"
+INTERNAL_ID = "8519623"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("MONDO_PROFILE", raising=False)
+    monkeypatch.delenv("MONDAY_API_VERSION", raising=False)
+    monkeypatch.setenv("MONDO_CONFIG", str(tmp_path / "nope.yaml"))
+    monkeypatch.setenv("MONDAY_API_TOKEN", "env-token-abcdef-long-enough")
+    monkeypatch.setenv("MONDO_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MONDO_CACHE_ENABLED", "false")
+
+
+def _ok(data: dict) -> dict:
+    return {"data": data, "extensions": {"request_id": "r"}}
+
+
+def _head_hit() -> dict:
+    return _ok(
+        {
+            "docs": [
+                {
+                    "id": INTERNAL_ID,
+                    "object_id": OBJECT_ID,
+                    "name": "Mondo Test Doc",
+                    "url": "https://acct.monday.com/docs/" + OBJECT_ID,
+                }
+            ]
+        }
+    )
+
+
+def _bodies(httpx_mock: HTTPXMock) -> list[dict]:
+    return [json.loads(r.content) for r in httpx_mock.get_requests()]
+
+
+class TestExportMarkdownObjectId:
+    def test_object_id_resolves_then_exports(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_head_hit())
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "export_markdown_from_doc": {
+                        "success": True,
+                        "markdown": "# Hello",
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        result = runner.invoke(
+            app, ["doc", "export-markdown", "--object-id", OBJECT_ID]
+        )
+        assert result.exit_code == 0, result.output
+        assert result.stdout.strip() == "# Hello"
+        head, export = _bodies(httpx_mock)
+        assert head["variables"] == {"objs": [int(OBJECT_ID)]}
+        assert export["variables"]["doc"] == int(INTERNAL_ID)
+
+    def test_doc_and_object_id_together_is_usage_error(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        result = runner.invoke(
+            app,
+            ["doc", "export-markdown", "--doc", INTERNAL_ID, "--object-id", OBJECT_ID],
+        )
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_neither_flag_is_usage_error(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(app, ["doc", "export-markdown"])
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_object_id_miss_exits_6(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
+        result = runner.invoke(
+            app, ["doc", "export-markdown", "--object-id", OBJECT_ID]
+        )
+        assert result.exit_code == 6
+        assert "not found" in result.stderr
+
+    def test_500_with_object_id_as_doc_gets_targeted_hint(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # The observed failure: object id sent as --doc → mutation-level 500.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "export_markdown_from_doc": {
+                        "success": False,
+                        "error": "Fetcher response returned NON-OK status=500 "
+                        "statusText=Internal Server Error",
+                        "markdown": "",
+                    }
+                }
+            ),
+        )
+        # Probe resolves the id as an object_id → targeted hint.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_head_hit())
+        result = runner.invoke(app, ["doc", "export-markdown", "--doc", OBJECT_ID])
+        assert result.exit_code == 5
+        assert "status=500" in result.stderr
+        assert f"--object-id {OBJECT_ID}" in result.stderr
+        assert "looks like a URL-visible object id" in result.stderr
+
+    def test_graphql_error_with_object_id_as_doc_gets_targeted_hint(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={
+                "errors": [
+                    {
+                        "message": "Internal server error",
+                        "extensions": {"code": "INTERNAL_SERVER_ERROR"},
+                    }
+                ]
+            },
+        )
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_head_hit())
+        result = runner.invoke(app, ["doc", "export-markdown", "--doc", OBJECT_ID])
+        assert result.exit_code != 0
+        assert f"--object-id {OBJECT_ID}" in result.stderr
+
+    def test_500_with_real_internal_id_no_hint(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "export_markdown_from_doc": {
+                        "success": False,
+                        "error": "boom",
+                        "markdown": "",
+                    }
+                }
+            ),
+        )
+        # Probe misses — the id is not an object id; no hint.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
+        result = runner.invoke(app, ["doc", "export-markdown", "--doc", INTERNAL_ID])
+        assert result.exit_code == 5
+        assert "--object-id" not in result.stderr
+
+
+MUTATION_CASES = [
+    (
+        ["doc", "rename", "--name", "n"],
+        {"update_doc_name": {"id": INTERNAL_ID}},
+    ),
+    (
+        ["doc", "delete"],
+        {"delete_doc": {"id": INTERNAL_ID}},
+    ),
+    (
+        ["doc", "add-markdown", "--markdown", "# Hi"],
+        {
+            "add_content_to_doc_from_markdown": {
+                "success": True,
+                "block_ids": ["b1"],
+                "error": None,
+            }
+        },
+    ),
+    (
+        ["doc", "version-history"],
+        {"doc_version_history": {"points": []}},
+    ),
+    (
+        ["doc", "version-diff", "--date", "2026-01-02", "--prev-date", "2026-01-01"],
+        {"doc_version_diff": {"blocks": []}},
+    ),
+]
+
+
+class TestUniformObjectIdSurface:
+    """Every doc subcommand that targets a doc accepts --doc XOR --object-id."""
+
+    @pytest.mark.parametrize(("args", "payload"), MUTATION_CASES)
+    def test_object_id_resolves_to_internal_id(
+        self, httpx_mock: HTTPXMock, args: list[str], payload: dict
+    ) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_head_hit())
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok(payload))
+        result = runner.invoke(app, [*args, "--object-id", OBJECT_ID])
+        assert result.exit_code == 0, result.output
+        assert _bodies(httpx_mock)[-1]["variables"]["doc"] == int(INTERNAL_ID)
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["doc", "export-markdown"],
+            ["doc", "rename", "--name", "n"],
+            ["doc", "delete"],
+            ["doc", "duplicate"],
+            ["doc", "add-markdown", "--markdown", "# Hi"],
+            ["doc", "add-block", "--type", "normal_text", "--content", "{}"],
+            ["doc", "add-content", "--markdown", "# Hi"],
+            ["doc", "version-history"],
+            ["doc", "version-diff", "--date", "d", "--prev-date", "p"],
+        ],
+    )
+    def test_both_flags_is_usage_error(
+        self, httpx_mock: HTTPXMock, args: list[str]
+    ) -> None:
+        result = runner.invoke(
+            app, [*args, "--doc", INTERNAL_ID, "--object-id", OBJECT_ID]
+        )
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_add_block_object_id(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_head_hit())
+        # Pre-fetch of existing blocks (append semantics).
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "docs": [
+                        {
+                            "id": INTERNAL_ID,
+                            "object_id": OBJECT_ID,
+                            "name": "D",
+                            "blocks": [],
+                        }
+                    ]
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"create_doc_block": {"id": "b9"}})
+        )
+        result = runner.invoke(
+            app,
+            [
+                "doc", "add-block",
+                "--object-id", OBJECT_ID,
+                "--type", "normal_text",
+                "--content", '{"deltaFormat": [{"insert": "hi"}]}',
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert _bodies(httpx_mock)[-1]["variables"]["doc"] == int(INTERNAL_ID)
+
+    def test_rename_doc_url_accepted_on_object_id(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_head_hit())
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"update_doc_name": {"id": INTERNAL_ID}}),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "doc", "rename",
+                "--object-id", f"https://acct.monday.com/docs/{OBJECT_ID}",
+                "--name", "renamed",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert _bodies(httpx_mock)[-1]["variables"]["doc"] == int(INTERNAL_ID)

--- a/tests/unit/test_cli_doc_object_id.py
+++ b/tests/unit/test_cli_doc_object_id.py
@@ -173,6 +173,62 @@ class TestExportMarkdownObjectId:
         assert "--object-id" not in result.stderr
 
 
+class TestAddMarkdownEnvelope:
+    def test_500_envelope_with_object_id_as_doc_gets_targeted_hint(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # HTTP 200 + success:false (the issue-#24 fetcher-500 case): the
+        # envelope must fail the command (exit 5), not be emitted as success.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": False,
+                        "error": "Fetcher response returned NON-OK status=500 "
+                        "statusText=Internal Server Error",
+                        "block_ids": None,
+                    }
+                }
+            ),
+        )
+        # Probe resolves the id as an object_id → targeted hint.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_head_hit())
+        result = runner.invoke(
+            app, ["doc", "add-markdown", "--doc", OBJECT_ID, "--markdown", "# Hi"]
+        )
+        assert result.exit_code == 5
+        assert "status=500" in result.stderr
+        assert f"--object-id {OBJECT_ID}" in result.stderr
+        assert "looks like a URL-visible object id" in result.stderr
+
+    def test_500_envelope_with_real_internal_id_no_hint(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": False,
+                        "error": "boom",
+                        "block_ids": None,
+                    }
+                }
+            ),
+        )
+        # Probe misses — the id is not an object id; no hint.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
+        result = runner.invoke(
+            app, ["doc", "add-markdown", "--doc", INTERNAL_ID, "--markdown", "# Hi"]
+        )
+        assert result.exit_code == 5
+        assert "boom" in result.stderr
+        assert "--object-id" not in result.stderr
+
+
 MUTATION_CASES = [
     (
         ["doc", "rename", "--name", "n"],


### PR DESCRIPTION
Closes #24.

## What

The URL-visible `object_id` (the `/docs/<id>` URL segment) is the only id a human or a pasted monday URL ever provides — but most doc subcommands only accepted `--doc` (internal id). Sending the object id there surfaced as an opaque monday 500 with no hint (observed twice in session logs).

1. **`--object-id` everywhere**: `export-markdown`, `add-block`, `add-content`, `add-markdown`, `rename`, `duplicate`, `delete`, `version-history`, `version-diff` now all accept `--object-id` (mutually exclusive with `--doc`, also accepts pasted `/docs/<id>` URLs). Resolution is one cheap `docs(object_ids: ...) { id }` head query; a miss exits 6. Cache invalidation keys keep using the resolved internal id.
2. **Guardrail on the opaque 500**: when a `--doc`-addressed call fails server-side — a GraphQL error (exit 1/5/6), a `success: false` mutation envelope (the observed `Fetcher response returned NON-OK status=500` case), or a not-found on `doc get` / `add-block` / `add-content` — mondo probes whether the id resolves as an object_id and appends: `hint: <id> looks like a URL-visible object id, not an internal doc id — retry with --object-id <id>`. Exit codes unchanged; the probe never masks the original error (any probe failure is swallowed).
3. **Audit**: `column doc *` is unaffected — those commands resolve the doc from the column value, never from a user-supplied internal id. `doc get`/`doc list` already had the flag.

## Acceptance criteria from #24

- ✅ `mondo doc export-markdown --object-id 5095668848` exports the doc (live-verified against the playground doc)
- ✅ `mondo doc export-markdown --doc <object-id>` fails with the targeted hint instead of a bare 500 envelope (live-verified — real 500 + hint)
- ✅ `--doc` + `--object-id` together → exit 2 usage error
- ✅ Unit tests + live coverage using MONDO_TEST_DOC_ID

## Tests

- 23 new unit tests in `tests/unit/test_cli_doc_object_id.py` (resolution, both/neither usage errors, miss → exit 6, 500 + hint, GraphQL error + hint, no-hint for genuine internal-id failures, uniform surface across all 9 subcommands, URL form accepted).
- 4 existing doc tests updated to mock the new probe call.
- New live integration test `test_live_doc_export_markdown_object_id` (read-only, runs against the prepared playground doc) — passing.
- Full unit suite: 1432 passed. Ruff clean on changed files (the one report in `test_live_writes.py` is a pre-existing import-sort finding on main, untouched by this PR).

Skill docs reference updated (`references/docs.md`); skill version bumped to 1.1.1.