### PR TITLE
chore(skill): add mondo-usage-audit maintainer skill

### DIFF
--- a/.claude/skills/mondo-usage-audit/SKILL.md
+++ b/.claude/skills/mondo-usage-audit/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: mondo-usage-audit
+description: >-
+  Audit how the `mondo` CLI and the `mondo` skill are actually being used by
+  analysing local Claude Code session logs since the last release — surfacing
+  errors, stumbling blocks, cold (skill-not-loaded) sessions, discoverability
+  gaps, zero-use features, latency hot-spots, and concrete skill/CLI
+  improvements. Use this whenever you want to check mondo's real-world agent
+  usage: "audit mondo usage", "how are agents using mondo", "what friction is
+  mondo hitting", "analyse my session logs for mondo problems", "what should I
+  improve in the mondo skill or CLI", "do the mondo usage review again", or as
+  a routine post-release health check. Run it from the Mondo repo.
+---
+
+# Mondo usage audit
+
+You are auditing **how agents actually use mondo in the wild** by mining the
+user's local Claude Code transcripts (`~/.claude/projects/*/*.jsonl`). The goal
+is to make the `mondo` CLI and the `mondo` skill as easy to use as possible —
+for agents first (that's all these logs show) and humans by extension.
+
+The deliverable is a **prioritised report**: what's breaking, what's confusing,
+what's slow, what's never discovered, and the cheapest changes that would fix
+the most friction. Then offer to act on it.
+
+## Why this is mostly a reading-and-judgement task
+
+A bundled script does the mechanical part — finding every mondo invocation,
+matching results, timing calls, counting patterns. **That's the easy 20%.** The
+value is in the 80% the script can't do: tracing a recurring error to its real
+cause, telling a genuine CLI gap from an agent's shell bug, and ranking fixes by
+leverage. The single biggest finding of the original audit was *not in mondo at
+all* — it was a stale cheat sheet in a project's `CLAUDE.md` teaching wrong flag
+syntax. Keep that in mind: **friction surfaces in the logs; its cause is often
+upstream of the CLI.**
+
+One hard limit, state it in the report: these logs show **agent** usage only.
+There is no interactive-human signal here, so "easy for humans" can only be
+inferred, not measured.
+
+## Workflow
+
+### 1. Run the scanner
+
+From the Mondo repo root (so it can auto-detect the last release tag):
+
+```bash
+python3 .claude/skills/mondo-usage-audit/scripts/scan_mondo_usage.py
+```
+
+By default it scans every transcript modified since the newest `vX.Y.Z` tag's
+commit date. Right after a release that window is tiny — for a meaningful audit,
+widen it to the *previous* release or a fixed date:
+
+```bash
+# wider window — last ~2 weeks regardless of tags
+python3 .claude/skills/mondo-usage-audit/scripts/scan_mondo_usage.py \
+    --since 2026-05-31T00:00:00+00:00
+```
+
+The script prints a full summary and writes the complete record set to
+`/tmp/mondo_usage.json` for drill-down. Read the whole summary before forming
+any conclusions — the sections are designed to be read top to bottom.
+
+By default it **excludes the Mondo repo's own transcripts** — those are full of
+commit messages, `gh issue` bodies and benchmark scripts that mention `mondo`
+but aren't real consumer usage. You're auditing how *other* projects use mondo.
+Pass `--include-self` only if you specifically want the dev sessions too.
+
+### 2. Read the scanner output — what each section is telling you
+
+- **SCOPE** — headline counts. The ratio that matters most: *sessions using
+  mondo* vs *skill-loaded*. A high **cold** count means agents drive the CLI
+  without loading the skill — almost all flag-guessing and graphql escapes come
+  from cold sessions. Note the success rate and the stderr-suppression %.
+- **SUBCOMMAND FREQUENCY** — what agents reach for. The long tail and the
+  *absent* commands are as informative as the top.
+- **PER-SESSION CONTEXT** — `COLD`/`REFS`/`SKILL` per session, plus `JOB` for
+  headless/cron runs and the first user message. Use this to find *which kinds
+  of sessions* (which slash commands, which projects) run cold. That's where
+  the root cause usually lives.
+- **ERRORS** — every failed invocation with its command and result. Read them
+  all. Classify each (see step 4) — do not assume an error is mondo's fault.
+- **RAW GRAPHQL ESCAPES** — every `mondo graphql` call. Each one is a signal:
+  either a real capability gap, or a discoverability miss (the CLI already does
+  it and the agent didn't know). Decide which for each cluster.
+- **FRICTION SIGNALS** — `graphql --query` misuse (query is positional;
+  `-q/--query` is the global JMESPath filter), redundant `-o json`,
+  `--no-cache`, errors hidden by `2>/dev/null`, retry-after-error pairs.
+- **FEATURE-USAGE PROBES** — recently-shipped sugar. Near-zero here means a
+  *discoverability* gap, not a capability gap. Don't propose building things
+  that already exist and aren't being found.
+- **PERFORMANCE** — latency percentiles and per-subcommand medians over
+  *attributable single-call* invocations (multi-command bash blocks and
+  idle/approval gaps are excluded so the numbers reflect mondo, not the shell).
+  The per-subcommand median table is the trustworthy view; the slowest list
+  shows the worst genuine single calls.
+
+### 3. Drill into anything that needs context
+
+The summary counts; `/tmp/mondo_usage.json` has the full commands and result
+text. Examples:
+
+```bash
+# every command + result snippet for a specific error pattern
+jq -r '.invocations[] | select(.command|test("graphql --query")) | .command' /tmp/mondo_usage.json
+# the project an error came from, to go read that project's CLAUDE.md / slash command
+jq -r '.invocations[] | select(.error) | .file' /tmp/mondo_usage.json | sort -u
+```
+
+### 4. Trace root causes — do NOT stop at "the CLI errored"
+
+For each recurring error or escape, ask **where the agent got the wrong idea**:
+
+- **Stale cheat sheets.** Read the `CLAUDE.md` of the projects that generated
+  the errors (the `file` field points at the transcript; its `cwd`/first user
+  message tells you the project). A `CLAUDE.md` "Key Commands" block teaching
+  `--board-id` / `mondo graphql --query` / `item rename <id> "name"` will
+  poison every agent in that project regardless of how good the CLI is. This was
+  the #1 finding last time. Fixing it costs nothing in the mondo repo.
+- **Slash commands / workflow skills that skip the mondo skill.** If cold
+  sessions cluster around specific commands (e.g. `/ticket-triage`), read those
+  command definitions — they likely write mondo commands from memory instead of
+  invoking the skill. The fix is "invoke the mondo skill first", not new CLI.
+- **Skill drift.** Compare the *installed* skill with the repo source — if they
+  disagree, agents are running stale guidance:
+  ```bash
+  diff -ru ~/.claude/skills/mondo src/mondo/skill 2>/dev/null
+  ```
+- **Genuine CLI/skill gaps.** Only after ruling out the above: a real missing
+  flag, a dead-end error message, a feature that should exist (e.g. last time:
+  `board create --with-url`, a `name`-column error that should point at
+  `item rename`, `file url --asset` to print a `public_url` without
+  downloading).
+
+Classify every error into one of: **real mondo issue**, **agent shell bug**
+(zsh `declare -A`, broken f-string quoting — not mondo's fault), **permission-
+classifier denial** (Claude Code blocked an unrequested write — behavioural,
+maybe a skill operating-norm note), or **monday-server variance** (500s,
+cold-cache slowness — not actionable in mondo). Report the breakdown honestly;
+inflating the mondo bug count helps no one.
+
+### 5. Cross-reference open issues before recommending anything
+
+Avoid filing duplicates and acknowledge work already in flight:
+
+```bash
+gh issue list --repo zoltanf/mondo --state open --limit 50
+gh pr list --repo zoltanf/mondo --state open --limit 30
+```
+
+Map each finding to: already-fixed, has-an-open-issue/PR, or net-new.
+
+### 6. Performance pass — verify hot-spots with read-only live benchmarks
+
+The latency table tells you *where* time goes; a quick live benchmark tells you
+*why*, and what a fix would buy. **Read-only only** — `list`/`get` against the
+playground/test board from `.env`, never mutations. Useful probes the original
+audit used to decompose the `item list` cost and the cold-directory tail:
+
+```bash
+TOKEN=$(grep ^MONDAY_API_TOKEN= .env | cut -d= -f2-)
+# full column_values vs slim — quantifies the per-page tax on item list
+MONDAY_API_TOKEN=$TOKEN /usr/bin/time -p mondo item list --board <big_board> -o json >/dev/null
+MONDAY_API_TOKEN=$TOKEN /usr/bin/time -p mondo item list --board <big_board> --fields id,name -o json >/dev/null
+# warm cache vs cold (cold ≈ first lookup of the workday)
+MONDAY_API_TOKEN=$TOKEN /usr/bin/time -p mondo board list >/dev/null
+MONDAY_API_TOKEN=$TOKEN /usr/bin/time -p mondo board list --no-cache >/dev/null
+```
+
+Note that monday's own server time is highly variable (identical queries have
+been seen at 118s cold / 21s warm) — run a couple of times and report ranges,
+not single numbers. Attribute slowness correctly: mondo overhead vs payload
+shape vs monday server vs cold cache.
+
+### 7. Write the report
+
+Use the structure below. Lead with the highest-leverage finding (often *not* a
+mondo code change). Every recommendation needs evidence from the logs (a count,
+a date, an observed failure) and a rough leverage estimate. Separate what's
+working from what's broken — confirming the good parts (e.g. "did you mean"
+suggestions self-correcting flag errors) is part of the picture.
+
+```markdown
+# Mondo usage analysis — <window> (<N> days)
+
+**Scope:** <N> transcripts scanned, <N> sessions used mondo, <N> CLI
+invocations, <N> errors (<X>% success), <N> skill invocations,
+<N> --help lookups, <N> raw graphql escapes.
+
+## Headline finding
+<the single highest-leverage thing — name it and quantify the damage>
+
+## Stumbling blocks observed in the wild
+<table or list: pattern | what's wrong | observed damage (count + dates)>
+
+## What's working well
+<the safeguards that earned their keep — keep these, don't regress them>
+
+## Discoverability / zero-use features
+<shipped capability nobody found; the fix is exposure, not building>
+
+## Not a mondo problem (for completeness)
+<agent shell bugs, permission denials, monday-server variance — counted and set aside>
+
+## Recommendations, ranked by leverage
+1. <often: fix a project CLAUDE.md / slash command — zero cost in the repo>
+2. <skill change: canonical-flags table, operating norms>
+3. <CLI change: the real gaps, each as its own issue>
+
+## Performance
+<latency hot-spots, what the live benchmark showed, ranked changes>
+
+> Caveat: logs show agent usage only — no interactive-human signal.
+```
+
+### 8. Offer to act
+
+End by offering concrete follow-ups, not a vague "want me to help?":
+
+- Fix the stale cheat sheets / slash commands directly (verify each flag against
+  the current source before editing — the whole point is to stop teaching wrong
+  syntax).
+- Add a "canonical flags / common mistakes" table or operating norms to the
+  mondo skill (`src/mondo/skill/`), and keep the installed copy in sync.
+- File the net-new CLI findings as focused GitHub issues on `zoltanf/mondo`
+  (one per independent change, matching the repo's issue style).
+
+## Scanner reference
+
+`scripts/scan_mondo_usage.py` flags:
+
+- `--since <ISO>` — cutoff override (e.g. `2026-05-31T00:00:00+00:00`). Default:
+  newest `vX.Y.Z` tag's commit date.
+- `--repo <path>` — Mondo repo for tag auto-detect (default: cwd).
+- `--root <path>` — logs root (default: `~/.claude/projects`).
+- `--json-out <path>` — full record set (default: `/tmp/mondo_usage.json`).
+- `--top <n>` — subcommands to list (default: 40).
+- `--include-self` — keep the Mondo repo's own dev transcripts (excluded by
+  default; they're commit/benchmark noise, not consumer usage).
+
+When new mondo features ship, add them to `FEATURE_PROBES` in the script so the
+discoverability check keeps measuring the current surface.

--- a/.claude/skills/mondo-usage-audit/scripts/scan_mondo_usage.py
+++ b/.claude/skills/mondo-usage-audit/scripts/scan_mondo_usage.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Scan local Claude Code session logs for `mondo` CLI + skill usage.
+
+Finds every `mondo` bash invocation and every `mondo` *skill* invocation across
+the user's session transcripts since a cutoff (default: the commit date of the
+most recent `vX.Y.Z` git tag in the Mondo repo), captures each command's
+result / error / latency / payload size, and prints an aggregated summary for
+usability + performance analysis. The full record set is also written to JSON
+so the agent can drill into anything the summary only counts.
+
+This consolidates the four ad-hoc scripts the original audit session wrote to
+/tmp. The numbers it prints are the raw material; the narrative judgement
+(root causes, what to fix, what to ignore) is the agent's job — see SKILL.md.
+
+Usage:
+    python3 scan_mondo_usage.py                 # since latest vX.Y.Z tag
+    python3 scan_mondo_usage.py --since 2026-05-31T17:23:00+00:00
+    python3 scan_mondo_usage.py --repo /path/to/Mondo --top 60
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# A `mondo` invocation at a command boundary (start of line, after ; & | or `(`).
+# Avoids matching e.g. "salmondo" or a path containing the substring.
+MONDO_CMD_RE = re.compile(r"(?:^|[\s;&|(])mondo\s+", re.M)
+
+# Recently-shipped sugar worth a usage probe — near-zero counts here mean a
+# discoverability gap (the feature exists but agents don't reach for it), not a
+# capability gap. Extend this list as new features ship.
+FEATURE_PROBES = [
+    "--batch", "item find", "--poll-until", "--max-items", "--columns",
+    "--fields", "column get-meta", "column labels", "mondo export",
+    "mondo import", "file upload", "file download", "file url",
+]
+
+
+def strip_noise(cmd):
+    """Blank out heredoc bodies and quoted strings before looking for `mondo`.
+
+    Without this, a `mondo` mentioned inside a `git commit -m "...mondo..."`
+    message, an `echo "run mondo ..."`, or a `gh issue create --body "$(cat
+    <<'EOF' ... mondo ... EOF)"` heredoc gets counted as a real invocation —
+    which badly pollutes the frequency table when scanning the Mondo repo's own
+    dev sessions. We only count `mondo` that survives in executable position.
+    """
+    # heredoc bodies: <<['"]?MARKER ... <newline>MARKER
+    cmd = re.sub(r"<<-?\s*(['\"]?)(\w+)\1.*?^\s*\2\b", " ", cmd, flags=re.S | re.M)
+    # simple quoted strings (our inputs don't nest escaped quotes meaningfully)
+    cmd = re.sub(r"'[^']*'", " ", cmd)
+    cmd = re.sub(r'"[^"]*"', " ", cmd)
+    return cmd
+
+
+def parse_ts(s):
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def resolve_cutoff(args):
+    """Return (cutoff_datetime, label). Prefer --since; else newest git tag."""
+    if args.since:
+        dt = parse_ts(args.since)
+        if not dt:
+            sys.exit(f"--since not an ISO timestamp: {args.since!r}")
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt, f"--since {args.since}"
+
+    def git(*a):
+        return subprocess.run(
+            ["git", "-C", args.repo, *a],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+    try:
+        tag = git("tag", "--list", "v*", "--sort=-creatordate").splitlines()[0]
+        iso = git("log", "-1", "--format=%aI", tag)
+    except (subprocess.CalledProcessError, IndexError, FileNotFoundError):
+        sys.exit(
+            "Could not auto-detect the last release tag. Run from the Mondo "
+            "repo, pass --repo /path/to/Mondo, or pass --since <ISO timestamp>."
+        )
+    dt = parse_ts(iso)
+    return dt, f"{tag} ({iso})"
+
+
+def _verb(tok):
+    """Does `tok` look like a real `mondo` group/verb, vs a redirection
+    (`2>&1`), a value (`id,title,type`), or a path the noise stripper missed?"""
+    return bool(tok and not tok.startswith(("-", "'", '"', "$"))
+                and not tok[0].isdigit() and not re.search(r"[<>/,|]", tok))
+
+
+def subcmd(cmd):
+    """Best-effort `mondo <group> <verb>` extraction for frequency counting."""
+    cmd = strip_noise(cmd)
+    m = re.search(r"(?:^|[\s;&|(])mondo\s+(--?\S+\s+)*(\S+)(?:\s+(\S+))?", cmd)
+    if not m:
+        return "?"
+    first, second = m.group(2), m.group(3) or ""
+    if first in ("--help", "-h"):
+        return "--help"
+    if not _verb(first):
+        return "?"  # bare `mondo` or an unparseable artifact
+    return f"{first} {second}" if _verb(second) else first
+
+
+def scan(cutoff, root, repo, include_self):
+    """Single pass over every transcript newer than the cutoff.
+
+    Returns (invocations, skill_invocations, sessions, n_files, n_excluded).
+    `sessions` maps a transcript path to its context flags (skill-loaded / read
+    refs / headless / first user message). Unless `include_self`, the Mondo
+    repo's own project transcripts are skipped — they're full of commit
+    messages, `gh issue` bodies and benchmark scripts that mention `mondo` but
+    aren't consumer usage. Claude Code names a project dir after its cwd with
+    `/` turned into `-`, so the repo at /a/b/Mondo lives in `-a-b-Mondo`.
+    """
+    self_slug = os.path.abspath(repo).replace("/", "-") if repo else None
+
+    files, n_excluded = [], 0
+    for f in glob.glob(os.path.join(root, "*", "*.jsonl")):
+        if not include_self and self_slug and os.path.basename(os.path.dirname(f)) == self_slug:
+            n_excluded += 1
+            continue
+        try:
+            mt = datetime.fromtimestamp(os.path.getmtime(f), tz=timezone.utc)
+        except OSError:
+            continue
+        if mt >= cutoff:
+            files.append(f)
+
+    invocations, skill_invocations = [], []
+    sessions = {}
+
+    for path in files:
+        pending = {}  # tool_use_id -> invocation dict awaiting its result
+        ctx = {"skill_loaded": False, "read_refs": 0, "headless": False,
+               "first_user": "", "n_inv": 0, "n_help": 0}
+        sessions[path] = ctx
+        try:
+            fh = open(path, encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        with fh:
+            for line in fh:
+                if "CLAUDE_JOB_DIR" in line or '"source":"cron"' in line:
+                    ctx["headless"] = True
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                ts = parse_ts(rec.get("timestamp", ""))
+                msg = rec.get("message") or {}
+                content = msg.get("content")
+
+                if (rec.get("type") == "user" and isinstance(content, str)
+                        and not ctx["first_user"]):
+                    ctx["first_user"] = content[:100].replace("\n", " ")
+
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    bt = block.get("type")
+                    if bt == "tool_use":
+                        name = block.get("name", "")
+                        inp = block.get("input") or {}
+                        if name == "Bash":
+                            cmd = inp.get("command", "")
+                            clean = strip_noise(cmd)
+                            if MONDO_CMD_RE.search(clean):
+                                inv = {"file": path, "ts": ts, "command": cmd,
+                                       "error": None, "result": "", "dur": None,
+                                       "rsize": 0}
+                                invocations.append(inv)
+                                pending[block.get("id")] = inv
+                                ctx["n_inv"] += 1
+                                if "--help" in clean or re.search(r"\s-h\b", clean):
+                                    ctx["n_help"] += 1
+                        elif name == "Skill":
+                            if "mondo" in inp.get("skill", ""):
+                                ctx["skill_loaded"] = True
+                                skill_invocations.append(
+                                    {"file": path, "ts": rec.get("timestamp", ""),
+                                     "skill": inp.get("skill", ""),
+                                     "args": inp.get("args", "")})
+                        elif name == "Read":
+                            if "skills/mondo" in str(inp.get("file_path", "")):
+                                ctx["read_refs"] += 1
+                    elif bt == "tool_result":
+                        inv = pending.pop(block.get("tool_use_id"), None)
+                        if inv is None:
+                            continue
+                        inv["error"] = bool(block.get("is_error"))
+                        c = block.get("content")
+                        if isinstance(c, list):
+                            txt = "\n".join(b.get("text", "") for b in c
+                                            if isinstance(b, dict))
+                        else:
+                            txt = str(c) if c else ""
+                        inv["rsize"] = len(txt)
+                        inv["result"] = txt[:3000]
+                        if ts and inv["ts"]:
+                            inv["dur"] = (ts - inv["ts"]).total_seconds()
+
+    return invocations, skill_invocations, sessions, len(files), n_excluded
+
+
+def proj(path):
+    return path.split("/")[-2].replace("-Users-zoltanf-Development-", "")[:34]
+
+
+def hr(title):
+    print(f"\n{'=' * 4} {title} {'=' * (66 - len(title))}")
+
+
+def report(invs, skills, sessions, n_files, n_excluded, label, top, json_out):
+    n_err = sum(1 for i in invs if i["error"])
+    bash_files = {i["file"] for i in invs}
+    skill_sessions = {s["file"] for s in skills}
+    helps = [i for i in invs if "--help" in i["command"] or re.search(r"\s-h\b", i["command"])]
+    gql = [i for i in invs if re.search(r"mondo\s+graphql", strip_noise(i["command"]))]
+    devnull = [i for i in invs if "2>/dev/null" in i["command"]]
+    cold = bash_files - skill_sessions
+
+    hr("SCOPE")
+    print(f"cutoff:                 {label}")
+    print(f"transcripts scanned:    {n_files}"
+          + (f"  ({n_excluded} Mondo-repo dev transcripts excluded; --include-self to keep)"
+             if n_excluded else ""))
+    print(f"sessions using mondo:    {len(bash_files)}  "
+          f"(skill-loaded: {len(bash_files & skill_sessions)}, cold: {len(cold)})")
+    print(f"mondo CLI invocations:   {len(invs)}")
+    print(f"  errored:               {n_err}"
+          + (f"  ({100 * (len(invs) - n_err) // len(invs)}% success)" if invs else ""))
+    print(f"mondo skill invocations: {len(skills)}")
+    print(f"--help lookups:          {len(helps)}")
+    print(f"raw graphql escapes:     {len(gql)}")
+    print(f"stderr-suppressed (2>/dev/null): {len(devnull)}"
+          + (f"  ({100 * len(devnull) // len(invs)}% of calls)" if invs else ""))
+
+    hr(f"SUBCOMMAND FREQUENCY (top {top})")
+    for k, v in collections.Counter(subcmd(i["command"]) for i in invs).most_common(top):
+        print(f"{v:4d}  {k}")
+
+    hr("PER-SESSION CONTEXT  (tag: SKILL=loaded skill, REFS=read skill files, COLD=neither)")
+    for path, c in sorted(sessions.items(), key=lambda kv: -kv[1]["n_inv"]):
+        if c["n_inv"] == 0:
+            continue
+        tag = "SKILL" if path in skill_sessions else ("REFS " if c["read_refs"] else "COLD ")
+        job = "JOB" if c["headless"] else "   "
+        print(f"{tag} {job} inv={c['n_inv']:3d} help={c['n_help']:2d} refs={c['read_refs']:2d} "
+              f"{proj(path):36s} | {c['first_user'][:64]}")
+
+    hr(f"ERRORS ({n_err})")
+    for i in invs:
+        if i["error"]:
+            print("-" * 72)
+            print(f"{(i['ts'].isoformat()[:19] if i['ts'] else '?'):19} {proj(i['file'])}")
+            print("CMD:", i["command"][:300].replace("\n", " "))
+            print("RES:", i["result"][:500].replace("\n", " | "))
+
+    hr(f"RAW GRAPHQL ESCAPES ({len(gql)})")
+    for g in gql:
+        print(f"--- {proj(g['file'])}")
+        print("   ", g["command"][:300].replace("\n", " "))
+
+    hr("FRICTION SIGNALS")
+    qmis = [i for i in invs if re.search(r"mondo\s+graphql\s+--query", i["command"])]
+    ojson = [i for i in invs if re.search(r"-o json|--output json", i["command"])]
+    nocache = [i for i in invs if "--no-cache" in i["command"]]
+    silent_err = [i for i in invs if i["error"] and "2>/dev/null" in i["command"]
+                  and len((i["result"] or "").strip()) < 60]
+    print(f"`graphql --query` misuse (query is positional):  {len(qmis)}")
+    print(f"redundant `-o json` (auto when piped):           {len(ojson)}")
+    print(f"`--no-cache` usage:                              {len(nocache)}")
+    print(f"errors with output hidden by 2>/dev/null:        {len(silent_err)}")
+
+    # error-recovery: an errored call followed by another mondo call <180s later
+    by_file = collections.defaultdict(list)
+    for i in invs:
+        if i["ts"]:
+            by_file[i["file"]].append(i)
+    recoveries = 0
+    for seq in by_file.values():
+        seq.sort(key=lambda x: x["ts"])
+        for a, b in zip(seq, seq[1:]):
+            if a["error"] and (b["ts"] - a["ts"]).total_seconds() < 180:
+                recoveries += 1
+    print(f"errors followed by a retry within 180s:          {recoveries}")
+
+    hr("FEATURE-USAGE PROBES (low/zero = discoverability gap, not capability gap)")
+    for feat in FEATURE_PROBES:
+        print(f"{sum(1 for i in invs if feat in i['command']):4d}  {feat}")
+
+    # ---- performance ----
+    # `timed` = every call we could time. `single` = exactly one mondo call in
+    # the bash block, so the wall-clock is attributable to mondo (not to echo /
+    # git / loops / `/usr/bin/time` wrappers that merely contain a mondo call).
+    # Gaps >300s are idle/approval waits, not latency — exclude from aggregates.
+    timed = [i for i in invs if i["dur"] is not None
+             and not (i["error"] and "denied" in (i["result"] or ""))]
+    single = [i for i in timed
+              if len(re.findall(r"mondo\s", i["command"])) == 1]
+    attributable = [i for i in single if i["dur"] <= 300]
+    idle = sum(1 for i in timed if i["dur"] > 300)
+    hr("PERFORMANCE — LATENCY")
+    if attributable:
+        durs = sorted(i["dur"] for i in attributable)
+
+        def pct(p):
+            return durs[min(len(durs) - 1, int(p / 100 * len(durs)))]
+
+        print(f"single-call invocations timed: {len(attributable)}  "
+              f"(of {len(timed)} timed; {idle} idle/approval gaps >300s excluded)")
+        print(f"latency s: p50={pct(50):.1f} p75={pct(75):.1f} p90={pct(90):.1f} "
+              f"p95={pct(95):.1f} max={durs[-1]:.1f}")
+        print(f"total wall time in attributable mondo calls: {sum(durs) / 60:.1f} min")
+
+        print("\nslowest 15 single mondo calls:")
+        for i in sorted(attributable, key=lambda x: -x["dur"])[:15]:
+            print(f"  {i['dur']:7.1f}s  {i['command'][:120].replace(chr(10), ' ')}")
+
+        by_sub = collections.defaultdict(list)
+        for i in attributable:
+            by_sub[subcmd(i["command"])].append(i["dur"])
+        print("\nmedian latency by subcommand (single call per bash, n>=4):")
+        for k, v in sorted(by_sub.items(), key=lambda kv: -statistics.median(kv[1])):
+            if len(v) >= 4:
+                print(f"  {statistics.median(v):6.1f}s median  n={len(v):3d}  "
+                      f"max={max(v):6.1f}  {k}")
+    else:
+        print("no attributable single-call invocations in window")
+
+    hr("PERFORMANCE — PAYLOAD & REDUNDANCY")
+    if timed:
+        rs = sorted(i["rsize"] for i in timed)
+        print(f"result size bytes: p50={rs[len(rs) // 2]} "
+              f"p90={rs[int(0.9 * len(rs))]} max={rs[-1]}")
+        big = [i for i in timed if i["rsize"] > 30000]
+        print(f"results >30KB dumped into context: {len(big)}")
+        for i in sorted(big, key=lambda x: -x["rsize"])[:8]:
+            print(f"  {i['rsize']:7d}B  {i['command'][:100].replace(chr(10), ' ')}")
+    rep = collections.Counter((i["file"], i["command"].strip()) for i in invs)
+    n_rep = sum(c - 1 for c in rep.values() if c > 1)
+    print(f"\nredundant repeats (identical command, same session): {n_rep}")
+    for (_, c), n in rep.most_common(6):
+        if n > 1:
+            print(f"  x{n}  {c[:100].replace(chr(10), ' ')}")
+    board_list = collections.Counter()
+    for i in invs:
+        for m in re.finditer(r"item list --board[= ]+(\d+)", i["command"]):
+            board_list[(i["file"], m.group(1))] += 1
+    multi = {k: v for k, v in board_list.items() if v > 2}
+    print(f"sessions re-listing the same board 3+ times: {len(multi)}")
+    rate = [i for i in invs if i["result"]
+            and re.search(r"complexity|rate limit|429|retry_in", i["result"], re.I)]
+    print(f"rate-limit / complexity mentions in results: {len(rate)}")
+
+    # ---- full dump for drill-down ----
+    dump = {
+        "cutoff": label,
+        "n_files": n_files,
+        "invocations": [{**i, "ts": i["ts"].isoformat() if i["ts"] else None}
+                        for i in invs],
+        "skill_invocations": skills,
+    }
+    with open(json_out, "w") as fh:
+        json.dump(dump, fh, indent=1)
+    print(f"\nfull record set written to {json_out} "
+          f"({len(invs)} invocations) — grep/jq it for anything above.")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--since", help="ISO timestamp cutoff; overrides tag auto-detect")
+    ap.add_argument("--repo", default=os.getcwd(),
+                    help="Mondo repo path for tag auto-detect (default: cwd)")
+    ap.add_argument("--root", default=os.path.expanduser("~/.claude/projects"),
+                    help="session-logs root (default: ~/.claude/projects)")
+    ap.add_argument("--json-out", default="/tmp/mondo_usage.json",
+                    help="where to write the full record set")
+    ap.add_argument("--top", type=int, default=40, help="subcommands to list")
+    ap.add_argument("--include-self", action="store_true",
+                    help="keep the Mondo repo's own dev transcripts "
+                         "(excluded by default — they're not consumer usage)")
+    args = ap.parse_args()
+
+    cutoff, label = resolve_cutoff(args)
+    invs, skills, sessions, n_files, n_excluded = scan(
+        cutoff, args.root, args.repo, args.include_self)
+    report(invs, skills, sessions, n_files, n_excluded, label, args.top, args.json_out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a repeatable **maintainer skill** that audits how the `mondo` CLI and the `mondo` skill are *actually* used by agents, by mining local Claude Code transcripts (`~/.claude/projects`). It codifies the post-release usage-review methodology into a project skill at `.claude/skills/mondo-usage-audit/` so it can be re-run from time to time (e.g. after each release).

Two files:

- **`scripts/scan_mondo_usage.py`** — the deterministic core. Scans transcripts since the last `vX.Y.Z` tag's commit date (or `--since`), captures every `mondo` CLI + skill invocation with its result / error / latency / payload size, and prints:
  - scope counts + the cold-vs-skill-loaded session ratio
  - subcommand frequency, full error dump, raw `graphql` escapes
  - friction signals (`graphql --query` misuse, redundant `-o json`, `2>/dev/null`-hidden errors, retry-after-error pairs)
  - feature-discoverability probes (near-zero = shipped-but-undiscovered)
  - an *attributable* latency breakdown (single-call only; idle/approval gaps and multi-command bash blocks excluded so the numbers reflect mondo, not the shell)
  - full record set to `/tmp/mondo_usage.json` for `jq` drill-down
- **`SKILL.md`** — the workflow that turns the scan into a ranked, root-cause report: trace friction to its real source (often a stale project `CLAUDE.md`, not the CLI), classify real bugs vs agent shell bugs vs permission-classifier denials vs monday-server variance, cross-reference open issues before recommending, run read-only live benchmarks, and a fixed report template.

## Why

The usage review has been run ad-hoc twice (the scanner consolidates four throwaway `/tmp` scripts from those sessions). Making it a first-class, version-controlled skill means the methodology — and its hard-won lessons — survives, and the audit is one command away.

## Reviewer notes

- The scanner **excludes the Mondo repo's own dev transcripts by default** (commit messages, `gh issue` bodies, and benchmark scripts mention `mondo` constantly but aren't consumer usage). `--include-self` opts them back in.
- It also blanks out quoted strings / heredoc bodies before detecting invocations, so `mondo` inside a commit message or `echo` isn't miscounted.
- Validated against the `v0.9.0` window: reproduces the original audit's findings (item-list ~23s median, 31% stderr-suppression, `graphql --query` misuse, zero-use `export`/`import`/`file upload`).
- Lives entirely under `.claude/` — no change to the shipped `mondo` product or the distributed `/mondo` skill.
- Paths and the `gh ... -R zoltanf/mondo` references assume this checkout; the logs root and tag detection are overridable via flags.