### PR TITLE
feat(group): accept --name as alias for --title on `group rename` (#38)

### DIFF
--- a/src/mondo/cli/group.py
+++ b/src/mondo/cli/group.py
@@ -246,13 +246,14 @@ def rename_cmd(
     first: bool = typer.Option(
         False, "--first", help="If a filter matches >1 group, pick the first one."
     ),
-    title: str = typer.Option(..., "--title", help="New group title."),
+    title: str = typer.Option(..., "--title", "--name", help="New group title (alias: --name)."),
 ) -> None:
     """Rename a group (shortcut for update --attribute title).
 
     Pick the target by id (`--id`/`--group`) or by client-side title match
     (`--name-contains` / `--name-matches` / `--name-fuzzy`). Pass `--first`
-    to auto-pick the first match when the filter is ambiguous.
+    to auto-pick the first match when the filter is ambiguous. The new title
+    is set with `--title` (or its alias `--name`).
     """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     client = client_or_exit(opts)

--- a/src/mondo/skill/references/groups.md
+++ b/src/mondo/skill/references/groups.md
@@ -37,6 +37,8 @@ Three ways to pick the group to rename: by `--id`, by `--name-contains <substrin
 ```bash
 # By id (always unambiguous):
 mondo group rename --board 5094861043 --id group_42 --title "Doing Now"
+# --name is an alias for --title (matches `create`'s --name):
+mondo group rename --board 5094861043 --id group_42 --name "Doing Now"
 
 # By substring; if multiple groups match, this exits 2 unless --first is added:
 mondo group rename --board 5094861043 \

--- a/tests/unit/test_cli_group.py
+++ b/tests/unit/test_cli_group.py
@@ -254,6 +254,28 @@ class TestGroupRename:
             "value": "New",
         }
 
+    def test_name_alias_for_title(self, httpx_mock: HTTPXMock) -> None:
+        # --name is an alias for --title (the new-value flag), matching the
+        # `--name` convention of `board create` / `item create`. It must not
+        # collide with the `--name-*` selectors.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"update_group": {"id": "topics", "title": "New"}}),
+        )
+        result = runner.invoke(
+            app,
+            ["group", "rename", "--board", "42", "--id", "topics", "--name", "New"],
+        )
+        assert result.exit_code == 0, result.stdout
+        v = _last_body(httpx_mock)["variables"]
+        assert v == {
+            "board": 42,
+            "group": "topics",
+            "attribute": "title",
+            "value": "New",
+        }
+
     def test_group_alias_for_id(self, httpx_mock: HTTPXMock) -> None:
         # Agent-friendly alias: --group works as a synonym for --id, matching
         # the convention used by `item create --group ...`.


### PR DESCRIPTION
Resolves #38.

## Problem
`mondo group rename` set the new title with `--title`, but users intuitively reach for `--name` (matching `board create` / `item create`). `--name` errored with a misleading hint pointing at the `--name-contains` / `--name-matches` / `--name-fuzzy` **selectors** (which find the group, not rename it).

## Fix
Add `--name` as an alias for the `--title` new-value flag:
```python
title: str = typer.Option(..., "--title", "--name", help="New group title (alias: --name).")
```
`--name` is an exact long-option string; Click matches long options exactly (no prefix/abbreviation matching), so it does **not** collide with the `--name-*` selectors. Verified in `--help` (four distinct rows) and by unit test.

## Testing
- New unit test `test_name_alias_for_title` asserts `--name New` routes to `attribute=title, value=New`, identical to `--title`.
- `tests/unit/test_cli_group.py` 42 passed; help/spec/contract suites green. Live smoke on the playground board renamed a throwaway group via `--name` and cleaned up.

## Review
`/simplify`: clean (idiomatic typer alias). `/code-review`: clean — confirmed no Click prefix ambiguity and no spec/contract test breakage. `/security-review`: no findings (pure alias; value already flows through a parameterized GraphQL variable).

Scope note: `column rename` has the same `--title`-only pattern; left untouched as out of scope for #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
