### PR TITLE
docs: add doc set/replace to output-contract-matrix

### DIFF
--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -582,6 +582,30 @@
     "source": "doc.py"
   },
   {
+    "command": "doc replace",
+    "output_type": "object",
+    "fields": [
+      "success",
+      "block_ids",
+      "error",
+      "replaced_blocks"
+    ],
+    "notes": "Alias of `doc set` (same handler / output).",
+    "source": "ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + replaced_blocks"
+  },
+  {
+    "command": "doc set",
+    "output_type": "object",
+    "fields": [
+      "success",
+      "block_ids",
+      "error",
+      "replaced_blocks"
+    ],
+    "notes": "In-place full content replace. Adds the new markdown first, then deletes the prior blocks; replaced_blocks counts the deleted originals. Alias: `doc replace`.",
+    "source": "ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + replaced_blocks"
+  },
+  {
     "command": "doc update-block",
     "output_type": "object",
     "fields": [

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -254,6 +254,16 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: none
   source: `doc.py`
   notes: Could not auto-infer. Final emit expression: data.get("update_doc_name")
+- `doc replace`
+  type: `object`
+  fields: `success`, `block_ids`, `error`, `replaced_blocks`
+  source: `ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + replaced_blocks`
+  notes: Alias of `doc set` (same handler / output).
+- `doc set`
+  type: `object`
+  fields: `success`, `block_ids`, `error`, `replaced_blocks`
+  source: `ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + replaced_blocks`
+  notes: In-place full content replace. Adds the new markdown first, then deletes the prior blocks; replaced_blocks counts the deleted originals. Alias: `doc replace`.
 - `doc update-block`
   type: `object`
   fields: `id`, `type`

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -342,6 +342,28 @@ MANUAL_ROWS: dict[str, Row] = {
         notes="Single created block payload.",
         source="CREATE_DOC_BLOCK.create_doc_block",
     ),
+    # `doc set` / `doc replace` share one handler (set_cmd), registered via
+    # `app.command(...)(set_cmd)` rather than a decorator, so the AST walk
+    # below cannot discover them — they live here as manual rows. The emit is
+    # the add_content_to_doc_from_markdown result spread with replaced_blocks
+    # appended.
+    "doc set": Row(
+        command="doc set",
+        output_type="object",
+        fields=["success", "block_ids", "error", "replaced_blocks"],
+        notes=(
+            "In-place full content replace. Adds the new markdown first, then deletes the prior "
+            "blocks; replaced_blocks counts the deleted originals. Alias: `doc replace`."
+        ),
+        source="ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + replaced_blocks",
+    ),
+    "doc replace": Row(
+        command="doc replace",
+        output_type="object",
+        fields=["success", "block_ids", "error", "replaced_blocks"],
+        notes="Alias of `doc set` (same handler / output).",
+        source="ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + replaced_blocks",
+    ),
     "doc duplicate": Row(
         command="doc duplicate",
         output_type="object",


### PR DESCRIPTION
Follow-up to the v0.9.2 work: the generated `docs/output-contract-matrix.{md,json}` was missing `doc set` / `doc replace`.

## Why they were missing
The generator (`scripts/generate_output_contract_matrix.py`) discovers commands by walking `@app.command(...)` **decorators**. `doc set` / `doc replace` share one handler (`set_cmd`) registered via the **call form** `app.command("set")(set_cmd)` / `app.command("replace")(set_cmd)` (one function, two names), so the AST walk never saw them.

## Fix
Added both as `MANUAL_ROWS` entries — the generator's intended escape hatch for emits it can't auto-infer (`set_cmd` emits `{**result, "replaced_blocks": N}`, a dict-spread `infer_auto_row` doesn't handle). Regenerated both output files.

Result (object): `success`, `block_ids`, `error`, `replaced_blocks` — sourced from `ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown` plus the appended `replaced_blocks` count.

## Verification
- Regeneration is idempotent (re-running yields no further diff); the change is purely additive (no other rows reordered/changed).
- `ruff check` clean on the generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
