### PR TITLE
feat(cli): keep errors visible when stderr is suppressed

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -159,6 +159,10 @@ Or via environment variables (highest non-CLI precedence):
 - `MONDO_CACHE_FUZZY_THRESHOLD` — integer 0-100
 - `MONDO_NO_CACHE_NOTICE=1` — silence the `cache: hit (entity=…, age=…)`
   stderr provenance line on hits
+- `MONDO_VERBOSE=1` — show the provenance line even when stderr is not a
+  TTY (since #25, benign notices are suppressed by default in
+  non-interactive runs; `--verbose` and `--explain-cache` also restore
+  them)
 
 Precedence (lowest → highest): built-in defaults → global `cache:` → profile
 `cache:` → env vars → CLI flags (`--no-cache`, `--refresh-cache`,

--- a/src/mondo/cli/_cache_flags.py
+++ b/src/mondo/cli/_cache_flags.py
@@ -79,8 +79,10 @@ def emit_cache_provenance(
 
     Fires only when `cached` was served from disk (`from_cache=True`). Suppressed
     when `MONDO_NO_CACHE_NOTICE=1` (unless `explain=True` — `--explain-cache`
-    is an explicit user request and overrides the env var) or when
-    `--output table` is in effect (interactive humans don't need it).
+    is an explicit user request and overrides the env var), when
+    `--output table` is in effect (interactive humans don't need it), or when
+    no human is plausibly watching stderr (non-TTY, see `_notices`) unless
+    `--verbose` / `MONDO_VERBOSE=1`.
 
     `explain=True` adds verbose detail (path, ttl, fetched_at).
     """
@@ -90,6 +92,10 @@ def emit_cache_provenance(
         if os.environ.get("MONDO_NO_CACHE_NOTICE") == "1":
             return
         if opts.output == "table":
+            return
+        from mondo.cli._notices import benign_notices_enabled
+
+        if not benign_notices_enabled(verbose=opts.verbose):
             return
 
     age_str = _format_age(cached.age.total_seconds())

--- a/src/mondo/cli/_errors.py
+++ b/src/mondo/cli/_errors.py
@@ -165,3 +165,28 @@ def error_envelope(exc: BaseException, *, suggestion: str | None = None) -> dict
 def emit_envelope(envelope: dict[str, Any]) -> None:
     """Write the envelope to stderr as a single JSON line."""
     typer.echo(json.dumps(envelope, separators=(",", ":")), err=True)
+
+
+def mirror_envelope_to_stdout(opts: GlobalOpts | None, envelope: dict[str, Any]) -> None:
+    """Mirror a fatal-error envelope to stdout in machine mode (#25).
+
+    31% of observed agent invocations suppress stderr (`2>/dev/null`), turning
+    every carefully-crafted error into an invisible failure: empty stdout +
+    nonzero exit. When the command dies before writing anything to stdout,
+    pipelines now receive the same JSON envelope there — parseable instead of
+    empty input. Exit codes are unchanged.
+
+    Guards:
+    - never fires once `emit()` has written to stdout (a partial-success
+      stream is never corrupted);
+    - `-o none` keeps stdout silent.
+
+    Callers gate on `is_machine_output` — the mirror only fires where the
+    stderr envelope fired too.
+    """
+    output = ((opts.output if opts is not None else None) or "").lower()
+    if output == "none":
+        return
+    if opts is not None and opts.stdout_emitted:
+        return
+    typer.echo(json.dumps(envelope, separators=(",", ":")))

--- a/src/mondo/cli/_errors.py
+++ b/src/mondo/cli/_errors.py
@@ -178,15 +178,13 @@ def mirror_envelope_to_stdout(opts: GlobalOpts | None, envelope: dict[str, Any])
 
     Guards:
     - never fires once `emit()` has written to stdout (a partial-success
-      stream is never corrupted);
-    - `-o none` keeps stdout silent.
+      stream is never corrupted).
 
-    Callers gate on `is_machine_output` — the mirror only fires where the
-    stderr envelope fired too.
+    Callers gate on `is_machine_output` / `is_machine_output_argv` — the
+    mirror only fires where the stderr envelope fired too. Those classify
+    `-o none` as a human format, so it keeps stdout silent without a
+    guard here.
     """
-    output = ((opts.output if opts is not None else None) or "").lower()
-    if output == "none":
-        return
     if opts is not None and opts.stdout_emitted:
         return
     typer.echo(json.dumps(envelope, separators=(",", ":")))

--- a/src/mondo/cli/_exec.py
+++ b/src/mondo/cli/_exec.py
@@ -73,19 +73,14 @@ def handle_mondo_error_or_exit(
 def usage_error_or_exit(message: str) -> NoReturn:
     """Uniform exit for command-level usage errors.
 
-    Red `error:` line on stderr plus, in machine mode, the JSON envelope
-    on stderr and the stdout mirror (#25). Replaces the bare
-    `typer.secho(...) + typer.Exit(2)` pattern, which left suppressed-stderr
-    pipelines with empty stdout and no clue.
+    Wraps `message` in a `UsageError` (exit code 2) and routes it through
+    the canonical `handle_mondo_error_or_exit` path: red `error:` line on
+    stderr plus, in machine mode, the JSON envelope on stderr and the
+    stdout mirror (#25). Replaces the bare `typer.secho(...) +
+    typer.Exit(2)` pattern, which left suppressed-stderr pipelines with
+    empty stdout and no clue.
     """
-    typer.secho(f"error: {message}", fg=typer.colors.RED, err=True)
-    ctx = click.get_current_context(silent=True)
-    opts = ctx.ensure_object(_GlobalOpts) if ctx is not None else None
-    if is_machine_output(opts):
-        envelope = error_envelope(UsageError(message))
-        emit_envelope(envelope)
-        mirror_envelope_to_stdout(opts, envelope)
-    raise typer.Exit(code=2)
+    handle_mondo_error_or_exit(UsageError(message))
 
 
 def client_or_exit(opts: GlobalOpts) -> MondayClient:

--- a/src/mondo/cli/_exec.py
+++ b/src/mondo/cli/_exec.py
@@ -18,8 +18,13 @@ from typing import TYPE_CHECKING, Annotated, Any, NoReturn
 import click
 import typer
 
-from mondo.api.errors import MondoError
-from mondo.cli._errors import emit_envelope, error_envelope, is_machine_output
+from mondo.api.errors import MondoError, UsageError
+from mondo.cli._errors import (
+    emit_envelope,
+    error_envelope,
+    is_machine_output,
+    mirror_envelope_to_stdout,
+)
 from mondo.cli.context import GlobalOpts as _GlobalOpts
 
 if TYPE_CHECKING:
@@ -47,7 +52,9 @@ def _emit_error(exc: BaseException, *, human_suffix: str | None = None) -> None:
     ctx = click.get_current_context(silent=True)
     opts = ctx.ensure_object(_GlobalOpts) if ctx is not None else None
     if is_machine_output(opts):
-        emit_envelope(error_envelope(exc))
+        envelope = error_envelope(exc)
+        emit_envelope(envelope)
+        mirror_envelope_to_stdout(opts, envelope)
 
 
 def handle_mondo_error_or_exit(
@@ -61,6 +68,24 @@ def handle_mondo_error_or_exit(
     """
     _emit_error(exc, human_suffix=human_suffix)
     raise typer.Exit(code=int(exc.exit_code)) from exc
+
+
+def usage_error_or_exit(message: str) -> NoReturn:
+    """Uniform exit for command-level usage errors.
+
+    Red `error:` line on stderr plus, in machine mode, the JSON envelope
+    on stderr and the stdout mirror (#25). Replaces the bare
+    `typer.secho(...) + typer.Exit(2)` pattern, which left suppressed-stderr
+    pipelines with empty stdout and no clue.
+    """
+    typer.secho(f"error: {message}", fg=typer.colors.RED, err=True)
+    ctx = click.get_current_context(silent=True)
+    opts = ctx.ensure_object(_GlobalOpts) if ctx is not None else None
+    if is_machine_output(opts):
+        envelope = error_envelope(UsageError(message))
+        emit_envelope(envelope)
+        mirror_envelope_to_stdout(opts, envelope)
+    raise typer.Exit(code=2)
 
 
 def client_or_exit(opts: GlobalOpts) -> MondayClient:

--- a/src/mondo/cli/_notices.py
+++ b/src/mondo/cli/_notices.py
@@ -1,0 +1,25 @@
+"""Gate for benign stderr notices (#25).
+
+A third of observed agent invocations append `2>/dev/null`, partly because
+mondo emits benign noise (cache-hit notices, skill-freshness warnings) on
+stderr in non-interactive runs — training the habit that stderr is junk,
+which then hides real errors. Benign notices now show only when a human is
+plausibly watching (stderr is a TTY) or when explicitly requested
+(`--verbose` / `MONDO_VERBOSE=1`). Errors are unaffected — they always go
+to stderr.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def benign_notices_enabled(*, verbose: bool = False) -> bool:
+    """True when benign notices should be written to stderr."""
+    if verbose or os.environ.get("MONDO_VERBOSE") == "1":
+        return True
+    try:
+        return sys.stderr.isatty()
+    except Exception:
+        return False

--- a/src/mondo/cli/_notices.py
+++ b/src/mondo/cli/_notices.py
@@ -19,7 +19,4 @@ def benign_notices_enabled(*, verbose: bool = False) -> bool:
     """True when benign notices should be written to stderr."""
     if verbose or os.environ.get("MONDO_VERBOSE") == "1":
         return True
-    try:
-        return sys.stderr.isatty()
-    except Exception:
-        return False
+    return sys.stderr.isatty()

--- a/src/mondo/cli/context.py
+++ b/src/mondo/cli/context.py
@@ -39,6 +39,10 @@ class GlobalOpts:
     fields: str | None = None
     yes: bool = False
     dry_run: bool = False
+    # True once `emit()` has written to stdout. The fatal-error stdout
+    # mirror (#25) checks this so a partial-success stream is never
+    # corrupted by a trailing error envelope.
+    stdout_emitted: bool = field(default=False, init=False)
     _config: Config | None = field(default=None, init=False, repr=False)
     _cache_config: ResolvedCacheConfig | None = field(default=None, init=False, repr=False)
 
@@ -88,6 +92,8 @@ class GlobalOpts:
         ):
             self._warn_unselected_projection_fields(self.query, selected_fields)
         format_output(projected, fmt=fmt, stream=out, tty=is_tty)
+        if stream is None and fmt != "none":
+            self.stdout_emitted = True
 
     @staticmethod
     def _warn_unselected_projection_fields(

--- a/src/mondo/cli/graphql.py
+++ b/src/mondo/cli/graphql.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import typer
 
 from mondo.api.errors import MondoError
-from mondo.cli._exec import handle_mondo_error_or_exit
+from mondo.cli._exec import handle_mondo_error_or_exit, usage_error_or_exit
 from mondo.cli._json_flag import parse_json_flag
 from mondo.cli.context import GlobalOpts
 
@@ -57,16 +57,13 @@ def graphql_command(
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
 
     if opts.dry_run:
-        typer.secho(
-            "error: --dry-run is not supported with `mondo graphql`. The raw "
+        usage_error_or_exit(
+            "--dry-run is not supported with `mondo graphql`. The raw "
             "passthrough can't preview safely (mondo doesn't parse your query, "
             "and verifying success requires sending it). Review the GraphQL "
             "manually and re-run without --dry-run, or use a typed subcommand "
-            "if one wraps your operation.",
-            fg=typer.colors.RED,
-            err=True,
+            "if one wraps your operation."
         )
-        raise typer.Exit(code=2)
 
     if query is None:
         # A4/A5 in the friction report: detect when the user passed their
@@ -74,21 +71,13 @@ def graphql_command(
         # and emit a targeted recovery hint instead of the generic
         # "Missing argument 'QUERY'" Click message.
         if opts.query and _looks_like_graphql(opts.query):
-            typer.secho(
-                "error: your GraphQL query was passed to `-q` (global JMESPath "
+            usage_error_or_exit(
+                "your GraphQL query was passed to `-q` (global JMESPath "
                 "projection) instead of as a positional argument. Pass it "
                 "positionally:\n"
-                "  mondo graphql 'query { … }'",
-                fg=typer.colors.RED,
-                err=True,
+                "  mondo graphql 'query { … }'"
             )
-            raise typer.Exit(code=2)
-        typer.secho(
-            "error: missing required argument 'QUERY'.",
-            fg=typer.colors.RED,
-            err=True,
-        )
-        raise typer.Exit(code=2)
+        usage_error_or_exit("missing required argument 'QUERY'.")
 
     query_text = _load_query(query)
     vars_dict: dict[str, object] = {}

--- a/src/mondo/cli/main.py
+++ b/src/mondo/cli/main.py
@@ -344,7 +344,13 @@ def _root(
         "Runs before --query. Client-side projection — does not narrow the "
         "GraphQL request.",
     ),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Log INFO-level events to stderr."),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        envvar="MONDO_VERBOSE",
+        help="Log INFO-level events to stderr.",
+    ),
     debug: bool = typer.Option(
         False, "--debug", help="Log every GraphQL query and response to stderr."
     ),

--- a/src/mondo/cli/main.py
+++ b/src/mondo/cli/main.py
@@ -378,7 +378,13 @@ def _root(
     # parses stdout as JSON. The freshness-check module itself remains
     # callable from `tests/unit/test_cli_skill_freshness.py` (which exercises
     # `warn_if_skill_outdated()` directly).
-    if not os.environ.get("PYTEST_CURRENT_TEST"):
+    # `benign_notices_enabled` (#25): the warning is benign noise to a
+    # pipeline — emit it only when a human is plausibly watching stderr.
+    from mondo.cli._notices import benign_notices_enabled
+
+    if not os.environ.get("PYTEST_CURRENT_TEST") and benign_notices_enabled(
+        verbose=verbose
+    ):
         warn_if_skill_outdated()
     ctx.obj = GlobalOpts(
         profile_name=profile,
@@ -419,6 +425,7 @@ def main() -> None:
             emit_envelope,
             error_envelope,
             is_machine_output_argv,
+            mirror_envelope_to_stdout,
             suggest_for_no_such_option,
         )
 
@@ -427,9 +434,12 @@ def main() -> None:
         # see the same shape regardless of which error source fired.
         e.show()
         if is_machine_output_argv(args):
-            emit_envelope(
-                error_envelope(e, suggestion=suggest_for_no_such_option(e))
-            )
+            envelope = error_envelope(e, suggestion=suggest_for_no_such_option(e))
+            emit_envelope(envelope)
+            # Parsing failed before any command ran, so stdout is
+            # guaranteed empty; `-o none` never reaches this branch
+            # (classified as human output by is_machine_output_argv).
+            mirror_envelope_to_stdout(None, envelope)
         sys.exit(e.exit_code or 2)
     except click.exceptions.Abort:
         click.echo("Aborted!", err=True)

--- a/src/mondo/help/agent-tips.md
+++ b/src/mondo/help/agent-tips.md
@@ -79,13 +79,16 @@ shorter than the equivalent `-q '[].{id:id,name:name,status:status}'`.
 
 ## Cache provenance
 
-Read commands that hit the local directory cache emit one stderr
+Read commands that hit the local directory cache can emit one stderr
 line so you can tell cached results from live ones:
 
     cache: hit (entity=boards, age=2m, count=143)
 
-Suppress with `MONDO_NO_CACHE_NOTICE=1`. The line is also auto-
-suppressed in `-o table` mode (TTY humans don't usually want it).
+Since #25 the line is suppressed by default when stderr is not a TTY
+(the typical agent context) — re-enable it with `--verbose` or
+`MONDO_VERBOSE=1`. On a TTY, suppress it with `MONDO_NO_CACHE_NOTICE=1`;
+it is also auto-suppressed in `-o table` mode (TTY humans don't usually
+want it).
 
 For verbose detail (cache path, ttl, exact fetched-at), pass
 `--explain-cache` on the read command:

--- a/src/mondo/help/output.md
+++ b/src/mondo/help/output.md
@@ -60,6 +60,30 @@ just want a smaller dict per row.
 - `tsv` / `csv` — flattens nested records using dotted paths. Header row first.
 - `none` — prints the raw scalar when `--query` collapses the payload to one.
 
+## Errors and stderr
+
+Errors stay on **stderr**: a human-readable `error:` line plus, in machine
+output mode (`-o json|jsonc|yaml`, or no `-o` with a non-TTY stdout), a
+one-line JSON envelope `{"error", "code", "exit_code", "request_id",
+"retry_in_seconds", "suggestion"}`.
+
+Two behaviors keep failures visible in pipelines:
+
+- **Fatal errors mirror the JSON envelope to stdout** in machine mode when
+  the command dies before writing anything to stdout. A pipeline that
+  suppressed stderr still receives a parseable `{"error": ..., "exit_code": N}`
+  instead of empty input. The mirror never corrupts a partial-success
+  stream (it only fires when stdout is still empty), `-o none` keeps
+  stdout silent, and exit codes are unchanged.
+- **Benign notices are suppressed when no human is watching**: the
+  `cache: hit (...)` provenance line and the skill-freshness warning only
+  appear when stderr is a TTY (or with `--verbose` / `MONDO_VERBOSE=1`;
+  `--explain-cache` always wins). Non-interactive runs get a clean stderr
+  that carries errors only.
+
+Don't `2>/dev/null` a mondo call — errors and recovery hints live on
+stderr. Use `2>&1` or leave stderr attached; branch on the exit code.
+
 ## Global flags are position-free
 
 az/gh/gam-style: global flags work anywhere on the command line.

--- a/src/mondo/help/output.md
+++ b/src/mondo/help/output.md
@@ -62,10 +62,12 @@ just want a smaller dict per row.
 
 ## Errors and stderr
 
-Errors stay on **stderr**: a human-readable `error:` line plus, in machine
-output mode (`-o json|jsonc|yaml`, or no `-o` with a non-TTY stdout), a
-one-line JSON envelope `{"error", "code", "exit_code", "request_id",
-"retry_in_seconds", "suggestion"}`.
+Errors stay on **stderr**: a human-readable `error:` line plus, for most
+errors — those raised through the shared error path — in machine output
+mode (`-o json|jsonc|yaml`, or no `-o` with a non-TTY stdout), a one-line
+JSON envelope `{"error", "code", "exit_code", "request_id",
+"retry_in_seconds", "suggestion"}`. A minority of ad-hoc usage errors
+still emit only the human-readable line.
 
 Two behaviors keep failures visible in pipelines:
 
@@ -74,7 +76,10 @@ Two behaviors keep failures visible in pipelines:
   suppressed stderr still receives a parseable `{"error": ..., "exit_code": N}`
   instead of empty input. The mirror never corrupts a partial-success
   stream (it only fires when stdout is still empty), `-o none` keeps
-  stdout silent, and exit codes are unchanged.
+  stdout silent, and exit codes are unchanged. Note this applies even to
+  commands whose success output is not JSON (e.g. `doc export-markdown`
+  redirected to a file): if they fail before producing output, the JSON
+  envelope lands on stdout.
 - **Benign notices are suppressed when no human is watching**: the
   `cache: hit (...)` provenance line and the skill-freshness warning only
   appear when stderr is a TTY (or with `--verbose` / `MONDO_VERBOSE=1`;

--- a/tests/unit/test_cache_provenance.py
+++ b/tests/unit/test_cache_provenance.py
@@ -44,6 +44,13 @@ class TestFormatAge:
 
 
 class TestEmitCacheProvenance:
+    @pytest.fixture(autouse=True)
+    def _human_watching(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Captured stderr is not a TTY, which would suppress the notice
+        # under the #25 gating. Force notices on; the gating itself is
+        # covered by TestBenignNoticeGating below.
+        monkeypatch.setenv("MONDO_VERBOSE", "1")
+
     def test_emits_when_from_cache(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -133,6 +140,54 @@ class TestEmitCacheProvenance:
         emit_cache_provenance(_opts(), _cached(from_cache=True, age_seconds=120))
         captured = capsys.readouterr()
         assert "age=2m" in captured.err
+
+
+class TestBenignNoticeGating:
+    """#25: cache notices are benign noise to a pipeline — suppressed when no
+    human is plausibly watching stderr, unless --verbose / MONDO_VERBOSE=1
+    (or --explain-cache, an explicit request)."""
+
+    @pytest.fixture(autouse=True)
+    def _non_tty_stderr(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stderr.isatty", lambda: False)
+        monkeypatch.delenv("MONDO_VERBOSE", raising=False)
+
+    def test_suppressed_when_stderr_not_a_tty(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        emit_cache_provenance(_opts(), _cached(from_cache=True))
+        assert capsys.readouterr().err == ""
+
+    def test_mondo_verbose_env_restores_notice(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("MONDO_VERBOSE", "1")
+        emit_cache_provenance(_opts(), _cached(from_cache=True))
+        assert "cache: hit" in capsys.readouterr().err
+
+    def test_verbose_flag_restores_notice(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        opts = _opts()
+        opts.verbose = True
+        emit_cache_provenance(opts, _cached(from_cache=True))
+        assert "cache: hit" in capsys.readouterr().err
+
+    def test_explain_overrides_non_tty(
+        self, capsys: pytest.CaptureFixture[str], tmp_path: Path
+    ) -> None:
+        store = CacheStore(
+            entity_type="boards",
+            cache_dir=tmp_path,
+            api_endpoint="https://api.monday.com/v2",
+            ttl_seconds=900,
+        )
+        emit_cache_provenance(
+            _opts(), _cached(from_cache=True), store=store, explain=True
+        )
+        assert "cache: hit" in capsys.readouterr().err
 
 
 class TestCacheStoreReadSetsFromCache:

--- a/tests/unit/test_cli_error_visibility.py
+++ b/tests/unit/test_cli_error_visibility.py
@@ -73,6 +73,34 @@ class TestBenignNoticesEnabled:
         assert benign_notices_enabled(verbose=True) is True
 
 
+class TestMondoVerboseEnvVar:
+    """`MONDO_VERBOSE=1` is wired onto the root `--verbose` option via
+    `envvar`, so it enables verbose logging — not just the benign-notice
+    gate in `_notices.py`."""
+
+    def _seen_verbose(self, monkeypatch: pytest.MonkeyPatch) -> bool:
+        import mondo.logging_ as logging_
+
+        seen: dict = {}
+        monkeypatch.setattr(
+            logging_,
+            "configure_logging",
+            lambda **kw: seen.update(kw),
+        )
+        result = runner.invoke(app, ["help", "output"])
+        assert result.exit_code == 0
+        return seen["verbose"]
+
+    def test_env_var_enables_verbose(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MONDO_VERBOSE", "1")
+        assert self._seen_verbose(monkeypatch) is True
+
+    def test_unset_env_var_keeps_verbose_off(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        assert self._seen_verbose(monkeypatch) is False
+
+
 class TestMondoErrorStdoutMirror:
     def test_machine_mode_mirrors_envelope_to_stdout(
         self, httpx_mock: HTTPXMock

--- a/tests/unit/test_cli_error_visibility.py
+++ b/tests/unit/test_cli_error_visibility.py
@@ -1,0 +1,195 @@
+"""Error visibility when stderr is suppressed (#25).
+
+Two measures:
+- benign stderr notices are gated on a human plausibly watching
+  (`_notices.benign_notices_enabled`);
+- fatal errors in machine mode mirror the JSON envelope to stdout when
+  nothing has been written there yet, so `2>/dev/null` pipelines receive
+  a parseable failure instead of empty input. Exit codes unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from mondo.cli._notices import benign_notices_enabled
+from mondo.cli.main import app
+
+ENDPOINT = "https://api.monday.com/v2"
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("MONDO_PROFILE", raising=False)
+    monkeypatch.delenv("MONDAY_API_VERSION", raising=False)
+    monkeypatch.delenv("MONDO_VERBOSE", raising=False)
+    monkeypatch.setenv("MONDO_CONFIG", str(tmp_path / "nope.yaml"))
+    monkeypatch.setenv("MONDAY_API_TOKEN", "env-token-abcdef-long-enough")
+    monkeypatch.setenv("MONDO_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("MONDO_CACHE_ENABLED", "false")
+
+
+def _graphql_error() -> dict:
+    return {
+        "errors": [
+            {
+                "message": "Resource not found",
+                "extensions": {"code": "ResourceNotFoundException", "request_id": "rq1"},
+            }
+        ]
+    }
+
+
+def _stdout_envelope(stdout: str) -> dict:
+    lines = [ln for ln in stdout.strip().splitlines() if ln.strip()]
+    assert lines, "expected an envelope on stdout, got nothing"
+    return json.loads(lines[-1])
+
+
+class TestBenignNoticesEnabled:
+    def test_tty_stderr_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+        assert benign_notices_enabled() is True
+
+    def test_non_tty_stderr_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stderr.isatty", lambda: False)
+        assert benign_notices_enabled() is False
+
+    def test_env_var_overrides_non_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stderr.isatty", lambda: False)
+        monkeypatch.setenv("MONDO_VERBOSE", "1")
+        assert benign_notices_enabled() is True
+
+    def test_verbose_flag_overrides_non_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("sys.stderr.isatty", lambda: False)
+        assert benign_notices_enabled(verbose=True) is True
+
+
+class TestMondoErrorStdoutMirror:
+    def test_machine_mode_mirrors_envelope_to_stdout(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_graphql_error())
+        result = runner.invoke(app, ["-o", "json", "item", "get", "--id", "1"])
+        assert result.exit_code == 6
+        env = _stdout_envelope(result.stdout)
+        assert env["error"].startswith("Resource not found")
+        assert env["exit_code"] == 6
+        assert env["code"] == "ResourceNotFoundException"
+        # The stderr envelope is unchanged — same payload there.
+        assert "Resource not found" in result.stderr
+
+    def test_output_none_keeps_stdout_silent(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_graphql_error())
+        result = runner.invoke(app, ["-o", "none", "item", "get", "--id", "1"])
+        assert result.exit_code == 6
+        assert result.stdout.strip() == ""
+
+    def test_human_mode_no_mirror(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_graphql_error())
+        result = runner.invoke(app, ["-o", "table", "item", "get", "--id", "1"])
+        assert result.exit_code == 6
+        assert result.stdout.strip() == ""
+
+    def test_mirror_skipped_once_stdout_written(self) -> None:
+        from mondo.cli._errors import mirror_envelope_to_stdout
+        from mondo.cli.context import GlobalOpts
+
+        opts = GlobalOpts(
+            profile_name=None,
+            flag_token=None,
+            flag_api_version=None,
+            verbose=False,
+            debug=False,
+            output="json",
+        )
+        opts.stdout_emitted = True
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            mirror_envelope_to_stdout(opts, {"error": "x", "exit_code": 5})
+        assert buf.getvalue() == ""
+
+
+class TestUsageErrorStdoutMirror:
+    def test_graphql_query_via_q_hint_lands_on_stdout(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        result = runner.invoke(
+            app, ["-o", "json", "-q", "query { me { id } }", "graphql"]
+        )
+        assert result.exit_code == 2
+        env = _stdout_envelope(result.stdout)
+        assert env["exit_code"] == 2
+        assert "passed to `-q`" in env["error"]
+        assert httpx_mock.get_requests() == []
+
+    def test_graphql_dry_run_refusal_lands_on_stdout(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        result = runner.invoke(
+            app, ["-o", "json", "--dry-run", "graphql", "query { me { id } }"]
+        )
+        assert result.exit_code == 2
+        env = _stdout_envelope(result.stdout)
+        assert "--dry-run is not supported" in env["error"]
+        assert httpx_mock.get_requests() == []
+
+    def test_human_mode_keeps_stdout_empty(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app, ["-o", "table", "-q", "query { me { id } }", "graphql"]
+        )
+        assert result.exit_code == 2
+        assert result.stdout.strip() == ""
+
+
+class TestMainUsageErrorMirror:
+    """Click parse failures route through `main()`'s wrapper (CliRunner uses
+    standalone mode and bypasses it) — drive `main()` via argv directly."""
+
+    def test_no_such_option_mirrors_envelope_to_stdout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from mondo.cli.main import main
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["mondo", "-o", "json", "board", "get", "--definitely-not-a-flag"],
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+        assert excinfo.value.code == 2
+        out = capsys.readouterr().out
+        env = _stdout_envelope(out)
+        assert env["code"] == "NoSuchOption"
+        assert env["exit_code"] == 2
+
+    def test_output_none_keeps_stdout_silent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from mondo.cli.main import main
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["mondo", "-o", "none", "board", "get", "--definitely-not-a-flag"],
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+        assert excinfo.value.code == 2
+        assert capsys.readouterr().out.strip() == ""


### PR DESCRIPTION
Closes #25.

## What

Session logs since v0.9.0: **31% of agent invocations append `2>/dev/null`**, and 10 of 33 hard errors were completely invisible (empty stdout + nonzero exit). This implements measures (1) and (2) from the issue; measure (3) — the skill/agent-tips norm — lands with the #23 norms batch PR to avoid SKILL.md conflicts.

### 1. Benign notices gated on a human plausibly watching

New `_notices.benign_notices_enabled()`: the `cache: hit (…)` provenance line and the skill-freshness warning now only appear when **stderr is a TTY**, or with `--verbose` / `MONDO_VERBOSE=1`. `--explain-cache` always wins; `MONDO_NO_CACHE_NOTICE=1` still force-silences. Non-interactive runs get a clean stderr that carries errors only — removing the incentive to `2>/dev/null`.

### 2. Fatal errors mirror the JSON envelope to stdout (machine mode)

Adopted the issue's measure (2) with the prescribed care:

- only when **nothing has been written to stdout yet** (`GlobalOpts.stdout_emitted` flag set by `emit()`) — a partial-success stream is never corrupted;
- `-o none` keeps stdout silent;
- exit codes unchanged;
- the stderr envelope is unchanged (mirror is additive).

Wired into: the central `MondoError` path (`_exec._emit_error`), the top-level Click `UsageError` handler in `main()`, and a new `usage_error_or_exit()` helper — used by `mondo graphql`'s three ad-hoc usage errors, including the `-q` recovery hint that was one of the observed invisible failures.

**Known limitation** (noted, not in issue scope): ad-hoc `not found` messages that exit 6 without raising `MondoError` (e.g. `item get` on a missing id) remain stderr-only. `usage_error_or_exit()` is the migration path for those sites.

## Acceptance criteria from #25

- ✅ Non-TTY runs emit no benign stderr noise by default; errors remain on stderr
- ✅ `mondo <bad usage> 2>/dev/null | cat` yields the error envelope on stdout; exit codes unchanged; documented in `mondo help output`
- ✅ Skill/agent-tips norm: delivered via the #23 norms PR (cross-referenced)

## Live verification (real pipes, real API)

- `mondo graphql -q 'query {…}' -o json 2>/dev/null | cat` → `{"error":"your GraphQL query was passed to \`-q\`…","code":"UsageError","exit_code":2}` on stdout
- server-side GraphQL error with `2>/dev/null` → envelope on stdout, exit 1
- `-o none` → stdout stays empty
- non-TTY stderr: no skill warning, no cache notice; `MONDO_VERBOSE=1` restores `cache: hit (entity=boards, age=1h, count=5966)`

## Tests

15 new tests in `tests/unit/test_cli_error_visibility.py` (gating unit tests, MondoError mirror, `-o none`/human-mode negatives, stdout-written guard, graphql usage-error mirror, `main()`-level Click UsageError mirror) + 4 new gating tests in `test_cache_provenance.py`. Existing provenance tests updated for the gate. Full suite: 1426 passed; ruff clean on changed files.