### PR TITLE
docs: sync doc surfaces with 0.9.x features

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ mondo doc get            --object-id 77   # URL-visible id
 mondo doc get            --id 7 --format markdown    # render blocks → markdown
 mondo doc get            --id 7 --format markdown --out ./doc.md  # +download images beside the file
 mondo doc get            --id 7 --format markdown --out ./doc.md --no-images  # skip download, keep URLs
-mondo doc export-markdown --doc 7                    # always-live markdown export
+mondo doc export-markdown --doc 7                    # always-live markdown export (--no-cache/--refresh-cache accepted as no-ops)
 mondo doc export-markdown --doc 7 --out ./doc.md     # +download images, rewrite URLs to local files
 mondo doc export-markdown --doc 7 --out ./doc.md --no-images  # skip download, keep URLs
 mondo doc create         --workspace 42 --name "Spec" --kind public [--folder 3042556]

--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -517,10 +517,13 @@
   },
   {
     "command": "doc export-markdown",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: result",
-    "source": "doc.py"
+    "output_type": "string | object",
+    "fields": [
+      "out?",
+      "images?"
+    ],
+    "notes": "Prints monday's server-rendered markdown to stdout by default. With --out FILE, writes the markdown to FILE and emits {out, images} where images is the list of localized image filenames downloaded beside it (empty with --no-images). Always live (no per-doc cache): --no-cache / --refresh-cache are accepted as no-ops.",
+    "source": "EXPORT_MARKDOWN_FROM_DOC + localize_markdown_images"
   },
   {
     "command": "doc get",
@@ -539,7 +542,7 @@
       "created_by{id,name}",
       "blocks{id,type,content,parent_block_id}"
     ],
-    "notes": "Default format is JSON object above. --format markdown prints markdown text instead.",
+    "notes": "Default format is JSON object above. --format markdown prints markdown text instead. With --format markdown --out FILE, writes the markdown to FILE and emits {out, images} where images is the list of localized image filenames downloaded beside it (empty with --no-images). --out requires --format markdown (exit 2 otherwise).",
     "source": "DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]"
   },
   {

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -231,15 +231,15 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   source: `DOC_HEAD_BY_OBJECT_ID.docs[0]{id,object_id,name,url}`
   notes: Emits a slim doc header for the newly created duplicate; fetched via DOC_HEAD_BY_OBJECT_ID.
 - `doc export-markdown`
-  type: `manual-review`
-  fields: none
-  source: `doc.py`
-  notes: Could not auto-infer. Final emit expression: result
+  type: `string | object`
+  fields: `out?`, `images?`
+  source: `EXPORT_MARKDOWN_FROM_DOC + localize_markdown_images`
+  notes: Prints monday's server-rendered markdown to stdout by default. With --out FILE, writes the markdown to FILE and emits {out, images} where images is the list of localized image filenames downloaded beside it (empty with --no-images). Always live (no per-doc cache): --no-cache / --refresh-cache are accepted as no-ops.
 - `doc get`
   type: `object | string`
   fields: `id`, `object_id`, `name`, `doc_kind`, `doc_folder_id`, `created_at`, `updated_at`, `url`, `relative_url`, `workspace_id`, `created_by{id,name}`, `blocks{id,type,content,parent_block_id}`
   source: `DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]`
-  notes: Default format is JSON object above. --format markdown prints markdown text instead.
+  notes: Default format is JSON object above. --format markdown prints markdown text instead. With --format markdown --out FILE, writes the markdown to FILE and emits {out, images} where images is the list of localized image filenames downloaded beside it (empty with --no-images). --out requires --format markdown (exit 2 otherwise).
 - `doc import-html`
   type: `object`
   fields: `error`, `success`, `doc_id`

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -388,8 +388,25 @@ MANUAL_ROWS: dict[str, Row] = {
             "created_by{id,name}",
             "blocks{id,type,content,parent_block_id}",
         ],
-        notes="Default format is JSON object above. --format markdown prints markdown text instead.",
+        notes=(
+            "Default format is JSON object above. --format markdown prints markdown text "
+            "instead. With --format markdown --out FILE, writes the markdown to FILE and emits "
+            "{out, images} where images is the list of localized image filenames downloaded "
+            "beside it (empty with --no-images). --out requires --format markdown (exit 2 otherwise)."
+        ),
         source="DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]",
+    ),
+    "doc export-markdown": Row(
+        command="doc export-markdown",
+        output_type="string | object",
+        fields=["out?", "images?"],
+        notes=(
+            "Prints monday's server-rendered markdown to stdout by default. With --out FILE, "
+            "writes the markdown to FILE and emits {out, images} where images is the list of "
+            "localized image filenames downloaded beside it (empty with --no-images). Always "
+            "live (no per-doc cache): --no-cache / --refresh-cache are accepted as no-ops."
+        ),
+        source="EXPORT_MARKDOWN_FROM_DOC + localize_markdown_images",
     ),
     "doc list": Row(
         command="doc list",

--- a/src/mondo/help/agent-tips.md
+++ b/src/mondo/help/agent-tips.md
@@ -148,6 +148,11 @@ circuit through the directory cache (`workspace / folder / team get`,
 force a fresh fetch use `--no-cache` or `--refresh-cache` on the same
 command. See `docs/caching.md` for the per-entity TTL table.
 
+`doc export-markdown` has no per-doc cache (it's always live), so it
+accepts `--no-cache` / `--refresh-cache` as no-ops — purely for flag
+symmetry with the other doc commands; they neither error nor change the
+result.
+
 ## Structured error envelope (`-o json|jsonc|yaml`)
 
 Every CLI error in machine-output mode emits a JSON line on

--- a/src/mondo/help/boards-vs-docs.md
+++ b/src/mondo/help/boards-vs-docs.md
@@ -55,6 +55,20 @@ On `board list` and `doc list`, `--with-url` is opt-in: the default output
 has no `url` / `relative_url` so the two commands emit the same core shape.
 Pass `--with-url` on either to get URLs back.
 
+## Once you've found a workdoc
+
+Render it to a markdown file (embedded images are downloaded alongside it,
+referenced by local filename — the raw monday image URLs only resolve in a
+logged-in browser):
+
+    mondo doc get --object-id <id> --format markdown --out ./doc.md
+    mondo doc export-markdown --object-id <id> --out ./doc.md   # server-side render
+
+Pass `--no-images` to skip the download and keep the original URLs. To write
+content back — replace a doc in place, or create one inside a folder — see
+`mondo help` and the bundled `references/docs.md` (`doc set` / `doc replace`,
+`doc create --folder`).
+
 ## Agent workflow
 
 1. Paste any monday URL into the command that matches its shape.

--- a/src/mondo/help/duplicate-and-customize.md
+++ b/src/mondo/help/duplicate-and-customize.md
@@ -59,6 +59,20 @@ options:
 See `mondo help batch-operations` for the full filter vocabulary,
 ambiguous-match behaviour, and `--first`.
 
+## Step 2b — Add a typed column (optional)
+
+If the customized board needs a new status/dropdown column, `column
+create --labels` seeds the initial labels in one call — no hand-built
+`--defaults` JSON:
+
+    mondo column create --board 9876543210 \
+        --title "Priority" --type status \
+        --labels "High,Medium,Low"
+
+`--labels` is a comma-separated list, applies only to `status` /
+`dropdown`, and is mutually exclusive with `--defaults` (use `--defaults`
+for any other column type or for advanced settings).
+
 ## Step 3 — Bulk seed items
 
 Seeding N items as N separate `mondo item create` calls is N HTTP

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mondo
 description: Use when the user wants to do anything against monday.com via the `mondo` CLI — reading or writing workspaces, folders, boards, groups, items, subitems, columns, updates, docs, files, users, teams, webhooks, or when they paste a monday.com URL.
-version: "1.3.0"
+version: "1.4.0"
 ---
 
 # mondo

--- a/src/mondo/skill/references/docs.md
+++ b/src/mondo/skill/references/docs.md
@@ -41,9 +41,29 @@ mondo doc get --object-id 5098297247 --format json -o json
 # Render to Markdown (--object-id for the URL-visible id, --doc for the internal id):
 mondo doc export-markdown --object-id 5098297247
 mondo doc export-markdown --doc 5095668848
+
+# Client-side render via `doc get` (prints markdown to stdout):
+mondo doc get --object-id 5098297247 --format markdown
 ```
 
+Two markdown paths exist: `doc export-markdown` (monday's server-side renderer) and `doc get --format markdown` (mondo's client-side block renderer). Both print to stdout by default.
+
 *Note:* `export-markdown` is always live (it has no per-doc cache), so `--no-cache` / `--refresh-cache` are accepted as no-ops purely for symmetry with the other doc commands.
+
+### Write markdown to a file (and download embedded images)
+
+Add `--out FILE` to either command to write the markdown to a file. Embedded monday images are downloaded into the **same folder** and referenced by a local `<assetId>-<name>` filename — because the raw `protected_static` image URLs only resolve in a logged-in browser, so the bare markdown is useless off-platform.
+
+```bash
+mondo doc get --object-id 5098297247 --format markdown --out ./spec.md
+mondo doc export-markdown --object-id 5098297247 --out ./spec.md
+```
+
+```json
+{"out": "spec.md", "images": ["238776078-image-from-clipboard.png", "238776079-diagram.png"]}
+```
+
+*Gotchas:* `--out` requires `--format markdown` on `doc get` (it's rejected with exit 2 for JSON). Pass `--no-images` to skip the download and leave the original monday URLs in place. The `images` field lists the local filenames actually written next to the markdown (images inside table cells are downloaded too, so references aren't orphaned).
 
 ```json
 {


### PR DESCRIPTION
## Summary

Audited every documentation surface against the features shipped in **0.9.0 → 0.9.3** (doc image export to file, `doc set`/`replace`, `doc create --folder`, `column create --labels`, `group rename --name`, `export-markdown` no-op cache flags).

**Finding:** nothing was factually *wrong* (no stale claims like "images are dropped" or "cache flags rejected) — the gaps were all **missing mentions** plus one stale auto-generated contract-matrix row. This PR closes them.

## Changes

- **`skill/references/docs.md`** — document `doc get --format markdown --out` and `doc export-markdown --out` (+ `--no-images`). This is the marquee 0.9.3 feature and it was entirely absent from the primary agent-facing reference. Bump **SKILL.md `1.3.0` → `1.4.0`** so the freshness checker nudges a re-pull.
- **`docs/output-contract-matrix.{md,json}`** — add a `doc export-markdown` `MANUAL_ROW` (was *"could not auto-infer"*) and document the `doc get --out` `{out, images}` variant; regenerated via `scripts/generate_output_contract_matrix.py`.
- **`help/boards-vs-docs.md`** — "once you've found a workdoc" → render-to-file section.
- **`help/duplicate-and-customize.md`** — `column create --labels` sub-step.
- **`help/agent-tips.md`** — note `export-markdown` cache flags are accepted as no-ops.
- **`README.md`** — same no-op note on the `doc export-markdown` line.

## Verification

- `scripts/generate_output_contract_matrix.py` regenerated cleanly; both doc rows now correct.
- `uv run pytest -k "matrix or help or skill or contract"` → **79 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)