### PR TITLE
feat(column): add --labels convenience flag to `column create` (#39)

### DIFF
--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -1104,7 +1104,17 @@ EXAMPLES: dict[str, list[Example]] = {
     ],
     "column create": [
         Example(
-            "Add a status column with initial labels",
+            "Seed a status column's labels with --labels (builds --defaults for you)",
+            'mondo column create --board 1234567890 --title "Priority" '
+            '--type status --labels "High,Medium,Low"',
+        ),
+        Example(
+            "Seed a dropdown column's options the same way",
+            'mondo column create --board 1234567890 --title "Tech stack" '
+            '--type dropdown --labels "Node/Express,Python/FastAPI"',
+        ),
+        Example(
+            "Hand-craft labels via --defaults (status shape shown)",
             'mondo column create --board 1234567890 --title "Priority" '
             "--type status "
             '--defaults \'{"labels":{"1":"High","2":"Medium"}}\'',

--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -595,6 +595,32 @@ def _parse_defaults(raw: str | None) -> str | None:
     return json.dumps(parsed)
 
 
+def _labels_to_defaults(labels: str, column_type: str) -> str:
+    """Build a `--defaults` JSON string from `--labels` for status/dropdown columns.
+
+    status wants `{"labels": {"1": name, ...}}` (1-based string index keys);
+    dropdown wants `{"settings": {"labels": [{"id": 1, "name": name}, ...]}}`.
+    """
+    names = [part.strip() for part in labels.split(",") if part.strip()]
+    if not names:
+        typer.secho("error: --labels is empty.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=2)
+    if column_type == "status":
+        payload: dict[str, Any] = {"labels": {str(i): name for i, name in enumerate(names, 1)}}
+    elif column_type == "dropdown":
+        payload = {
+            "settings": {"labels": [{"id": i, "name": name} for i, name in enumerate(names, 1)]}
+        }
+    else:
+        typer.secho(
+            "error: --labels only applies to status/dropdown columns.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    return json.dumps(payload)
+
+
 @app.command("create", epilog=epilog_for("column create"))
 def create_cmd(
     ctx: typer.Context,
@@ -617,7 +643,17 @@ def create_cmd(
         metavar="JSON",
         help=(
             'Type-specific defaults as JSON (e.g. status: \'{"labels":{"1":"High"}}\', '
-            'dropdown: \'{"settings":{"labels":[...]}}\').'
+            'dropdown: \'{"settings":{"labels":[...]}}\'). For initial status/dropdown '
+            "labels, prefer --labels, which builds this for you. Mutually exclusive "
+            "with --labels."
+        ),
+    ),
+    labels: str | None = typer.Option(
+        None,
+        "--labels",
+        help=(
+            "Comma-separated initial labels for a status/dropdown column; builds "
+            "--defaults for you. Mutually exclusive with --defaults."
         ),
     ),
     custom_id: str | None = typer.Option(
@@ -633,6 +669,15 @@ def create_cmd(
 ) -> None:
     """Create a new column on a board."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+    if labels is not None:
+        if defaults is not None:
+            typer.secho(
+                "error: --labels and --defaults are mutually exclusive.",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        defaults = _labels_to_defaults(labels, column_type)
     defaults_str = _parse_defaults(defaults)
     variables: dict[str, Any] = {
         "board": board_id,

--- a/src/mondo/skill/references/columns.md
+++ b/src/mondo/skill/references/columns.md
@@ -65,6 +65,18 @@ mondo column create --board 5094861043 \
 {"id": "e2e_status", "title": "Status", "type": "status"}
 ```
 
+### Seed initial labels (status / dropdown)
+
+```bash
+mondo column create --board 5094861043 \
+  --title "Stage" --type status --labels "New,In Review,Live"
+
+mondo column create --board 5094861043 \
+  --title "Stack" --type dropdown --labels "Node/Express,Python/FastAPI"
+```
+
+*Gotcha:* `--labels` builds the right per-type `--defaults` payload for you (status uses an index→name object, dropdown an array of `{id,name}` under `settings`). It only applies to `status`/`dropdown` and is mutually exclusive with `--defaults`.
+
 *Gotcha:* `--id` sets a **stable, human-readable column id** that survives renames — use it whenever you'll reference the column from scripts. Without it monday auto-assigns `text_xyz123`. Common types: `status`, `people`, `date`, `timeline`, `numbers`, `text`, `long_text`, `doc`, `dropdown`, `checkbox`, `country`, `email`, `phone`, `link`, `rating`, `tags`, `file`, `world_clock`, `board_relation`. See `mondo help codecs` for value-format hints per type.
 
 ## Read a column value (single item)

--- a/tests/unit/test_cli_column.py
+++ b/tests/unit/test_cli_column.py
@@ -117,9 +117,7 @@ class TestColumnGetMeta:
                 }
             ),
         )
-        result = runner.invoke(
-            app, ["column", "get-meta", "--board", "42", "--column", "status"]
-        )
+        result = runner.invoke(app, ["column", "get-meta", "--board", "42", "--column", "status"])
         assert result.exit_code == 0, result.stdout
         parsed = json.loads(result.stdout)
         assert parsed["id"] == "status"
@@ -154,9 +152,7 @@ class TestColumnGetMeta:
                 }
             ),
         )
-        result = runner.invoke(
-            app, ["column", "get-meta", "--board", "42", "--column", "missing"]
-        )
+        result = runner.invoke(app, ["column", "get-meta", "--board", "42", "--column", "missing"])
         assert result.exit_code == 6
         combined = (result.stdout or "") + (result.stderr or "")
         assert "missing" in combined.lower() and "not found" in combined.lower()
@@ -627,6 +623,143 @@ class TestColumnCreate:
         assert "create_column" in parsed["query"]
         assert httpx_mock.get_requests() == []
 
+    def test_labels_status_builds_defaults(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_column": {"id": "stage"}}),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "column",
+                "create",
+                "--board",
+                "42",
+                "--title",
+                "Stage",
+                "--type",
+                "status",
+                "--labels",
+                "A,B,C",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        v = json.loads(httpx_mock.get_requests()[-1].content)["variables"]
+        assert isinstance(v["defaults"], str)
+        assert json.loads(v["defaults"]) == {"labels": {"1": "A", "2": "B", "3": "C"}}
+
+    def test_labels_dropdown_builds_defaults(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_column": {"id": "stack"}}),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "column",
+                "create",
+                "--board",
+                "42",
+                "--title",
+                "Stack",
+                "--type",
+                "dropdown",
+                "--labels",
+                "X,Y",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        v = json.loads(httpx_mock.get_requests()[-1].content)["variables"]
+        assert json.loads(v["defaults"]) == {
+            "settings": {"labels": [{"id": 1, "name": "X"}, {"id": 2, "name": "Y"}]}
+        }
+
+    def test_labels_trims_and_drops_empty(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_column": {"id": "stage"}}),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "column",
+                "create",
+                "--board",
+                "42",
+                "--title",
+                "Stage",
+                "--type",
+                "status",
+                "--labels",
+                " A , ,B ,,",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        v = json.loads(httpx_mock.get_requests()[-1].content)["variables"]
+        assert json.loads(v["defaults"]) == {"labels": {"1": "A", "2": "B"}}
+
+    def test_labels_wrong_type_exits_2(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "column",
+                "create",
+                "--board",
+                "42",
+                "--title",
+                "P",
+                "--type",
+                "text",
+                "--labels",
+                "A,B",
+            ],
+        )
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_labels_with_defaults_exits_2(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "column",
+                "create",
+                "--board",
+                "42",
+                "--title",
+                "P",
+                "--type",
+                "status",
+                "--labels",
+                "A,B",
+                "--defaults",
+                '{"labels":{"1":"High"}}',
+            ],
+        )
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_labels_all_empty_exits_2(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "column",
+                "create",
+                "--board",
+                "42",
+                "--title",
+                "P",
+                "--type",
+                "status",
+                "--labels",
+                " , ,",
+            ],
+        )
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
 
 class TestColumnRename:
     def test_basic(self, httpx_mock: HTTPXMock) -> None:
@@ -679,10 +812,14 @@ class TestColumnRename:
         result = runner.invoke(
             app,
             [
-                "column", "rename",
-                "--board", "42",
-                "--name-contains", "status",
-                "--title", "Workflow",
+                "column",
+                "rename",
+                "--board",
+                "42",
+                "--name-contains",
+                "status",
+                "--title",
+                "Workflow",
             ],
         )
         assert result.exit_code == 0, result.stdout


### PR DESCRIPTION
Resolves #39.

## Problem
Seeding initial labels at `column create` time required `--defaults` with two different, undocumented per-type JSON shapes (status: index→name object; dropdown: `{id,name}` array under `settings`), discoverable only by dry-run trial-and-error.

## Fix
New typed `--labels "A,B,C"` flag that builds the correct `--defaults` payload for the given `--type`:
- **status** → `{"labels": {"1": "A", "2": "B", "3": "C"}}`
- **dropdown** → `{"settings": {"labels": [{"id": 1, "name": "A"}, ...]}}`

`--labels` only applies to status/dropdown (else exit 2), is mutually exclusive with `--defaults` (exit 2), trims whitespace, and drops empty entries.

```bash
mondo column create --board <B> --title "Stage" --type status   --labels "New,In Review,Live"
mondo column create --board <B> --title "Stack" --type dropdown --labels "Node/Express,Python/FastAPI"
```

## Testing
- 6 new unit tests: status build, dropdown build, whitespace/empty handling, wrong-type exit 2, `--labels`+`--defaults` exit 2, all-empty exit 2. Full non-integration suite: **1565 passed**.
- **Live-verified** on the playground board: created status + dropdown columns via `--labels`; `column labels` read them back at the expected 1-based indices (1/2/3) with correct names; columns deleted afterward.

## Review
`/simplify`: clean. `/code-review`: verified the **1-based status index** convention live (matches issue #39's own example and the existing `--defaults` seed docs; reads back as index 1/2/3) and added the missing `--labels` examples both reviewers flagged. `/security-review`: no findings — label content flows through `json.dumps` into a parameterized GraphQL `$defaults` variable, never interpolated into the query.

Scope note: `--type` remains case-sensitive (pre-existing behavior); `--type Status` is rejected by monday's lowercase enum regardless, so it was left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
