### PR TITLE
feat(doc): download embedded images on markdown export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,8 +117,9 @@ Variables `.env` sets:
 - `MONDO_TEST_DOC_ID` / `MONDO_TEST_DOC_URL` — pre-prepared "Mondo Test
   Doc" in workspace `592446`, exercising every block type the markdown
   renderer cares about (notice box, check lists, bulleted lists, code,
-  divider, table cells, normal text). Read-only doc tests skip unless
-  this is set.
+  divider, table cells, normal text, and image blocks — one top-level
+  plus two inside a table, relied on by `test_live_doc_images.py`).
+  Read-only doc tests skip unless this is set.
   - The value `5095668848` is the **URL-visible `object_id`** (the
     last segment of `https://marktguru.monday.com/docs/5095668848`),
     NOT the internal numeric id. The matching internal id is
@@ -155,6 +156,9 @@ Live integration tests live under `tests/integration/`, split by feature:
 - `test_live_folders.py` — folder tree, parent linking, rename, delete
   archives contained boards.
 - `test_live_doc_column.py` — `column doc set/get/append/clear`.
+- `test_live_doc_images.py` — `doc get --format markdown --out` and
+  `doc export-markdown --out` download embedded images into the markdown's
+  folder and reference them by `<assetId>-<name>` local filename.
 - `test_live_doc_md_roundtrip.py` — standalone-doc markdown round-trip
   (strict subset + rich golden) plus `doc duplicate`/`doc rename`
   (currently `xfail`-pinned for the `Int!` vs `ID!` schema mismatch).

--- a/README.md
+++ b/README.md
@@ -578,7 +578,11 @@ mondo doc list           [--workspace 42] [--object-id 77] [--order-by used_at] 
 mondo doc get            --id 7           # internal id
 mondo doc get            --object-id 77   # URL-visible id
 mondo doc get            --id 7 --format markdown    # render blocks → markdown
+mondo doc get            --id 7 --format markdown --out ./doc.md  # +download images beside the file
+mondo doc get            --id 7 --format markdown --out ./doc.md --no-images  # skip download, keep URLs
 mondo doc export-markdown --doc 7                    # always-live markdown export
+mondo doc export-markdown --doc 7 --out ./doc.md     # +download images, rewrite URLs to local files
+mondo doc export-markdown --doc 7 --out ./doc.md --no-images  # skip download, keep URLs
 mondo doc create         --workspace 42 --name "Spec" --kind public [--folder 3042556]
 
 mondo doc add-content    --doc 7 --from-file spec.md         # bulk markdown → blocks (append)

--- a/src/mondo/cli/_doc_images.py
+++ b/src/mondo/cli/_doc_images.py
@@ -146,10 +146,17 @@ def download_doc_images(
     }
 
 
-def localize_markdown_images(opts: GlobalOpts, markdown: str, folder: Path) -> str:
+def localize_markdown_images(
+    opts: GlobalOpts, markdown: str, folder: Path
+) -> tuple[str, list[str]]:
     """Download images referenced in a server-rendered markdown string and
-    rewrite their URLs to the downloaded local filenames."""
+    rewrite their URLs to the downloaded local filenames.
+
+    Returns `(rewritten_markdown, local_filenames)`. The filename list covers
+    only images that were actually downloaded + rewritten — assets monday
+    didn't return keep their remote URL and are excluded.
+    """
     asset_ids = extract_asset_ids_from_markdown(markdown)
     downloaded = _download_assets(opts, asset_ids, folder)
     filenames = {aid: info["filename"] for aid, info in downloaded.items()}
-    return rewrite_markdown_images(markdown, filenames)
+    return rewrite_markdown_images(markdown, filenames), list(filenames.values())

--- a/src/mondo/cli/_doc_images.py
+++ b/src/mondo/cli/_doc_images.py
@@ -1,0 +1,155 @@
+"""Download monday doc images into a local folder for markdown export.
+
+Shared by `doc get --format markdown --out` (block-tree path) and
+`doc export-markdown --out` (server-rendered-string path).
+
+monday image blocks carry a numeric `assetId` plus a protected_static `url`
+that only resolves in a logged-in browser. We resolve each asset to its
+pre-signed `public_url` via `assets(ids)` (reusing `ASSETS_GET`, the same
+query `mondo file download` uses) and stream the bytes to disk with the
+`httpx.stream(..., follow_redirects=True)` pattern from `mondo.cli.file`.
+
+Files are named `<assetId>-<sanitized-name>` so clipboard images — which all
+share the name `image-from-clipboard.png` — don't collide.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from mondo.api.errors import NetworkError
+from mondo.api.queries import ASSETS_GET
+from mondo.cli._exec import execute_read
+from mondo.cli.context import GlobalOpts
+from mondo.docs import collect_image_asset_ids
+
+# assetId embedded in a monday protected_static URL: `.../resources/<id>/...`.
+_RESOURCE_ID_RE = re.compile(r"/resources/(\d+)/")
+# Markdown image: `![alt](url)`. URL stops at whitespace or the closing paren.
+_MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)\s]+)\)")
+# Characters we keep in a local filename; everything else collapses to `-`.
+_FILENAME_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def local_filename(asset_id: int, name: str | None, file_extension: str | None) -> str:
+    """`<assetId>-<sanitized-name>` — unique even when names repeat.
+
+    Falls back to the asset's `file_extension` when monday returns no name.
+    """
+    safe = (
+        _FILENAME_UNSAFE_RE.sub("-", name).strip("-")
+        if name
+        else f"asset{file_extension or ''}"
+    )
+    return f"{asset_id}-{safe}" if safe else str(asset_id)
+
+
+def extract_asset_ids_from_markdown(markdown: str) -> list[int]:
+    """Asset IDs of monday-hosted images in a markdown string, de-duplicated.
+
+    Only matches images whose URL is a monday protected_static link
+    (`.../resources/<id>/...`); external image URLs are left untouched.
+    """
+    ids: list[int] = []
+    for match in _MD_IMAGE_RE.finditer(markdown):
+        rid = _RESOURCE_ID_RE.search(match.group(2))
+        if rid:
+            ids.append(int(rid.group(1)))
+    return list(dict.fromkeys(ids))
+
+
+def rewrite_markdown_images(markdown: str, filenames: dict[int, str]) -> str:
+    """Rewrite monday image URLs to the local filenames in `filenames`.
+
+    Images whose assetId isn't in the map (external, or failed to download)
+    keep their original URL.
+    """
+
+    def repl(match: re.Match[str]) -> str:
+        rid = _RESOURCE_ID_RE.search(match.group(2))
+        if rid:
+            local = filenames.get(int(rid.group(1)))
+            if local is not None:
+                return f"![{match.group(1)}]({local})"
+        return match.group(0)
+
+    return _MD_IMAGE_RE.sub(repl, markdown)
+
+
+def _resolve_assets(opts: GlobalOpts, asset_ids: list[int]) -> dict[int, dict[str, Any]]:
+    """Key an `assets(ids)` payload by asset id. Unknown ids are simply
+    absent from the result (callers fall back to the remote URL)."""
+    if not asset_ids:
+        return {}
+    data = execute_read(opts, ASSETS_GET, {"ids": asset_ids})
+    assets = data.get("assets") or []
+    return {int(a["id"]): a for a in assets if a.get("id") is not None}
+
+
+def _download(url: str, target: Path) -> None:
+    try:
+        with httpx.stream("GET", url, follow_redirects=True) as resp:
+            resp.raise_for_status()
+            with target.open("wb") as fh:
+                for chunk in resp.iter_bytes():
+                    fh.write(chunk)
+    except httpx.HTTPStatusError as e:
+        raise NetworkError(f"image download failed: HTTP {e.response.status_code}") from e
+    except httpx.RequestError as e:
+        raise NetworkError(f"image download failed: {e}") from e
+
+
+def _download_assets(
+    opts: GlobalOpts, asset_ids: list[int], folder: Path
+) -> dict[int, dict[str, str]]:
+    """Resolve + download each asset into `folder`.
+
+    Returns `{assetId: {"filename", "name"}}` for the assets that downloaded;
+    ids monday didn't return, or that carry no url, are skipped.
+    """
+    meta = _resolve_assets(opts, asset_ids)
+    if not meta:
+        return {}
+    folder.mkdir(parents=True, exist_ok=True)
+    downloaded: dict[int, dict[str, str]] = {}
+    for aid in asset_ids:
+        asset = meta.get(aid)
+        if asset is None:
+            continue
+        # Prefer the pre-signed S3 `public_url`; `url` is the protected proxy.
+        url = asset.get("public_url") or asset.get("url")
+        if not url:
+            continue
+        name = asset.get("name")
+        filename = local_filename(aid, name, asset.get("file_extension"))
+        _download(url, folder / filename)
+        downloaded[aid] = {"filename": filename, "name": name or ""}
+    return downloaded
+
+
+def download_doc_images(
+    opts: GlobalOpts, blocks: list[dict[str, Any]], folder: Path
+) -> dict[str, tuple[str, str]]:
+    """Download every image block's asset into `folder`.
+
+    Returns the `images` map `blocks_to_markdown` expects:
+    `str(assetId) → (alt_text, local_filename)`, with the asset name as alt.
+    """
+    asset_ids = collect_image_asset_ids(blocks)
+    downloaded = _download_assets(opts, asset_ids, folder)
+    return {
+        str(aid): (info["name"], info["filename"]) for aid, info in downloaded.items()
+    }
+
+
+def localize_markdown_images(opts: GlobalOpts, markdown: str, folder: Path) -> str:
+    """Download images referenced in a server-rendered markdown string and
+    rewrite their URLs to the downloaded local filenames."""
+    asset_ids = extract_asset_ids_from_markdown(markdown)
+    downloaded = _download_assets(opts, asset_ids, folder)
+    filenames = {aid: info["filename"] for aid, info in downloaded.items()}
+    return rewrite_markdown_images(markdown, filenames)

--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -602,6 +602,14 @@ EXAMPLES: dict[str, list[Example]] = {
             "Render the block tree as markdown",
             "mondo doc get --id 7 --format markdown",
         ),
+        Example(
+            "Save markdown to a file + download images beside it",
+            "mondo doc get --id 7 --format markdown --out ./doc.md",
+        ),
+        Example(
+            "Save to a file but keep image URLs (skip download)",
+            "mondo doc get --id 7 --format markdown --out ./doc.md --no-images",
+        ),
         Example("Just the doc name", "mondo doc get --id 7 -q name -o none"),
     ],
     "doc create": [
@@ -688,6 +696,14 @@ EXAMPLES: dict[str, list[Example]] = {
         Example(
             "Export specific blocks only",
             "mondo doc export-markdown --doc 7 --block <block-1> --block <block-2> --raw",
+        ),
+        Example(
+            "Save to a file + download images beside it (rewrites URLs to local files)",
+            "mondo doc export-markdown --doc 7 --out ./doc.md",
+        ),
+        Example(
+            "Save to a file but keep image URLs (skip download)",
+            "mondo doc export-markdown --doc 7 --out ./doc.md --no-images",
         ),
     ],
     "doc version-history": [

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -1377,19 +1377,14 @@ def export_markdown_cmd(
         )
     markdown = result.get("markdown") or ""
     if out is not None:
-        from mondo.cli._doc_images import (
-            extract_asset_ids_from_markdown,
-            localize_markdown_images,
-        )
+        from mondo.cli._doc_images import localize_markdown_images
 
-        image_count = (
-            0 if no_images else len(extract_asset_ids_from_markdown(markdown))
-        )
+        images: list[str] = []
         if not no_images:
-            markdown = localize_markdown_images(opts, markdown, out.parent)
+            markdown, images = localize_markdown_images(opts, markdown, out.parent)
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(markdown)
-        opts.emit({"out": str(out), "images": image_count})
+        opts.emit({"out": str(out), "images": images})
         return
     typer.echo(markdown)
 

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -51,6 +51,7 @@ from mondo.cli._exec import (
     exec_or_exit,
     execute,
     handle_mondo_error_or_exit,
+    usage_error_or_exit,
 )
 from mondo.cli._json_flag import parse_json_flag
 from mondo.cli._resolve import resolve_required_id
@@ -557,6 +558,21 @@ def get_cmd(
         help="Emit raw JSON (blocks as-is) or render blocks to markdown.",
         case_sensitive=False,
     ),
+    out: Path | None = typer.Option(
+        None,
+        "--out",
+        help=(
+            "Write markdown to this file and download embedded images into "
+            "the same folder, referenced by local filename (requires "
+            "--format markdown). Without it, markdown goes to stdout and "
+            "images keep their (browser-only) monday URLs."
+        ),
+    ),
+    no_images: bool = typer.Option(
+        False,
+        "--no-images",
+        help="With --out, skip downloading images; keep their monday URLs.",
+    ),
     with_url: bool = typer.Option(
         False,
         "--with-url",
@@ -595,6 +611,8 @@ def get_cmd(
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     reject_mutually_exclusive(no_cache, refresh_cache)
     del with_url  # docs always carry `url` from monday; flag kept for symmetry
+    if out is not None and fmt is not DocFormat.markdown:
+        usage_error_or_exit("--out is only valid with --format markdown.")
     sources = sum(x is not None for x in (doc_id, object_id))
     if sources != 1:
         typer.secho(
@@ -667,6 +685,21 @@ def get_cmd(
 
     if fmt is DocFormat.markdown:
         blocks = doc.get("blocks") or []
+        if out is not None:
+            images: dict[str, tuple[str, str]] = {}
+            if not no_images:
+                from mondo.cli._doc_images import download_doc_images
+
+                images = download_doc_images(opts, blocks, out.parent)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(blocks_to_markdown(blocks, images=images))
+            opts.emit(
+                {
+                    "out": str(out),
+                    "images": [ref for _, ref in images.values()],
+                }
+            )
+            return
         typer.echo(blocks_to_markdown(blocks))
         return
     doc = normalize_doc_entry(doc)
@@ -1288,6 +1321,20 @@ def export_markdown_cmd(
         "--raw",
         help="Emit API JSON envelope instead of plain markdown text.",
     ),
+    out: Path | None = typer.Option(
+        None,
+        "--out",
+        help=(
+            "Write the markdown to this file and download embedded images "
+            "into the same folder, rewriting their URLs to local filenames. "
+            "Without it, markdown goes to stdout with monday image URLs."
+        ),
+    ),
+    no_images: bool = typer.Option(
+        False,
+        "--no-images",
+        help="With --out, skip downloading images; keep their monday URLs.",
+    ),
     no_cache: bool = typer.Option(
         False,
         "--no-cache",
@@ -1311,6 +1358,8 @@ def export_markdown_cmd(
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     reject_mutually_exclusive(no_cache, refresh_cache)
+    if raw and out is not None:
+        usage_error_or_exit("--raw and --out are mutually exclusive.")
     data, _ = _execute_doc_command(
         opts,
         EXPORT_MARKDOWN_FROM_DOC,
@@ -1326,7 +1375,23 @@ def export_markdown_cmd(
         _fail_with_object_id_hint(
             opts, result.get("error") or "export_markdown_from_doc failed", doc_id
         )
-    typer.echo(result.get("markdown") or "")
+    markdown = result.get("markdown") or ""
+    if out is not None:
+        from mondo.cli._doc_images import (
+            extract_asset_ids_from_markdown,
+            localize_markdown_images,
+        )
+
+        image_count = (
+            0 if no_images else len(extract_asset_ids_from_markdown(markdown))
+        )
+        if not no_images:
+            markdown = localize_markdown_images(opts, markdown, out.parent)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(markdown)
+        opts.emit({"out": str(out), "images": image_count})
+        return
+    typer.echo(markdown)
 
 
 @app.command("version-history", epilog=epilog_for("doc version-history"))

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -7,10 +7,14 @@ Scope (plan §6.4 / monday-api.md §11.5.22):
   `CreateBlockInput` dicts. Supported blocks: heading (h1/h2/h3),
   normal_text, bullet_list, numbered_list, check_list (GFM task list
   syntax `- [ ] / - [x]`), quote, code, divider.
-- `blocks_to_markdown` reverses the above for display.
+- `blocks_to_markdown` reverses the above for display. `image` blocks render
+  as `![alt](ref)`; pass an `images` map (assetId → (alt, local filename)) to
+  rewrite the monday `url` to a downloaded local file — see
+  `mondo.cli._doc_images`. Without the map they keep the (browser-only)
+  monday `url`.
 
-Unsupported markdown (images, tables, nested lists, inline formatting)
-round-trips through `normal_text` — we prefer correctness over feature parity.
+Unsupported markdown (nested lists, inline formatting) round-trips through
+`normal_text` — we prefer correctness over feature parity.
 """
 
 from __future__ import annotations
@@ -243,6 +247,29 @@ def _extract_checked(content: Any) -> bool:
     return bool(parsed.get("checked")) if parsed else False
 
 
+def collect_image_asset_ids(blocks: list[dict[str, Any]]) -> list[int]:
+    """Asset IDs of every `image` block, in document order, de-duplicated.
+
+    Markdown export resolves + downloads these before rendering. An image
+    block carries its numeric `assetId` in `content`; the sibling `url` is a
+    protected_static link that only works in a logged-in browser, so callers
+    swap it for a pre-signed asset URL / downloaded file.
+    """
+    ids: list[int] = []
+    for block in blocks:
+        if _normalize_type(block.get("type") or "") != "image":
+            continue
+        content = _as_content_dict(block.get("content")) or {}
+        aid = content.get("assetId")
+        if isinstance(aid, bool):
+            continue
+        if isinstance(aid, int):
+            ids.append(aid)
+        elif isinstance(aid, str) and aid.isdigit():
+            ids.append(int(aid))
+    return list(dict.fromkeys(ids))
+
+
 _READ_ALIASES = {
     # old name → normalized-for-dispatch name
     "heading": "large_title",
@@ -298,6 +325,26 @@ _LEAF_TYPES = frozenset(
 )
 
 
+def _render_image(
+    block: dict[str, Any], images: dict[str, tuple[str, str]] | None
+) -> str:
+    """`![alt](ref)` for an `image` block.
+
+    With an `images` map the asset's downloaded local filename (ref) and name
+    (alt) replace the browser-only monday `url`; without it the `url` is kept
+    so the image isn't silently dropped.
+    """
+    content = _as_content_dict(block.get("content")) or {}
+    asset_id = content.get("assetId")
+    alt = ""
+    ref = content.get("url") or ""
+    if images is not None and asset_id is not None:
+        entry = images.get(str(asset_id))
+        if entry is not None:
+            alt, ref = entry
+    return f"![{alt}]({ref})"
+
+
 def _container_marker(btype: str, has_children: bool) -> str | None:
     """Resolve the container handling for a block.
 
@@ -318,13 +365,20 @@ def _container_marker(btype: str, has_children: bool) -> str | None:
     return None
 
 
-def blocks_to_markdown(blocks: list[dict[str, Any]]) -> str:
+def blocks_to_markdown(
+    blocks: list[dict[str, Any]],
+    images: dict[str, tuple[str, str]] | None = None,
+) -> str:
     """Render a list of monday doc blocks as a markdown string.
 
     Walks the parent→children tree implied by `parent_block_id` so container
     blocks (notice/callout/layout/table) render with their inner content
     nested underneath, instead of children being detached and rendered out
     of context (issue #1).
+
+    `images` maps `str(assetId)` → `(alt_text, ref)`; when an `image` block's
+    asset is in the map its `ref` (a downloaded local filename) is emitted
+    instead of the browser-only monday `url`.
     """
     if not blocks:
         return ""
@@ -352,7 +406,7 @@ def blocks_to_markdown(blocks: list[dict[str, Any]]) -> str:
             children_of.setdefault(str(parent), []).append(b)
 
     lines: list[str] = []
-    _render_block_list(roots, children_of, "", lines)
+    _render_block_list(roots, children_of, "", lines, images)
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -361,6 +415,7 @@ def _render_table(
     children_of: dict[str, list[dict[str, Any]]],
     prefix: str,
     lines: list[str],
+    images: dict[str, tuple[str, str]] | None = None,
 ) -> bool:
     """Render a `table` block as a markdown pipe table.
 
@@ -395,6 +450,9 @@ def _render_table(
                     cell_id = str(ref)
             pieces: list[str] = []
             for child in children_of.get(cell_id, []):
+                if _normalize_type(child.get("type") or "") == "image":
+                    pieces.append(_render_image(child, images))
+                    continue
                 t = _extract_text(child.get("content"))
                 if t:
                     pieces.append(t)
@@ -425,6 +483,7 @@ def _render_block_list(
     children_of: dict[str, list[dict[str, Any]]],
     prefix: str,
     lines: list[str],
+    images: dict[str, tuple[str, str]] | None = None,
 ) -> None:
     """Render a sibling group at indentation `prefix`.
 
@@ -441,7 +500,9 @@ def _render_block_list(
         if btype != "numbered_list":
             numbered_counter = 0
 
-        if btype == "table" and _render_table(block, children_of, prefix, lines):
+        if btype == "table" and _render_table(
+            block, children_of, prefix, lines, images
+        ):
             continue
 
         marker = _container_marker(btype, has_children=bool(kids))
@@ -449,7 +510,7 @@ def _render_block_list(
             child_prefix = prefix + "> " if marker else prefix
             if marker:
                 lines.append(f"{prefix}> {marker}")
-            _render_block_list(kids, children_of, child_prefix, lines)
+            _render_block_list(kids, children_of, child_prefix, lines, images)
             lines.append("")
             continue
 
@@ -479,6 +540,8 @@ def _render_block_list(
             if text:
                 lines.append(f"{prefix}{text}")
             lines.append(f"{prefix}```")
+        elif btype == "image":
+            lines.append(f"{prefix}{_render_image(block, images)}")
         elif text:
             # normal_text + any other leaf type we haven't taught.
             lines.append(f"{prefix}{text}")
@@ -486,6 +549,6 @@ def _render_block_list(
         # Defensive: a leaf block with unexpected children would otherwise
         # drop them. Render at same prefix so content survives.
         if kids:
-            _render_block_list(kids, children_of, prefix, lines)
+            _render_block_list(kids, children_of, prefix, lines, images)
 
         lines.append("")

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -342,7 +342,9 @@ def _render_image(
         entry = images.get(str(asset_id))
         if entry is not None:
             alt, ref = entry
-    return f"![{alt}]({ref})"
+    # Escape `]` so an asset name like "a]b.png" can't close the alt span
+    # early and corrupt the surrounding markdown.
+    return f"![{alt.replace(']', r'\]')}]({ref})"
 
 
 def _container_marker(btype: str, has_children: bool) -> str | None:

--- a/tests/integration/test_live_doc_images.py
+++ b/tests/integration/test_live_doc_images.py
@@ -1,0 +1,123 @@
+"""Live integration tests for image download on doc markdown export.
+
+Both export paths must download embedded monday images into the markdown's
+folder and reference them by local filename instead of the browser-only
+`protected_static` URL:
+
+- `doc get --format markdown --out` (our client-side block renderer).
+- `doc export-markdown --out` (monday's server-side markdown).
+
+Gated by MONDO_TEST_DOC_ID; the prepared doc carries image blocks (one
+top-level, two inside a table).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from ._helpers import invoke, invoke_json
+
+# `![alt](<assetId>-<name>)` — a localized (downloaded) image reference.
+_LOCAL_IMAGE_RE = re.compile(r"!\[[^\]]*\]\((\d+-[^)]+)\)")
+
+
+@pytest.mark.integration
+def test_live_doc_get_markdown_downloads_images(live_test_doc_id: int, tmp_path) -> None:
+    out = tmp_path / "doc.md"
+    summary = invoke_json(
+        [
+            "doc", "get",
+            "--object-id", str(live_test_doc_id),
+            "--format", "markdown",
+            "--out", str(out),
+        ]
+    )
+    assert out.exists(), "markdown file not written"
+    md = out.read_text()
+
+    images = summary.get("images") or []
+    assert images, f"expected downloaded images, got summary: {summary}"
+    for fname in images:
+        assert re.match(r"\d+-", fname), f"unexpected filename scheme: {fname}"
+        downloaded = tmp_path / fname
+        assert downloaded.exists() and downloaded.stat().st_size > 0, fname
+        assert f"]({fname})" in md, f"{fname} downloaded but not referenced"
+
+    # Every image block was downloaded, so no browser-only URL should survive.
+    assert "protected_static" not in md, md
+
+
+@pytest.mark.integration
+def test_live_doc_export_markdown_downloads_images(
+    live_test_doc_id: int, tmp_path
+) -> None:
+    out = tmp_path / "exp.md"
+    summary = invoke_json(
+        [
+            "doc", "export-markdown",
+            "--object-id", str(live_test_doc_id),
+            "--out", str(out),
+        ]
+    )
+    assert out.exists(), "markdown file not written"
+    md = out.read_text()
+
+    assert summary.get("images", 0) >= 1, summary
+    refs = _LOCAL_IMAGE_RE.findall(md)
+    assert refs, f"no localized image references in export markdown:\n{md}"
+    for fname in refs:
+        downloaded = tmp_path / fname
+        assert downloaded.exists() and downloaded.stat().st_size > 0, fname
+
+    # The server emits images inside table cells too; all must be localized.
+    assert "protected_static" not in md, md
+
+
+@pytest.mark.integration
+def test_live_doc_export_no_images_keeps_urls(live_test_doc_id: int, tmp_path) -> None:
+    """`--no-images` writes the file but downloads nothing and leaves the
+    monday image URLs in place — for both export paths."""
+    get_out = tmp_path / "get.md"
+    invoke_json(
+        [
+            "doc", "get",
+            "--object-id", str(live_test_doc_id),
+            "--format", "markdown",
+            "--out", str(get_out),
+            "--no-images",
+        ]
+    )
+    exp_out = tmp_path / "exp.md"
+    invoke_json(
+        [
+            "doc", "export-markdown",
+            "--object-id", str(live_test_doc_id),
+            "--out", str(exp_out),
+            "--no-images",
+        ]
+    )
+
+    # No image files downloaded into the folder.
+    assert not list(tmp_path.glob("*.png")), list(tmp_path.glob("*.png"))
+    # URLs preserved, not rewritten to local filenames.
+    assert "protected_static" in get_out.read_text()
+    assert "protected_static" in exp_out.read_text()
+
+
+@pytest.mark.integration
+def test_live_doc_get_out_rejected_without_markdown(live_test_doc_id: int, tmp_path) -> None:
+    """`--out` only makes sense for markdown output; JSON must be rejected
+    before any fetch (exit 2)."""
+    result = invoke(
+        [
+            "doc", "get",
+            "--object-id", str(live_test_doc_id),
+            "--format", "json",
+            "--out", str(tmp_path / "doc.md"),
+        ],
+        expect_exit=None,
+    )
+    assert result.exit_code == 2, result.stderr
+    assert "--out is only valid with --format markdown" in result.stderr

--- a/tests/integration/test_live_doc_images.py
+++ b/tests/integration/test_live_doc_images.py
@@ -64,9 +64,12 @@ def test_live_doc_export_markdown_downloads_images(
     assert out.exists(), "markdown file not written"
     md = out.read_text()
 
-    assert summary.get("images", 0) >= 1, summary
+    # `images` is the list of localized filenames (same shape as `doc get`).
+    localized = summary.get("images") or []
+    assert localized, summary
     refs = _LOCAL_IMAGE_RE.findall(md)
     assert refs, f"no localized image references in export markdown:\n{md}"
+    assert set(refs) == set(localized), (refs, localized)
     for fname in refs:
         downloaded = tmp_path / fname
         assert downloaded.exists() and downloaded.stat().st_size > 0, fname

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -1667,3 +1667,70 @@ class TestDocSet:
         result = runner.invoke(app, ["doc", "set", "--doc", "10"])
         assert result.exit_code == 2
         assert httpx_mock.get_requests() == []
+
+
+class TestImageExportOutputGuards:
+    """`--out` (markdown→file + image download) flag validation. Both guards
+    must reject before any network call."""
+
+    def test_get_out_requires_markdown_format(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app,
+            ["doc", "get", "--object-id", "77", "--format", "json", "--out", "x.md"],
+        )
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_export_markdown_raw_and_out_mutually_exclusive(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        result = runner.invoke(
+            app,
+            ["doc", "export-markdown", "--doc", "10", "--raw", "--out", "x.md"],
+        )
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_get_no_images_skips_asset_download(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        """`--no-images` writes the file but never queries `assets(ids)` or
+        fetches image bytes — the monday URL stays in the markdown."""
+        httpx_mock.add_response(
+            json={
+                "data": {
+                    "docs": [
+                        {
+                            "id": "7",
+                            "object_id": "77",
+                            "name": "D",
+                            "blocks": [
+                                {
+                                    "id": "b1",
+                                    "type": "image",
+                                    "content": json.dumps(
+                                        {"assetId": 99, "url": "https://x/img.png"}
+                                    ),
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        )
+        out = tmp_path / "doc.md"
+        result = runner.invoke(
+            app,
+            [
+                "doc", "get", "--id", "7",
+                "--format", "markdown",
+                "--out", str(out),
+                "--no-images",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        # Only the doc fetch happened — no assets(ids) call.
+        assert len(httpx_mock.get_requests()) == 1
+        md = out.read_text()
+        assert "![](https://x/img.png)" in md
+        assert json.loads(result.stdout)["images"] == []

--- a/tests/unit/test_doc_images.py
+++ b/tests/unit/test_doc_images.py
@@ -1,0 +1,82 @@
+"""Tests for mondo.cli._doc_images — pure filename / markdown-rewrite helpers.
+
+The download/resolve paths hit the network and `assets(ids)`, so they're
+exercised by the live integration suite; here we cover the pure logic.
+"""
+
+from __future__ import annotations
+
+from mondo.cli._doc_images import (
+    extract_asset_ids_from_markdown,
+    local_filename,
+    rewrite_markdown_images,
+)
+
+
+class TestLocalFilename:
+    def test_prefixes_asset_id_to_name(self) -> None:
+        assert (
+            local_filename(238776078, "image-from-clipboard.png", ".png")
+            == "238776078-image-from-clipboard.png"
+        )
+
+    def test_collision_names_stay_unique_via_id(self) -> None:
+        """Clipboard images share a name; the id prefix keeps them distinct."""
+        a = local_filename(1, "image-from-clipboard.png", ".png")
+        b = local_filename(2, "image-from-clipboard.png", ".png")
+        assert a != b
+        assert a == "1-image-from-clipboard.png"
+
+    def test_falls_back_to_extension_when_no_name(self) -> None:
+        assert local_filename(99, None, ".jpg") == "99-asset.jpg"
+
+    def test_no_name_no_extension(self) -> None:
+        assert local_filename(99, None, None) == "99-asset"
+
+    def test_sanitizes_unsafe_characters(self) -> None:
+        assert local_filename(5, "a b/c?.png", ".png") == "5-a-b-c-.png"
+
+
+class TestExtractAssetIds:
+    def test_extracts_protected_static_ids(self) -> None:
+        md = (
+            "![Image: ](https://acme.monday.com/protected_static/1/"
+            "resources/238776078/image-from-clipboard.png)"
+        )
+        assert extract_asset_ids_from_markdown(md) == [238776078]
+
+    def test_ignores_external_images(self) -> None:
+        md = "![a](https://example.test/img.png)"
+        assert extract_asset_ids_from_markdown(md) == []
+
+    def test_dedupes_preserving_order(self) -> None:
+        md = (
+            "![](https://x/resources/20/a.png) "
+            "![](https://x/resources/10/b.png) "
+            "![](https://x/resources/20/a.png)"
+        )
+        assert extract_asset_ids_from_markdown(md) == [20, 10]
+
+    def test_finds_images_inside_table_cells(self) -> None:
+        md = (
+            "| ![](https://x/resources/110/a.png) "
+            "| ![](https://x/resources/117/b.png) |"
+        )
+        assert extract_asset_ids_from_markdown(md) == [110, 117]
+
+
+class TestRewriteMarkdownImages:
+    def test_rewrites_mapped_id_keeps_alt(self) -> None:
+        md = "![Image: ](https://x/resources/55/foo.png)"
+        assert (
+            rewrite_markdown_images(md, {55: "55-foo.png"})
+            == "![Image: ](55-foo.png)"
+        )
+
+    def test_unmapped_id_keeps_url(self) -> None:
+        md = "![](https://x/resources/55/foo.png)"
+        assert rewrite_markdown_images(md, {}) == md
+
+    def test_external_image_untouched(self) -> None:
+        md = "![](https://example.test/img.png)"
+        assert rewrite_markdown_images(md, {1: "x.png"}) == md

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -6,6 +6,7 @@ import pytest
 
 from mondo.docs import (
     blocks_to_markdown,
+    collect_image_asset_ids,
     extract_doc_ids_from_column_value,
     markdown_to_blocks,
 )
@@ -221,6 +222,81 @@ class TestBlocksToMarkdown:
 
     def test_empty_block_list(self) -> None:
         assert blocks_to_markdown([]) == ""
+
+
+class TestBlocksToMarkdownImages:
+    def _image(self, asset_id: int | None, url: str = "") -> dict:
+        content: dict = {"url": url}
+        if asset_id is not None:
+            content["assetId"] = asset_id
+        return {"type": "image", "content": content}
+
+    def test_image_without_map_emits_monday_url(self) -> None:
+        """No download map → degrade to the (browser-only) monday url rather
+        than silently dropping the image."""
+        out = blocks_to_markdown([self._image(238776078, "https://x/img.png")])
+        assert "![](https://x/img.png)" in out
+
+    def test_image_with_map_uses_local_filename_and_alt(self) -> None:
+        out = blocks_to_markdown(
+            [self._image(238776078, "https://x/img.png")],
+            images={"238776078": ("photo.png", "238776078-photo.png")},
+        )
+        assert "![photo.png](238776078-photo.png)" in out
+
+    def test_image_with_unmapped_asset_keeps_url(self) -> None:
+        out = blocks_to_markdown(
+            [self._image(999, "https://x/img.png")],
+            images={"238776078": ("photo.png", "238776078-photo.png")},
+        )
+        assert "![](https://x/img.png)" in out
+
+    def test_image_normalizes_spaced_type(self) -> None:
+        """monday returns the type as `"image"` already, but reads pass through
+        `_normalize_type`; a spaced variant must still render."""
+        block = {"type": "image", "content": {"assetId": 1, "url": "u"}}
+        assert "![](u)" in blocks_to_markdown([block])
+
+    def test_nested_image_inside_notice_renders(self) -> None:
+        blocks = [
+            {"id": "n", "type": "notice_box", "content": {}},
+            {
+                "id": "i",
+                "type": "image",
+                "parent_block_id": "n",
+                "content": {"assetId": 7, "url": "https://x/n.png"},
+            },
+        ]
+        out = blocks_to_markdown(
+            blocks, images={"7": ("n.png", "7-n.png")}
+        )
+        assert "> ![n.png](7-n.png)" in out
+
+
+class TestCollectImageAssetIds:
+    def test_collects_in_order_deduped(self) -> None:
+        blocks = [
+            {"type": "image", "content": {"assetId": 20}},
+            {"type": "normal text", "content": {}},
+            {"type": "image", "content": {"assetId": 10}},
+            {"type": "image", "content": {"assetId": 20}},
+        ]
+        assert collect_image_asset_ids(blocks) == [20, 10]
+
+    def test_accepts_string_asset_id(self) -> None:
+        assert collect_image_asset_ids(
+            [{"type": "image", "content": '{"assetId":"55"}'}]
+        ) == [55]
+
+    def test_skips_image_without_asset_id(self) -> None:
+        assert collect_image_asset_ids(
+            [{"type": "image", "content": {"url": "u"}}]
+        ) == []
+
+    def test_ignores_non_image_blocks(self) -> None:
+        assert collect_image_asset_ids(
+            [{"type": "normal_text", "content": {"assetId": 1}}]
+        ) == []
 
 
 class TestBlocksToMarkdownContainers:
@@ -439,6 +515,27 @@ class TestBlocksToMarkdownTables:
                 if txt:
                     blocks.append(self._cell_text(f"{cid}-t", cid, txt))
         return blocks
+
+    def test_image_inside_cell_renders_with_local_filename(self) -> None:
+        """Table cells can hold image children (not just text). They must
+        render so downloaded images aren't orphaned (no markdown reference)."""
+        blocks = [
+            {
+                "id": "t",
+                "type": "table",
+                "content": self._table_payload([["t-c0-0"]]),
+                "parent_block_id": None,
+            },
+            self._cell("t-c0-0", "t"),
+            {
+                "id": "img",
+                "type": "image",
+                "content": {"assetId": 7, "url": "https://x/n.png"},
+                "parent_block_id": "t-c0-0",
+            },
+        ]
+        out = blocks_to_markdown(blocks, images={"7": ("n.png", "7-n.png")})
+        assert "| ![n.png](7-n.png) |" in out
 
     def test_simple_2x2_table_renders_as_pipe_table(self) -> None:
         blocks = self._build_table(

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -257,6 +257,15 @@ class TestBlocksToMarkdownImages:
         block = {"type": "image", "content": {"assetId": 1, "url": "u"}}
         assert "![](u)" in blocks_to_markdown([block])
 
+    def test_image_alt_escapes_closing_bracket(self) -> None:
+        """An asset name containing `]` must not close the alt span early and
+        corrupt the markdown."""
+        out = blocks_to_markdown(
+            [self._image(1, "https://x/img.png")],
+            images={"1": ("a]b.png", "1-a-b.png")},
+        )
+        assert "![a\\]b.png](1-a-b.png)" in out
+
     def test_nested_image_inside_notice_renders(self) -> None:
         blocks = [
             {"id": "n", "type": "notice_box", "content": {}},


### PR DESCRIPTION
## What

Doc markdown export now handles embedded images. Adds `--out FILE` to **both** `doc get --format markdown` and `doc export-markdown`: writes the markdown to `FILE` and downloads embedded images into the **same folder**, referencing them by `<assetId>-<name>` local filename.

### Why
- `doc get --format markdown` previously **dropped image blocks entirely** (the renderer had no `image` case, and the block's text content is empty).
- `doc export-markdown` emitted monday `protected_static` URLs, which only resolve in a logged-in browser (`302 → /users/sign_in` even with an API token) — useless once the markdown leaves monday.

The real download URL is the pre-signed S3 `public_url` from `assets(ids)`. Filenames use `<assetId>-<name>` because clipboard images all share the name `image-from-clipboard.png` and would otherwise collide.

## Changes
- **`docs.py`** — render `image` blocks as `![alt](ref)`. An optional `images` map (`assetId → (alt, local_filename)`) swaps the browser-only `url` for a downloaded local file; without it the `url` is kept (no more silent drops). Images **inside table cells** render too, so downloads aren't orphaned. New `collect_image_asset_ids`.
- **`cli/_doc_images.py`** (new) — reuses the existing `ASSETS_GET` query and the `httpx.stream(..., follow_redirects=True)` download pattern from `file.py`. Block-tree download for `doc get`; regex URL-rewrite (extracting assetId from `/resources/<id>/`) for the server-rendered `doc export-markdown`.
- **`cli/doc.py`** — `--out` on both commands; `--no-images` opt-out (keep URLs, skip download) following the `--no-cache` convention. Guards: `--out` requires markdown format; `--raw`/`--out` mutually exclusive.
- Docs: README, `--help` examples, CLAUDE.md (test-doc now carries image blocks).

## Testing
- **Unit** (`test_docs.py`, `test_doc_images.py`, `test_cli_doc.py`): renderer image cases, table-cell images, asset-id collection, filename/regex helpers, CLI guards, `--no-images` skips the `assets` call. Full suite: **1597 pass**.
- **Live** (`test_live_doc_images.py`): both export paths download all images and reference them locally with no `protected_static` left; `--no-images` downloads nothing and preserves URLs. **4 pass** against the prepared playground doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)