### PR TITLE
docs: sync README + bump skill version for merged doc/group/column features

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,20 +578,26 @@ mondo doc list           [--workspace 42] [--object-id 77] [--order-by used_at] 
 mondo doc get            --id 7           # internal id
 mondo doc get            --object-id 77   # URL-visible id
 mondo doc get            --id 7 --format markdown    # render blocks → markdown
-mondo doc create         --workspace 42 --name "Spec" --kind public
+mondo doc export-markdown --doc 7                    # always-live markdown export
+mondo doc create         --workspace 42 --name "Spec" --kind public [--folder 3042556]
 
-mondo doc add-content    --doc 7 --from-file spec.md         # bulk markdown → blocks
+mondo doc add-content    --doc 7 --from-file spec.md         # bulk markdown → blocks (append)
+mondo doc set            --doc 7 --from-file spec.md         # replace full content in place
+mondo doc replace        --object-id 77 --markdown "# Fresh" # alias of `doc set`
 mondo doc add-block      --doc 7 --type normal_text \
                          --content '{"deltaFormat":[{"insert":"hi"}]}' \
                          [--after <block-id>] [--parent-block <block-id>]
 mondo doc update-block   --id <block-id> --content '<json>'
 mondo doc delete-block   --id <block-id>
+mondo doc delete         --doc 7                             # delete the whole doc
 ```
 
 `add-content` reuses the Phase-1f markdown converter (headings h1-h3,
 paragraphs, bullet / numbered lists, blockquotes, fenced code, horizontal
-rules). monday has no top-level `delete_doc` mutation — delete individual
-blocks, or delete via the monday UI.
+rules). `doc set` (alias `doc replace`) overwrites the whole doc in place
+(preserving its id / object_id / URL) by writing the new content first, then
+deleting the prior blocks. `doc create --folder <id>` places the new doc
+directly inside a folder.
 
 ### Updates (item comments)
 
@@ -674,7 +680,7 @@ mondo workspace remove-team   --id 7 --team 11
 mondo group list       --board 1234567890
 mondo group create     --board 1234567890 --name "Planning" [--color "#00c875"] \
                        [--relative-to topics] [--position-relative-method after_at]
-mondo group rename     --board 1234567890 --id topics --title "Workstreams"
+mondo group rename     --board 1234567890 --id topics --title "Workstreams"   # --name is an alias for --title
 mondo group update     --board 1234567890 --id topics --attribute color --value "#ff007f"
 mondo group reorder    --board 1234567890 --id topics (--after g2 | --before g1 | --position 3)
 mondo group duplicate  --board 1234567890 --id topics [--title "Topics 2"] [--add-to-top]
@@ -736,8 +742,10 @@ mondo column clear    --item 987 --column status
 
 # Structural (2b)
 mondo column create          --board 1234567890 --title "Priority" --type status \
-                             --defaults '{"labels":{"1":"High","2":"Medium"}}' \
+                             --labels "High,Medium,Low" \   # builds --defaults for you (status/dropdown)
                              [--id priority] [--after status] [--description "…"]
+mondo column create          --board 1234567890 --title "Priority" --type status \
+                             --defaults '{"labels":{"1":"High","2":"Medium"}}'   # hand-crafted alternative
 mondo column rename          --board 1234567890 --id status --title "Workflow"
 mondo column change-metadata --board 1234567890 --id status --property description --value "…"
 mondo column delete          --board 1234567890 --id status --yes

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mondo
 description: Use when the user wants to do anything against monday.com via the `mondo` CLI — reading or writing workspaces, folders, boards, groups, items, subitems, columns, updates, docs, files, users, teams, webhooks, or when they paste a monday.com URL.
-version: "1.2.0"
+version: "1.3.0"
 ---
 
 # mondo


### PR DESCRIPTION
Docs-only follow-up to the merged feature PRs (#40, #41, #42). The shipped command surface changed, but the top-level README and the bundled skill version did not — this syncs them.

## Changes
- **`SKILL.md`**: `version: 1.2.0 → 1.3.0`. The freshness checker (`_skill_freshness.py`) warns users running an older installed copy; bumping it nudges them to re-pull the updated `references/` (docs/groups/columns changed in #40–#42). Matches the convention from #18 (skill version bumped on CLI surface changes).
- **`README.md`** (Workspace docs block):
  - Document `doc set` / `doc replace` (in-place full replace), `doc create --folder`, `doc export-markdown`, and `doc delete`.
  - **Fix a stale claim**: README said "monday has no top-level `delete_doc` mutation — delete individual blocks, or delete via the monday UI." That's wrong — `delete_doc` exists and `mondo doc delete` ships (`queries.py:711`, `doc.py:1260`). Replaced with accurate `doc set`/`--folder` notes.
- **`README.md`** (group / column blocks): note `group rename --name` (alias of `--title`) and `column create --labels`.

## Why no `output-contract-matrix` update
The generated `docs/output-contract-matrix.{md,json}` doesn't list `doc set`/`doc replace` because they're registered via `app.command(...)(set_cmd)` (one function, two names) rather than a single `@app.command` decorator, and the generator's AST walk only reads decorator lists. Regenerating produces no diff. It's a non-test-enforced maintainer doc and `set_cmd`'s `{**result, ...}` emit isn't shape-inferable by the generator anyway, so I left the generator untouched rather than expand it for two non-inferable rows. Flagging for awareness.

## Testing / review
- `tests/unit/test_cli_skill_freshness.py` + `test_cli_help.py`: 36 passed (the only tests touching these files). Full non-integration suite was green on merged main (1578 passed).
- Every command/flag added to the README was verified against the code. Docs-only diff, so `/simplify` and `/security-review` have no code surface; the `/code-review` equivalent (accuracy check) was done inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
