### PR TITLE
refactor: extract CLI business logic into a service layer (item, doc, board)

### DIFF
--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -215,7 +215,7 @@
       "<updated board metadata?>"
     ],
     "notes": "Emits monday's update_board payload directly. Legacy stringified JSON is parsed before emit; non-JSON scalars pass through unchanged.",
-    "source": "_decode_json_string_payload(data.get(\"update_board\"))"
+    "source": "decode_json_string_payload(data.get(\"update_board\"))"
   },
   {
     "command": "cache clear",

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -92,7 +92,7 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
 - `board update`
   type: `object | scalar`
   fields: `success?`, `<updated board metadata?>`
-  source: `_decode_json_string_payload(data.get("update_board"))`
+  source: `decode_json_string_payload(data.get("update_board"))`
   notes: Emits monday's update_board payload directly. Legacy stringified JSON is parsed before emit; non-JSON scalars pass through unchanged.
 
 ## cache

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -207,7 +207,7 @@ MANUAL_ROWS: dict[str, Row] = {
             "Emits monday's update_board payload directly. Legacy stringified JSON is parsed "
             "before emit; non-JSON scalars pass through unchanged."
         ),
-        source='_decode_json_string_payload(data.get("update_board"))',
+        source='decode_json_string_payload(data.get("update_board"))',
     ),
     "cache clear": Row(
         command="cache clear",

--- a/src/mondo/cli/board.py
+++ b/src/mondo/cli/board.py
@@ -7,7 +7,6 @@ applied client-side after retrieval.
 
 from __future__ import annotations
 
-import json
 import re
 from enum import StrEnum
 from typing import Any
@@ -43,6 +42,13 @@ from mondo.cli._json_flag import parse_json_flag
 from mondo.cli._resolve import resolve_required_id
 from mondo.cli._url import MondayIdParam
 from mondo.cli.context import GlobalOpts
+from mondo.services.boards import (
+    BoardTypeFilter,
+    decode_json_string_payload,
+    fetch_items_count,
+    projection_wants_items_count,
+    type_matches,
+)
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -66,43 +72,6 @@ class BoardState(StrEnum):
 class BoardOrderBy(StrEnum):
     used_at = "used_at"
     created_at = "created_at"
-
-
-class BoardTypeFilter(StrEnum):
-    """`--type` selector on `board list`.
-
-    monday's `boards()` query returns both real boards and workdoc-backing
-    boards (monday models every workdoc as a board with `type=="document"`).
-    The CLI hides docs by default; pass `--type doc` to list only docs, or
-    `--type all` to see everything including non-standard types such as
-    `sub_items_board` and `custom_object`.
-    """
-
-    board = "board"
-    doc = "doc"
-    all = "all"
-
-
-# Mapping from CLI filter → monday's `Board.type` server value.
-_BOARD_TYPE_SERVER_VALUE: dict[BoardTypeFilter, str] = {
-    BoardTypeFilter.board: "board",
-    BoardTypeFilter.doc: "document",
-}
-
-
-def _type_matches(entry: dict[str, Any], type_filter: BoardTypeFilter) -> bool:
-    """Return True when `entry` should pass the `--type` filter.
-
-    Entries cached before schema_version 2 lack `type`; we don't want those
-    to silently disappear under `--type board` (the common default). The
-    schema_version bump forces a one-off refresh so this branch should only
-    matter in the edge case of an in-memory fetch before the cache is warm.
-    Treat missing as `"board"` to keep behavior predictable.
-    """
-    if type_filter is BoardTypeFilter.all:
-        return True
-    observed = entry.get("type") or "board"
-    return observed == _BOARD_TYPE_SERVER_VALUE[type_filter]
 
 
 class BoardAttribute(StrEnum):
@@ -142,16 +111,6 @@ def _resolve_source_workspace(opts: GlobalOpts, board_id: int) -> int | None:
         return int(ws)
     except TypeError, ValueError:
         return None
-
-
-def _decode_json_string_payload(value: Any) -> Any:
-    """Parse monday's legacy stringified-JSON mutation payloads when possible."""
-    if not isinstance(value, str):
-        return value
-    try:
-        return json.loads(value)
-    except json.JSONDecodeError:
-        return value
 
 
 # ----- read commands -----
@@ -367,7 +326,7 @@ def list_cmd(
                         max_items=None,  # client-side filters applied below
                     )
                 )
-                if _type_matches(b, type_filter) and _name_matches(b, needle_lower, pattern)
+                if type_matches(b, type_filter) and _name_matches(b, needle_lower, pattern)
             ]
     except MondoError as e:
         handle_mondo_error_or_exit(e)
@@ -474,7 +433,7 @@ def _list_via_cache(
     if kind is not None:
         entries = [b for b in entries if (b.get("kind") or "") == kind.value]
     if type_filter is not BoardTypeFilter.all:
-        entries = [b for b in entries if _type_matches(b, type_filter)]
+        entries = [b for b in entries if type_matches(b, type_filter)]
     if workspace:
         wanted = {str(w) for w in workspace}
         entries = [b for b in entries if str(b.get("workspace_id") or "") in wanted]
@@ -611,8 +570,8 @@ def get_cmd(
                 )
                 emit_cache_provenance(opts, cached, store=store, explain=explain_cache)
                 board = cached.entries[0] if cached.entries else None
-                if board is not None and _projection_wants_items_count(opts):
-                    items_count = _fetch_items_count(client, board_id)
+                if board is not None and projection_wants_items_count(opts):
+                    items_count = fetch_items_count(client, board_id)
                     board = {**board, "items_count": items_count}
         except NotFoundError:
             board = None
@@ -628,43 +587,6 @@ def get_cmd(
             board = {**board, "url": board_url(get_tenant_slug(client), board_id)}
     board = normalize_board_entry(board)
     opts.emit(board, selected_fields=board_get_fields(with_views=with_views))
-
-
-def _projection_wants_items_count(opts: GlobalOpts) -> bool:
-    """Skip the live `items_count` merge when the caller's projection won't
-    surface it. Default behavior (no `-q`/`--fields`) returns True so the
-    field stays in the emitted payload as it did pre-cache; with an explicit
-    projection we only pay the round-trip if `items_count` actually appears.
-
-    The check is intentionally lenient (substring): a JMESPath expression
-    or comma-separated field list that mentions `items_count` keeps the
-    merge; anything else skips it. False negatives just mean the cached
-    `items_count: null` flows through — accurate per the cache contract.
-    """
-    needle = "items_count"
-    if opts.query and needle in opts.query:
-        return True
-    if opts.fields and needle in opts.fields:
-        return True
-    return opts.query is None and opts.fields is None
-
-
-def _fetch_items_count(client: Any, board_id: int) -> int | None:
-    """One-field live fetch for the volatile items_count field. Used to merge
-    a fresh count onto a `board_details` cache hit so the cache file stays
-    invalidation-free of item writes. Returns None on any unexpected shape."""
-    from mondo.api.queries import BOARD_ITEMS_COUNT
-    from mondo.cli._exec import exec_or_exit
-
-    data = exec_or_exit(client, BOARD_ITEMS_COUNT, {"ids": [board_id]})
-    boards = data.get("boards") or []
-    if not boards:
-        return None
-    raw = boards[0].get("items_count")
-    try:
-        return int(raw) if raw is not None else None
-    except TypeError, ValueError:
-        return None
 
 
 # ----- write commands -----
@@ -753,7 +675,7 @@ def update_cmd(
         {"board": board_id, "attribute": attribute.value, "value": value},
     )
     invalidate_board_caches(opts, board_id)
-    opts.emit(_decode_json_string_payload(data.get("update_board")))
+    opts.emit(decode_json_string_payload(data.get("update_board")))
 
 
 @app.command("set-permission", epilog=epilog_for("board set-permission"))

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -57,6 +57,12 @@ from mondo.cli._json_flag import parse_json_flag
 from mondo.cli._resolve import resolve_required_id
 from mondo.cli._url import MondayIdParam
 from mondo.cli.context import GlobalOpts
+from mondo.services.docs import (
+    last_block_id,
+    object_id_hint,
+    object_id_hint_with_client,
+    resolve_doc_id_from_object_id,
+)
 
 if TYPE_CHECKING:
     from mondo.api.client import MondayClient
@@ -196,17 +202,6 @@ def _fetch_doc_by_object_id_all_blocks(
         query=DOCS_BY_OBJECT_ID_BLOCKS_PAGE,
         identity={"objs": [object_id]},
     )
-
-
-def _last_block_id(doc: dict[str, Any]) -> str | None:
-    blocks = doc.get("blocks") or []
-    if not blocks:
-        return None
-    last = blocks[-1]
-    if not isinstance(last, dict):
-        return None
-    last_id = last.get("id")
-    return str(last_id) if last_id else None
 
 
 # ----- read commands -----
@@ -608,7 +603,7 @@ def get_cmd(
                 resolved_doc_id = (
                     doc_id
                     if doc_id is not None
-                    else _resolve_doc_id_from_object_id(opts, client, object_id or 0)
+                    else resolve_doc_id_from_object_id(opts, client, object_id or 0)
                 )
             else:
                 resolved_doc_id = None
@@ -646,31 +641,6 @@ def get_cmd(
         return
     doc = normalize_doc_entry(doc)
     opts.emit(doc)
-
-
-def _resolve_doc_id_from_object_id(
-    opts: GlobalOpts, client: MondayClient, object_id: int
-) -> int | None:
-    """Map a URL-visible `object_id` to its internal `doc_id` via the docs
-    directory cache (auto-populated on miss). Returns None when the
-    object_id isn't visible — the caller falls back to a live fetch.
-    """
-    from mondo.cache.directory import get_docs as _cache_get_docs
-
-    target = str(object_id)
-    store = opts.build_cache_store("docs")
-    try:
-        cached = _cache_get_docs(client, store=store, refresh=False)
-    except MondoError:
-        return None
-    for entry in cached.entries:
-        if str(entry.get("object_id")) == target:
-            raw = entry.get("id")
-            try:
-                return int(raw) if raw is not None else None
-            except TypeError, ValueError:
-                return None
-    return None
 
 
 def _emit_doc_not_found(
@@ -714,44 +684,15 @@ def _emit_doc_not_found(
 _OBJECT_ID_HINT_EXIT_CODES = frozenset({1, 5, 6, 7})
 
 
-def _object_id_hint_with_client(client: MondayClient, doc_id: int) -> str | None:
-    """Probe whether a failing `--doc` id is actually a URL-visible object_id
-    (the id a human copies out of a `/docs/<id>` URL). Returns the targeted
-    hint when it resolves; never raises — the probe must not mask the
-    original error.
-    """
-    try:
-        result = client.execute(DOC_HEAD_BY_OBJECT_ID, {"objs": [doc_id]})
-        docs = (result.get("data") or {}).get("docs") or []
-    except Exception:
-        return None
-    if not docs:
-        return None
-    return (
-        f"hint: {doc_id} looks like a URL-visible object id, not an internal "
-        f"doc id — retry with --object-id {doc_id}"
-    )
-
-
 def _emit_doc_id_not_found(client: MondayClient, doc_id: int, *, probe: bool) -> None:
     """Standard `doc id=X not found.` line, plus the object-id retry hint
     when the id was user-supplied via `--doc` (`probe=True`)."""
     line = f"doc id={doc_id} not found."
     if probe:
-        hint = _object_id_hint_with_client(client, doc_id)
+        hint = object_id_hint_with_client(client, doc_id)
         if hint is not None:
             line = f"{line}\n{hint}"
     typer.secho(line, fg=typer.colors.RED, err=True)
-
-
-def _object_id_hint(opts: GlobalOpts, doc_id: int) -> str | None:
-    """`_object_id_hint_with_client` with a fresh short-lived client."""
-    try:
-        client = opts.build_client()
-        with client:
-            return _object_id_hint_with_client(client, doc_id)
-    except Exception:
-        return None
 
 
 def _fail_with_object_id_hint(opts: GlobalOpts, err_line: str, doc_id: int | None) -> NoReturn:
@@ -762,7 +703,7 @@ def _fail_with_object_id_hint(opts: GlobalOpts, err_line: str, doc_id: int | Non
     mutation-level 500 ("Fetcher response returned NON-OK status=500") —
     probe before giving up.
     """
-    hint = _object_id_hint(opts, doc_id) if doc_id is not None else None
+    hint = object_id_hint(opts, doc_id) if doc_id is not None else None
     handle_mondo_error_or_exit(ValidationError(err_line), human_suffix=hint)
 
 
@@ -802,7 +743,7 @@ def _resolve_doc_in_client(
     assert object_id is not None
     resolved: int | None = None
     if opts.resolve_cache_config().enabled:
-        resolved = _resolve_doc_id_from_object_id(opts, client, object_id)
+        resolved = resolve_doc_id_from_object_id(opts, client, object_id)
     if resolved is None:
         resolved = _resolve_object_id_live(client, object_id)
     if resolved is None:
@@ -842,7 +783,7 @@ def _execute_doc_command(
             except MondoError as e:
                 suffix = None
                 if doc_id is not None and int(e.exit_code) in _OBJECT_ID_HINT_EXIT_CODES:
-                    suffix = _object_id_hint_with_client(client, doc_id)
+                    suffix = object_id_hint_with_client(client, doc_id)
                 handle_mondo_error_or_exit(e, human_suffix=suffix)
             return (result.get("data") or {}), resolved
     except MondoError as e:
@@ -931,7 +872,7 @@ def add_block_cmd(
                 if existing_doc is None:
                     _emit_doc_id_not_found(client, resolved_doc, probe=doc_id is not None)
                     raise typer.Exit(code=6)
-                effective_after = _last_block_id(existing_doc)
+                effective_after = last_block_id(existing_doc)
             data = exec_or_exit(client, CREATE_DOC_BLOCK, _variables(resolved_doc, effective_after))
     except MondoError as e:
         handle_mondo_error_or_exit(e)
@@ -993,7 +934,7 @@ def add_content_cmd(
             if existing_doc is None:
                 _emit_doc_id_not_found(client, resolved_doc, probe=doc_id is not None)
                 raise typer.Exit(code=6)
-            prev_id = _last_block_id(existing_doc)
+            prev_id = last_block_id(existing_doc)
             created = create_blocks(client, resolved_doc, blocks, after_block_id=prev_id)
     except MondoError as e:
         handle_mondo_error_or_exit(e)

--- a/src/mondo/cli/item.py
+++ b/src/mondo/cli/item.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-import sys
 from contextlib import nullcontext
 from enum import StrEnum
 from pathlib import Path
@@ -36,8 +34,7 @@ from mondo.api.queries import (
 )
 from mondo.cli._batch import build_aliased_mutation, chunk_inputs, parse_aliased_response
 from mondo.cli._cache_invalidate import invalidate_board_items_cache, invalidate_entity
-from mondo.cli._column_cache import fetch_board_columns, invalidate_columns_cache
-from mondo.cli._columns import parse_settings, resolve_tag_names_to_ids
+from mondo.cli._column_cache import invalidate_columns_cache
 from mondo.cli._confirm import confirm_or_abort as _confirm
 from mondo.cli._examples import epilog_for
 from mondo.cli._exec import (
@@ -52,9 +49,21 @@ from mondo.cli._exec import (
     poll_or_exit,
     usage_error_or_exit,
 )
-from mondo.cli._resolve import resolve_by_filters, resolve_required_id
+from mondo.cli._resolve import resolve_required_id
 from mondo.cli._url import MondayIdParam
 from mondo.cli.context import GlobalOpts
+from mondo.services.items import (
+    PositionRelative,
+    build_create_variables_for_row,
+    build_query_params,
+    can_slim_column_values,
+    fetch_column_defs,
+    parse_column_mapping,
+    parse_columns_csv,
+    read_batch_input,
+    resolve_item_target,
+    split_filter_expr,
+)
 from mondo.util.kvparse import parse_column_kv
 
 if TYPE_CHECKING:
@@ -64,11 +73,6 @@ app = typer.Typer(
     no_args_is_help=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-
-
-class PositionRelative(StrEnum):
-    before_at = "before_at"
-    after_at = "after_at"
 
 
 class OrderDir(StrEnum):
@@ -98,171 +102,6 @@ def _execute_create_item(
         handle_mondo_error_or_exit(e, human_suffix=column_value_hint or None)
     except MondoError as e:
         handle_mondo_error_or_exit(e)
-
-
-def _split_filter_expr(expr: str) -> tuple[str, str, str]:
-    """Return ``(column_id, raw_value, operator)`` for a `--filter` expression."""
-    if "!=" in expr:
-        col, _, raw = expr.partition("!=")
-        return col.strip(), raw, "not_any_of"
-    if "=" in expr:
-        col, _, raw = expr.partition("=")
-        return col.strip(), raw, "any_of"
-    raise UsageError(f"invalid --filter {expr!r}: expected COL=VAL or COL!=VAL")
-
-
-def _build_filter_rule(
-    parsed: tuple[str, str, str],
-    column_defs: dict[str, dict[str, Any]],
-    board_id: int | None = None,
-) -> dict[str, Any]:
-    """Build one `items_page.query_params.rule` from a parsed `(col, raw, op)`.
-
-    Dispatches by column type so status / dropdown filters end up with the
-    integer indices / option ids monday actually accepts (sending labels
-    returns 0 results silently). Falls back to a raw string list when the
-    column id isn't on the board (server will raise `Column not found`) or
-    when the column type has no codec.
-    """
-    from mondo.columns import UnknownColumnTypeError, parse_filter_value
-
-    col, raw, operator = parsed
-    definition = column_defs.get(col)
-    if definition is None:
-        compare_value: list[Any] = [v.strip() for v in raw.split(",")]
-    else:
-        col_type = definition["type"]
-        settings = parse_settings(definition.get("settings_str"))
-        try:
-            compare_value = parse_filter_value(col_type, raw, settings)
-        except UnknownColumnTypeError:
-            compare_value = [v.strip() for v in raw.split(",")]
-        except ValueError as e:
-            board_hint = f"--board {board_id} " if board_id is not None else ""
-            raise UsageError(
-                f"--filter {col}={raw!r}: {e}. "
-                f"Run `mondo column labels {board_hint}--column {col}` "
-                f"for the canonical list."
-            ) from e
-    return {"column_id": col, "compare_value": compare_value, "operator": operator}
-
-
-def _fetch_column_defs(
-    opts: GlobalOpts,
-    client: MondayClient,
-    board_id: int,
-    *,
-    no_cache: bool = False,
-    refresh: bool = False,
-) -> dict[str, dict[str, Any]]:
-    """One-shot fetch of `{col_id: {type, settings_str, ...}}` for a board.
-
-    Reads from the per-board columns cache when enabled; falls back to a live
-    query otherwise. Silently returns `{}` when the board isn't visible — the
-    caller's codec dispatch will treat unknown columns as raw passthroughs,
-    mirroring the previous behavior when the API returned no boards.
-    """
-    try:
-        columns = fetch_board_columns(opts, client, board_id, no_cache=no_cache, refresh=refresh)
-    except NotFoundError:
-        return {}
-    return {c["id"]: c for c in columns}
-
-
-def _build_column_values(
-    opts: GlobalOpts,
-    client: MondayClient,
-    board_id: int,
-    pairs: list[str],
-    *,
-    raw_mode: bool,
-    create_labels: bool = False,
-    tag_cache: dict[str, int] | None = None,
-    column_defs: dict[str, dict[str, Any]] | None = None,
-) -> dict[str, Any]:
-    """Apply codecs to `--column K=V` pairs, using live board column types.
-
-    raw_mode=True disables codec dispatch (user's value used as-is after JSON
-    parse-or-passthrough). Raw mode also skips the preflight query.
-
-    `tag_cache` and `column_defs`, when provided, dedupe work across rows
-    in a batch: a 50-row batch tagging "urgent" issues one
-    `create_or_get_tag` instead of fifty, and `_fetch_column_defs` runs
-    once per batch instead of once per row.
-    """
-    from mondo.columns import UnknownColumnTypeError, parse_value
-
-    parsed_pairs = [parse_column_kv(p) for p in pairs]
-
-    if raw_mode:
-        return dict(parsed_pairs)
-
-    defs = column_defs if column_defs is not None else _fetch_column_defs(opts, client, board_id)
-    out: dict[str, Any] = {}
-    for col_id, raw_value in parsed_pairs:
-        definition = defs.get(col_id)
-        # dict/list/None mean the user passed a structured JSON payload (or an
-        # explicit "clear" signal) — honor it as raw. Bare scalars (int, float,
-        # bool) are valid codec shorthand (e.g. people: `42`, numbers: `5`) and
-        # must be stringified back so the codec sees them.
-        if definition is None or isinstance(raw_value, (dict, list)) or raw_value is None:
-            out[col_id] = raw_value
-            continue
-        col_type = definition["type"]
-        settings = parse_settings(definition.get("settings_str"))
-        str_value = raw_value if isinstance(raw_value, str) else json.dumps(raw_value)
-        if col_type == "tags":
-            str_value = resolve_tag_names_to_ids(client, board_id, str_value, cache=tag_cache)
-        try:
-            out[col_id] = parse_value(col_type, str_value, settings, create_labels=create_labels)
-        except UnknownColumnTypeError:
-            # Unfamiliar column type → don't translate, send raw
-            out[col_id] = raw_value
-        except ValueError as e:
-            raise ValueError(f"--column {col_id}={raw_value!r}: {e}") from e
-    return out
-
-
-def _parse_columns_csv(spec: str) -> list[str]:
-    """Split a `--columns col1,col2` spec; raise `UsageError` when empty."""
-    col_ids = [c.strip() for c in spec.split(",") if c.strip()]
-    if not col_ids:
-        raise UsageError("--columns expects a comma-separated list of column ids.")
-    return col_ids
-
-
-def _can_slim_column_values(opts: GlobalOpts) -> bool:
-    """True when `--fields` provably never reads `column_values`, so the
-    GraphQL query can drop it (~3x cheaper per page on big boards).
-
-    Only `--fields` is inspected. A `-q` JMESPath cannot prove this: it
-    can read fields inside predicates / sort keys yet still return whole
-    rows (e.g. `[?contains(name, 'x')]`), so any `-q` — alone or combined
-    with `--fields` (it runs first, against the raw rows) — keeps the
-    full selection.
-    """
-    if opts.query is not None or not opts.fields:
-        return False
-    keys = [k.strip() for k in opts.fields.split(",") if k.strip()]
-    return bool(keys) and all(k.split(".")[0] != "column_values" for k in keys)
-
-
-def _build_query_params(
-    parsed_filters: list[tuple[str, str, str]] | None,
-    order_by: str | None,
-    column_defs: dict[str, dict[str, Any]] | None = None,
-    board_id: int | None = None,
-) -> dict[str, Any] | None:
-    qp: dict[str, Any] = {}
-    if parsed_filters:
-        defs = column_defs or {}
-        qp["rules"] = [_build_filter_rule(f, defs, board_id=board_id) for f in parsed_filters]
-        qp["operator"] = "and"
-    if order_by:
-        # Syntax: "column_id" or "column_id,asc" / "column_id,desc"
-        col, _, direction = order_by.partition(",")
-        qp["order_by"] = [{"column_id": col.strip(), "direction": (direction or "asc").strip()}]
-    return qp or None
 
 
 # ----- read commands -----
@@ -346,7 +185,7 @@ def get_cmd(
     variables: dict[str, Any] = {"id": item_id}
     if columns_sel is not None:
         try:
-            variables["cols"] = _parse_columns_csv(columns_sel)
+            variables["cols"] = parse_columns_csv(columns_sel)
         except UsageError as e:
             usage_error_or_exit(str(e))
         query = ITEM_GET_WITH_COLUMNS
@@ -568,7 +407,7 @@ def _list_items_impl(
     parsed_filters: list[tuple[str, str, str]] = []
     if filter_expr:
         try:
-            parsed_filters = [_split_filter_expr(f) for f in filter_expr]
+            parsed_filters = [split_filter_expr(f) for f in filter_expr]
         except UsageError as e:
             usage_error_or_exit(str(e))
 
@@ -581,12 +420,12 @@ def _list_items_impl(
     slim = False
     if columns_sel is not None:
         try:
-            extra_vars = {"cols": _parse_columns_csv(columns_sel)}
+            extra_vars = {"cols": parse_columns_csv(columns_sel)}
         except UsageError as e:
             usage_error_or_exit(str(e))
         query_initial, query_next = build_items_page_queries(column_values="ids")
     else:
-        slim = poll_until is None and _can_slim_column_values(opts)
+        slim = poll_until is None and can_slim_column_values(opts)
         query_initial, query_next = build_items_page_queries(
             column_values="none" if slim else "full"
         )
@@ -643,14 +482,14 @@ def _list_items_impl(
             # indices/ids.
             column_defs: dict[str, dict[str, Any]] = {}
             if parsed_filters:
-                column_defs = _fetch_column_defs(
+                column_defs = fetch_column_defs(
                     opts,
                     client,
                     board_id,
                     no_cache=no_cache,
                     refresh=refresh_cache,
                 )
-            qp = _build_query_params(parsed_filters, order_by, column_defs, board_id=board_id)
+            qp = build_query_params(parsed_filters, order_by, column_defs, board_id=board_id)
 
             if opts.dry_run:
                 opts.emit(
@@ -731,79 +570,6 @@ def find_cmd(
 
 
 # ----- write commands -----
-
-
-def _build_create_variables_for_row(
-    opts: GlobalOpts,
-    client: MondayClient | None,
-    board_id: int,
-    row: dict[str, Any],
-    *,
-    raw_columns: bool,
-    create_labels_default: bool,
-    tag_cache: dict[str, int] | None = None,
-    column_defs: dict[str, dict[str, Any]] | None = None,
-) -> dict[str, Any]:
-    """Render one batch row into the `ITEM_CREATE` variable dict.
-
-    Reuses `_build_column_values` for codec dispatch — `client` is required
-    when codec preflight is needed (`raw_columns=False` and the row carries
-    `columns`). Raises `ValueError` (exit 5) for malformed column values
-    and `MondoError` for upstream codec failures.
-    """
-    raw_columns_field = row.get("columns") or []
-    if not isinstance(raw_columns_field, list):
-        raise ValueError(f"row {row.get('name', '?')!r}: 'columns' must be a list of K=V strings.")
-    create_labels = bool(row.get("create_labels", create_labels_default))
-    col_values: dict[str, Any] = {}
-    if raw_columns_field:
-        if raw_columns:
-            col_values = dict(parse_column_kv(p) for p in raw_columns_field)
-        else:
-            assert client is not None, "preflight requires a client"
-            col_values = _build_column_values(
-                opts,
-                client,
-                board_id,
-                list(raw_columns_field),
-                raw_mode=False,
-                create_labels=create_labels,
-                tag_cache=tag_cache,
-                column_defs=column_defs,
-            )
-    prm = row.get("position_relative_method")
-    if prm is not None:
-        prm = PositionRelative(prm).value
-    return {
-        "board": board_id,
-        "name": str(row["name"]),
-        "group": row.get("group_id"),
-        # monday's column_values wants a JSON-*string*, not a JSON object (§11.4).
-        "values": json.dumps(col_values) if col_values else None,
-        "create_labels": create_labels if create_labels else None,
-        "prm": prm,
-        "relto": row.get("relative_to"),
-    }
-
-
-def _read_batch_input(source: Path) -> list[dict[str, Any]]:
-    """Read the `--batch` source and validate it's a JSON array of objects
-    each carrying a `name`. Use `Path("-")` for stdin."""
-    text = sys.stdin.read() if str(source) == "-" else source.read_text(encoding="utf-8")
-    try:
-        parsed = json.loads(text)
-    except json.JSONDecodeError as e:
-        raise UsageError(f"--batch input is not valid JSON: {e}") from e
-    if not isinstance(parsed, list):
-        raise UsageError("--batch input must be a JSON array of objects.")
-    if not parsed:
-        raise UsageError("--batch input is an empty array — nothing to do.")
-    for i, row in enumerate(parsed):
-        if not isinstance(row, dict):
-            raise UsageError(f"--batch row {i}: expected object, got {type(row).__name__}.")
-        if not row.get("name"):
-            raise UsageError(f"--batch row {i}: missing required 'name' field.")
-    return parsed
 
 
 @app.command("create", epilog=epilog_for("item create"))
@@ -892,7 +658,7 @@ def create_cmd(
                 "settings into the JSON array."
             )
         try:
-            rows = _read_batch_input(batch)
+            rows = read_batch_input(batch)
         except UsageError as e:
             usage_error_or_exit(str(e))
         if chunk_size < 1:
@@ -935,7 +701,7 @@ def create_cmd(
     ctx_mgr: Any = client_for_preflight if client_for_preflight is not None else nullcontext()
     try:
         with ctx_mgr:
-            variables = _build_create_variables_for_row(
+            variables = build_create_variables_for_row(
                 opts,
                 client_for_preflight,
                 board_id,
@@ -995,7 +761,7 @@ def _run_batch(
         column_defs: dict[str, dict[str, Any]] | None = None
         tag_cache: dict[str, int] = {}
         if needs_preflight and client is not None:
-            column_defs = _fetch_column_defs(opts, client, board_id)
+            column_defs = fetch_column_defs(opts, client, board_id)
 
         ctx_mgr: Any = client if client is not None else nullcontext()
         per_row_vars: list[dict[str, Any]] = []
@@ -1003,7 +769,7 @@ def _run_batch(
             with ctx_mgr:
                 for row in rows:
                     per_row_vars.append(
-                        _build_create_variables_for_row(
+                        build_create_variables_for_row(
                             opts,
                             client,
                             board_id,
@@ -1074,38 +840,6 @@ def _run_batch(
         raise typer.Exit(code=1)
 
 
-def _resolve_item_target(
-    client: MondayClient,
-    board_id: int,
-    *,
-    item_id: int | None,
-    name_contains: str | None,
-    name_matches_re: str | None,
-    name_fuzzy: str | None,
-    first: bool,
-    fuzzy_threshold: int,
-) -> int:
-    """Pick a single item id for the mutation. The filter path streams
-    `items_page` live and matches client-side — it deliberately skips the
-    short-TTL board_items cache so name filters never resolve a mutation
-    target against stale rows."""
-    if item_id is not None and not (name_contains or name_matches_re or name_fuzzy):
-        return item_id
-    items = list(iter_items_page(client, board_id=board_id))
-    chosen = resolve_by_filters(
-        items,
-        explicit_id=item_id,
-        name_contains=name_contains,
-        name_matches_re=name_matches_re,
-        name_fuzzy=name_fuzzy,
-        first=first,
-        fuzzy_threshold=fuzzy_threshold,
-        key="name",
-        resource="item",
-    )
-    return int(chosen["id"])
-
-
 @app.command("rename", epilog=epilog_for("item rename"))
 def rename_cmd(
     ctx: typer.Context,
@@ -1144,7 +878,7 @@ def rename_cmd(
     client = client_or_exit(opts)
     try:
         with client:
-            resolved_item = _resolve_item_target(
+            resolved_item = resolve_item_target(
                 client,
                 board_id,
                 item_id=explicit_id,
@@ -1241,33 +975,6 @@ def move_cmd(
     opts.emit(data.get("move_item_to_group") or {})
 
 
-def _parse_column_mapping(tokens: list[str]) -> list[dict[str, Any]]:
-    """Parse `source[=target]` tokens into ColumnMappingInput dicts.
-
-    `src=dst` maps source column `src` to dest column `dst`.
-    `src=` (empty target) or bare `src` drops the column on the destination
-    (monday treats a null `target` as "don't carry this column over").
-    """
-    out: list[dict[str, Any]] = []
-    for tok in tokens:
-        raw = tok.strip()
-        if not raw:
-            continue
-        if "=" in raw:
-            src, _, tgt = raw.partition("=")
-            src = src.strip()
-            tgt = tgt.strip()
-        else:
-            src, tgt = raw, ""
-        if not src:
-            raise UsageError(
-                f"--column-mapping {tok!r}: source column id is required "
-                "(use 'src=dst' or 'src=' to drop)."
-            )
-        out.append({"source": src, "target": tgt or None})
-    return out
-
-
 @app.command("move-to-board", epilog=epilog_for("item move-to-board"))
 def move_to_board_cmd(
     ctx: typer.Context,
@@ -1303,8 +1010,8 @@ def move_to_board_cmd(
     """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     try:
-        columns = _parse_column_mapping(column_mapping or [])
-        subitem_columns = _parse_column_mapping(subitem_column_mapping or [])
+        columns = parse_column_mapping(column_mapping or [])
+        subitem_columns = parse_column_mapping(subitem_column_mapping or [])
     except UsageError as e:
         usage_error_or_exit(str(e))
     variables: dict[str, Any] = {

--- a/src/mondo/cli/subitem.py
+++ b/src/mondo/cli/subitem.py
@@ -94,7 +94,7 @@ def _build_column_values(
         definition = defs.get(col_id)
         # dict/list/None: structured JSON the user crafted — pass through as raw.
         # Bare scalars (int, float, bool) are valid codec shorthand and must be
-        # stringified so the codec sees them (mirror of item.py:_build_column_values).
+        # stringified so the codec sees them (mirror of mondo.services.items.build_column_values).
         if definition is None or isinstance(raw_value, (dict, list)) or raw_value is None:
             out[col_id] = raw_value
             continue

--- a/src/mondo/cli/subitem.py
+++ b/src/mondo/cli/subitem.py
@@ -17,7 +17,7 @@ Without it, `--column` values are sent as raw strings/JSON.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import typer
 
@@ -31,7 +31,7 @@ from mondo.api.queries import (
     SUBITEM_CREATE,
     SUBITEMS_LIST,
 )
-from mondo.cli._column_cache import fetch_board_columns, invalidate_columns_cache
+from mondo.cli._column_cache import invalidate_columns_cache
 from mondo.cli._confirm import confirm_or_abort as _confirm
 from mondo.cli._examples import epilog_for
 from mondo.cli._exec import (
@@ -42,75 +42,13 @@ from mondo.cli._exec import (
 from mondo.cli._resolve import resolve_required_id
 from mondo.cli._url import MondayIdParam
 from mondo.cli.context import GlobalOpts
+from mondo.services.items import build_column_values
 from mondo.util.kvparse import parse_column_kv
-
-if TYPE_CHECKING:
-    from mondo.api.client import MondayClient
 
 app = typer.Typer(
     no_args_is_help=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-
-
-# ----- helpers -----
-
-
-def _parse_settings(raw: str | None) -> dict[str, Any]:
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
-
-
-def _build_column_values(
-    opts: GlobalOpts,
-    client: MondayClient,
-    subitems_board_id: int | None,
-    pairs: list[str],
-    *,
-    create_labels: bool = False,
-) -> dict[str, Any]:
-    """Turn `--column K=V` pairs into the write JSON shape.
-
-    With `subitems_board_id` set, does codec dispatch via the subitems-board
-    column types. Without it, values pass through verbatim.
-    """
-    from mondo.columns import UnknownColumnTypeError, parse_value
-
-    parsed_pairs = [parse_column_kv(p) for p in pairs]
-    if subitems_board_id is None:
-        return dict(parsed_pairs)
-    try:
-        columns = fetch_board_columns(opts, client, subitems_board_id)
-    except NotFoundError:
-        return dict(parsed_pairs)
-    defs = {c["id"]: c for c in columns}
-    out: dict[str, Any] = {}
-    for col_id, raw_value in parsed_pairs:
-        definition = defs.get(col_id)
-        # dict/list/None: structured JSON the user crafted — pass through as raw.
-        # Bare scalars (int, float, bool) are valid codec shorthand and must be
-        # stringified so the codec sees them (mirror of mondo.services.items.build_column_values).
-        if definition is None or isinstance(raw_value, (dict, list)) or raw_value is None:
-            out[col_id] = raw_value
-            continue
-        col_type = definition.get("type")
-        if not isinstance(col_type, str):
-            out[col_id] = raw_value
-            continue
-        settings = _parse_settings(definition.get("settings_str"))
-        str_value = raw_value if isinstance(raw_value, str) else json.dumps(raw_value)
-        try:
-            out[col_id] = parse_value(col_type, str_value, settings, create_labels=create_labels)
-        except UnknownColumnTypeError:
-            out[col_id] = raw_value
-        except ValueError as e:
-            raise ValueError(f"--column {col_id}={raw_value!r}: {e}") from e
-    return out
 
 
 # ----- read commands -----
@@ -316,11 +254,12 @@ def create_cmd(
             client = client_or_exit(opts)
             try:
                 with client:
-                    col_values = _build_column_values(
+                    col_values = build_column_values(
                         opts,
                         client,
                         subitems_board,
                         columns,
+                        raw_mode=False,
                         create_labels=create_labels_if_missing,
                     )
             except MondoError as e:

--- a/src/mondo/output/fields.py
+++ b/src/mondo/output/fields.py
@@ -7,7 +7,7 @@ dotted form so a downstream JMESPath / formatter sees a flat record.
 Missing keys map to None — never raise — so a heterogeneous list projects
 cleanly. Projection itself is client-side, but `item list` also inspects
 the spec up front and drops `column_values` from its GraphQL request when
-no key reads them (see `_can_slim_column_values` in mondo.cli.item).
+no key reads them (see `can_slim_column_values` in mondo.services.items).
 """
 
 from __future__ import annotations

--- a/src/mondo/services/__init__.py
+++ b/src/mondo/services/__init__.py
@@ -1,0 +1,8 @@
+"""Service layer: behavior-neutral business logic extracted from the CLI.
+
+Modules here hold the query-building, validation, and response-shaping logic
+that the Typer command callbacks in :mod:`mondo.cli` delegate to. Functions
+take plain arguments, return plain data, and raise domain errors from
+:mod:`mondo.api.errors`; the CLI layer owns argument parsing, emission, and
+exit-code mapping.
+"""

--- a/src/mondo/services/boards.py
+++ b/src/mondo/services/boards.py
@@ -1,0 +1,101 @@
+"""Business logic for the `mondo board` command group.
+
+Type-filter matching, payload decoding, and the live `items_count` helpers
+extracted from :mod:`mondo.cli.board`. The Typer callbacks own argument
+parsing, emission, polling, and exit-code mapping; everything here takes
+plain arguments, returns plain data, and raises domain errors from
+:mod:`mondo.api.errors`.
+"""
+
+from __future__ import annotations
+
+import json
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mondo.cli.context import GlobalOpts
+
+
+class BoardTypeFilter(StrEnum):
+    """`--type` selector on `board list`.
+
+    monday's `boards()` query returns both real boards and workdoc-backing
+    boards (monday models every workdoc as a board with `type=="document"`).
+    The CLI hides docs by default; pass `--type doc` to list only docs, or
+    `--type all` to see everything including non-standard types such as
+    `sub_items_board` and `custom_object`.
+    """
+
+    board = "board"
+    doc = "doc"
+    all = "all"
+
+
+# Mapping from CLI filter → monday's `Board.type` server value.
+_BOARD_TYPE_SERVER_VALUE: dict[BoardTypeFilter, str] = {
+    BoardTypeFilter.board: "board",
+    BoardTypeFilter.doc: "document",
+}
+
+
+def type_matches(entry: dict[str, Any], type_filter: BoardTypeFilter) -> bool:
+    """Return True when `entry` should pass the `--type` filter.
+
+    Entries cached before schema_version 2 lack `type`; we don't want those
+    to silently disappear under `--type board` (the common default). The
+    schema_version bump forces a one-off refresh so this branch should only
+    matter in the edge case of an in-memory fetch before the cache is warm.
+    Treat missing as `"board"` to keep behavior predictable.
+    """
+    if type_filter is BoardTypeFilter.all:
+        return True
+    observed = entry.get("type") or "board"
+    return observed == _BOARD_TYPE_SERVER_VALUE[type_filter]
+
+
+def decode_json_string_payload(value: Any) -> Any:
+    """Parse monday's legacy stringified-JSON mutation payloads when possible."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def projection_wants_items_count(opts: GlobalOpts) -> bool:
+    """Skip the live `items_count` merge when the caller's projection won't
+    surface it. Default behavior (no `-q`/`--fields`) returns True so the
+    field stays in the emitted payload as it did pre-cache; with an explicit
+    projection we only pay the round-trip if `items_count` actually appears.
+
+    The check is intentionally lenient (substring): a JMESPath expression
+    or comma-separated field list that mentions `items_count` keeps the
+    merge; anything else skips it. False negatives just mean the cached
+    `items_count: null` flows through — accurate per the cache contract.
+    """
+    needle = "items_count"
+    if opts.query and needle in opts.query:
+        return True
+    if opts.fields and needle in opts.fields:
+        return True
+    return opts.query is None and opts.fields is None
+
+
+def fetch_items_count(client: Any, board_id: int) -> int | None:
+    """One-field live fetch for the volatile items_count field. Used to merge
+    a fresh count onto a `board_details` cache hit so the cache file stays
+    invalidation-free of item writes. Returns None on any unexpected shape."""
+    from mondo.api.queries import BOARD_ITEMS_COUNT
+    from mondo.cli._exec import exec_or_exit
+
+    data = exec_or_exit(client, BOARD_ITEMS_COUNT, {"ids": [board_id]})
+    boards = data.get("boards") or []
+    if not boards:
+        return None
+    raw = boards[0].get("items_count")
+    try:
+        return int(raw) if raw is not None else None
+    except TypeError, ValueError:
+        return None

--- a/src/mondo/services/docs.py
+++ b/src/mondo/services/docs.py
@@ -1,0 +1,83 @@
+"""Business logic for the `mondo doc` command group.
+
+Block inspection and object-id/doc-id resolution extracted from
+:mod:`mondo.cli.doc`. The Typer callbacks own argument parsing, emission,
+polling, and exit-code mapping; everything here takes plain arguments,
+returns plain data, and raises domain errors from :mod:`mondo.api.errors`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from mondo.api.errors import MondoError
+from mondo.api.queries import DOC_HEAD_BY_OBJECT_ID
+
+if TYPE_CHECKING:
+    from mondo.api.client import MondayClient
+    from mondo.cli.context import GlobalOpts
+
+
+def last_block_id(doc: dict[str, Any]) -> str | None:
+    blocks = doc.get("blocks") or []
+    if not blocks:
+        return None
+    last = blocks[-1]
+    if not isinstance(last, dict):
+        return None
+    last_id = last.get("id")
+    return str(last_id) if last_id else None
+
+
+def resolve_doc_id_from_object_id(
+    opts: GlobalOpts, client: MondayClient, object_id: int
+) -> int | None:
+    """Map a URL-visible `object_id` to its internal `doc_id` via the docs
+    directory cache (auto-populated on miss). Returns None when the
+    object_id isn't visible — the caller falls back to a live fetch.
+    """
+    from mondo.cache.directory import get_docs as _cache_get_docs
+
+    target = str(object_id)
+    store = opts.build_cache_store("docs")
+    try:
+        cached = _cache_get_docs(client, store=store, refresh=False)
+    except MondoError:
+        return None
+    for entry in cached.entries:
+        if str(entry.get("object_id")) == target:
+            raw = entry.get("id")
+            try:
+                return int(raw) if raw is not None else None
+            except TypeError, ValueError:
+                return None
+    return None
+
+
+def object_id_hint_with_client(client: MondayClient, doc_id: int) -> str | None:
+    """Probe whether a failing `--doc` id is actually a URL-visible object_id
+    (the id a human copies out of a `/docs/<id>` URL). Returns the targeted
+    hint when it resolves; never raises — the probe must not mask the
+    original error.
+    """
+    try:
+        result = client.execute(DOC_HEAD_BY_OBJECT_ID, {"objs": [doc_id]})
+        docs = (result.get("data") or {}).get("docs") or []
+    except Exception:
+        return None
+    if not docs:
+        return None
+    return (
+        f"hint: {doc_id} looks like a URL-visible object id, not an internal "
+        f"doc id — retry with --object-id {doc_id}"
+    )
+
+
+def object_id_hint(opts: GlobalOpts, doc_id: int) -> str | None:
+    """`object_id_hint_with_client` with a fresh short-lived client."""
+    try:
+        client = opts.build_client()
+        with client:
+            return object_id_hint_with_client(client, doc_id)
+    except Exception:
+        return None

--- a/src/mondo/services/items.py
+++ b/src/mondo/services/items.py
@@ -1,0 +1,328 @@
+"""Business logic for the `mondo item` command group.
+
+Query building, validation, and column-value rendering extracted from
+:mod:`mondo.cli.item`. The Typer callbacks own argument parsing, emission,
+polling, and exit-code mapping; everything here takes plain arguments,
+returns plain data, and raises domain errors from :mod:`mondo.api.errors`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from mondo.api.errors import NotFoundError, UsageError
+from mondo.api.pagination import iter_items_page
+from mondo.cli._column_cache import fetch_board_columns
+from mondo.cli._columns import parse_settings, resolve_tag_names_to_ids
+from mondo.cli._resolve import resolve_by_filters
+from mondo.util.kvparse import parse_column_kv
+
+if TYPE_CHECKING:
+    from mondo.api.client import MondayClient
+    from mondo.cli.context import GlobalOpts
+
+
+class PositionRelative(StrEnum):
+    before_at = "before_at"
+    after_at = "after_at"
+
+
+def split_filter_expr(expr: str) -> tuple[str, str, str]:
+    """Return ``(column_id, raw_value, operator)`` for a `--filter` expression."""
+    if "!=" in expr:
+        col, _, raw = expr.partition("!=")
+        return col.strip(), raw, "not_any_of"
+    if "=" in expr:
+        col, _, raw = expr.partition("=")
+        return col.strip(), raw, "any_of"
+    raise UsageError(f"invalid --filter {expr!r}: expected COL=VAL or COL!=VAL")
+
+
+def build_filter_rule(
+    parsed: tuple[str, str, str],
+    column_defs: dict[str, dict[str, Any]],
+    board_id: int | None = None,
+) -> dict[str, Any]:
+    """Build one `items_page.query_params.rule` from a parsed `(col, raw, op)`.
+
+    Dispatches by column type so status / dropdown filters end up with the
+    integer indices / option ids monday actually accepts (sending labels
+    returns 0 results silently). Falls back to a raw string list when the
+    column id isn't on the board (server will raise `Column not found`) or
+    when the column type has no codec.
+    """
+    from mondo.columns import UnknownColumnTypeError, parse_filter_value
+
+    col, raw, operator = parsed
+    definition = column_defs.get(col)
+    if definition is None:
+        compare_value: list[Any] = [v.strip() for v in raw.split(",")]
+    else:
+        col_type = definition["type"]
+        settings = parse_settings(definition.get("settings_str"))
+        try:
+            compare_value = parse_filter_value(col_type, raw, settings)
+        except UnknownColumnTypeError:
+            compare_value = [v.strip() for v in raw.split(",")]
+        except ValueError as e:
+            board_hint = f"--board {board_id} " if board_id is not None else ""
+            raise UsageError(
+                f"--filter {col}={raw!r}: {e}. "
+                f"Run `mondo column labels {board_hint}--column {col}` "
+                f"for the canonical list."
+            ) from e
+    return {"column_id": col, "compare_value": compare_value, "operator": operator}
+
+
+def parse_columns_csv(spec: str) -> list[str]:
+    """Split a `--columns col1,col2` spec; raise `UsageError` when empty."""
+    col_ids = [c.strip() for c in spec.split(",") if c.strip()]
+    if not col_ids:
+        raise UsageError("--columns expects a comma-separated list of column ids.")
+    return col_ids
+
+
+def can_slim_column_values(opts: GlobalOpts) -> bool:
+    """True when `--fields` provably never reads `column_values`, so the
+    GraphQL query can drop it (~3x cheaper per page on big boards).
+
+    Only `--fields` is inspected. A `-q` JMESPath cannot prove this: it
+    can read fields inside predicates / sort keys yet still return whole
+    rows (e.g. `[?contains(name, 'x')]`), so any `-q` — alone or combined
+    with `--fields` (it runs first, against the raw rows) — keeps the
+    full selection.
+    """
+    if opts.query is not None or not opts.fields:
+        return False
+    keys = [k.strip() for k in opts.fields.split(",") if k.strip()]
+    return bool(keys) and all(k.split(".")[0] != "column_values" for k in keys)
+
+
+def build_query_params(
+    parsed_filters: list[tuple[str, str, str]] | None,
+    order_by: str | None,
+    column_defs: dict[str, dict[str, Any]] | None = None,
+    board_id: int | None = None,
+) -> dict[str, Any] | None:
+    qp: dict[str, Any] = {}
+    if parsed_filters:
+        defs = column_defs or {}
+        qp["rules"] = [build_filter_rule(f, defs, board_id=board_id) for f in parsed_filters]
+        qp["operator"] = "and"
+    if order_by:
+        # Syntax: "column_id" or "column_id,asc" / "column_id,desc"
+        col, _, direction = order_by.partition(",")
+        qp["order_by"] = [{"column_id": col.strip(), "direction": (direction or "asc").strip()}]
+    return qp or None
+
+
+def read_batch_input(source: Path) -> list[dict[str, Any]]:
+    """Read the `--batch` source and validate it's a JSON array of objects
+    each carrying a `name`. Use `Path("-")` for stdin."""
+    text = sys.stdin.read() if str(source) == "-" else source.read_text(encoding="utf-8")
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise UsageError(f"--batch input is not valid JSON: {e}") from e
+    if not isinstance(parsed, list):
+        raise UsageError("--batch input must be a JSON array of objects.")
+    if not parsed:
+        raise UsageError("--batch input is an empty array — nothing to do.")
+    for i, row in enumerate(parsed):
+        if not isinstance(row, dict):
+            raise UsageError(f"--batch row {i}: expected object, got {type(row).__name__}.")
+        if not row.get("name"):
+            raise UsageError(f"--batch row {i}: missing required 'name' field.")
+    return parsed
+
+
+def parse_column_mapping(tokens: list[str]) -> list[dict[str, Any]]:
+    """Parse `source[=target]` tokens into ColumnMappingInput dicts.
+
+    `src=dst` maps source column `src` to dest column `dst`.
+    `src=` (empty target) or bare `src` drops the column on the destination
+    (monday treats a null `target` as "don't carry this column over").
+    """
+    out: list[dict[str, Any]] = []
+    for tok in tokens:
+        raw = tok.strip()
+        if not raw:
+            continue
+        if "=" in raw:
+            src, _, tgt = raw.partition("=")
+            src = src.strip()
+            tgt = tgt.strip()
+        else:
+            src, tgt = raw, ""
+        if not src:
+            raise UsageError(
+                f"--column-mapping {tok!r}: source column id is required "
+                "(use 'src=dst' or 'src=' to drop)."
+            )
+        out.append({"source": src, "target": tgt or None})
+    return out
+
+
+def fetch_column_defs(
+    opts: GlobalOpts,
+    client: MondayClient,
+    board_id: int,
+    *,
+    no_cache: bool = False,
+    refresh: bool = False,
+) -> dict[str, dict[str, Any]]:
+    """One-shot fetch of `{col_id: {type, settings_str, ...}}` for a board.
+
+    Reads from the per-board columns cache when enabled; falls back to a live
+    query otherwise. Silently returns `{}` when the board isn't visible — the
+    caller's codec dispatch will treat unknown columns as raw passthroughs,
+    mirroring the previous behavior when the API returned no boards.
+    """
+    try:
+        columns = fetch_board_columns(opts, client, board_id, no_cache=no_cache, refresh=refresh)
+    except NotFoundError:
+        return {}
+    return {c["id"]: c for c in columns}
+
+
+def build_column_values(
+    opts: GlobalOpts,
+    client: MondayClient,
+    board_id: int,
+    pairs: list[str],
+    *,
+    raw_mode: bool,
+    create_labels: bool = False,
+    tag_cache: dict[str, int] | None = None,
+    column_defs: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Apply codecs to `--column K=V` pairs, using live board column types.
+
+    raw_mode=True disables codec dispatch (user's value used as-is after JSON
+    parse-or-passthrough). Raw mode also skips the preflight query.
+
+    `tag_cache` and `column_defs`, when provided, dedupe work across rows
+    in a batch: a 50-row batch tagging "urgent" issues one
+    `create_or_get_tag` instead of fifty, and `fetch_column_defs` runs
+    once per batch instead of once per row.
+    """
+    from mondo.columns import UnknownColumnTypeError, parse_value
+
+    parsed_pairs = [parse_column_kv(p) for p in pairs]
+
+    if raw_mode:
+        return dict(parsed_pairs)
+
+    defs = column_defs if column_defs is not None else fetch_column_defs(opts, client, board_id)
+    out: dict[str, Any] = {}
+    for col_id, raw_value in parsed_pairs:
+        definition = defs.get(col_id)
+        # dict/list/None mean the user passed a structured JSON payload (or an
+        # explicit "clear" signal) — honor it as raw. Bare scalars (int, float,
+        # bool) are valid codec shorthand (e.g. people: `42`, numbers: `5`) and
+        # must be stringified back so the codec sees them.
+        if definition is None or isinstance(raw_value, (dict, list)) or raw_value is None:
+            out[col_id] = raw_value
+            continue
+        col_type = definition["type"]
+        settings = parse_settings(definition.get("settings_str"))
+        str_value = raw_value if isinstance(raw_value, str) else json.dumps(raw_value)
+        if col_type == "tags":
+            str_value = resolve_tag_names_to_ids(client, board_id, str_value, cache=tag_cache)
+        try:
+            out[col_id] = parse_value(col_type, str_value, settings, create_labels=create_labels)
+        except UnknownColumnTypeError:
+            # Unfamiliar column type → don't translate, send raw
+            out[col_id] = raw_value
+        except ValueError as e:
+            raise ValueError(f"--column {col_id}={raw_value!r}: {e}") from e
+    return out
+
+
+def build_create_variables_for_row(
+    opts: GlobalOpts,
+    client: MondayClient | None,
+    board_id: int,
+    row: dict[str, Any],
+    *,
+    raw_columns: bool,
+    create_labels_default: bool,
+    tag_cache: dict[str, int] | None = None,
+    column_defs: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Render one batch row into the `ITEM_CREATE` variable dict.
+
+    Reuses `build_column_values` for codec dispatch — `client` is required
+    when codec preflight is needed (`raw_columns=False` and the row carries
+    `columns`). Raises `ValueError` (exit 5) for malformed column values
+    and `MondoError` for upstream codec failures.
+    """
+    raw_columns_field = row.get("columns") or []
+    if not isinstance(raw_columns_field, list):
+        raise ValueError(f"row {row.get('name', '?')!r}: 'columns' must be a list of K=V strings.")
+    create_labels = bool(row.get("create_labels", create_labels_default))
+    col_values: dict[str, Any] = {}
+    if raw_columns_field:
+        if raw_columns:
+            col_values = dict(parse_column_kv(p) for p in raw_columns_field)
+        else:
+            assert client is not None, "preflight requires a client"
+            col_values = build_column_values(
+                opts,
+                client,
+                board_id,
+                list(raw_columns_field),
+                raw_mode=False,
+                create_labels=create_labels,
+                tag_cache=tag_cache,
+                column_defs=column_defs,
+            )
+    prm = row.get("position_relative_method")
+    if prm is not None:
+        prm = PositionRelative(prm).value
+    return {
+        "board": board_id,
+        "name": str(row["name"]),
+        "group": row.get("group_id"),
+        # monday's column_values wants a JSON-*string*, not a JSON object (§11.4).
+        "values": json.dumps(col_values) if col_values else None,
+        "create_labels": create_labels if create_labels else None,
+        "prm": prm,
+        "relto": row.get("relative_to"),
+    }
+
+
+def resolve_item_target(
+    client: MondayClient,
+    board_id: int,
+    *,
+    item_id: int | None,
+    name_contains: str | None,
+    name_matches_re: str | None,
+    name_fuzzy: str | None,
+    first: bool,
+    fuzzy_threshold: int,
+) -> int:
+    """Pick a single item id for the mutation. The filter path streams
+    `items_page` live and matches client-side — it deliberately skips the
+    short-TTL board_items cache so name filters never resolve a mutation
+    target against stale rows."""
+    if item_id is not None and not (name_contains or name_matches_re or name_fuzzy):
+        return item_id
+    items = list(iter_items_page(client, board_id=board_id))
+    chosen = resolve_by_filters(
+        items,
+        explicit_id=item_id,
+        name_contains=name_contains,
+        name_matches_re=name_matches_re,
+        name_fuzzy=name_fuzzy,
+        first=first,
+        fuzzy_threshold=fuzzy_threshold,
+        key="name",
+        resource="item",
+    )
+    return int(chosen["id"])

--- a/tests/integration/test_live_subitems.py
+++ b/tests/integration/test_live_subitems.py
@@ -6,6 +6,7 @@ up — never touches the original 5 fixture items.
 
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any
 
@@ -169,6 +170,99 @@ def test_live_subitem_set_and_get_column_value(
         assert values.get(text_col_id) == text_value, f"text col={values.get(text_col_id)!r}"
 
     wait_for("subitem text column landed", _value_landed)
+
+
+@pytest.mark.integration
+def test_live_subitem_create_with_tags_codec_resolves_names(
+    pm_board_session: PmBoard, cleanup_plan: CleanupPlan
+) -> None:
+    """`subitem create --subitems-board --column <tags>=name` resolves the tag
+    name to an id via create_or_get_tag, matching `item create`.
+
+    Regression for the subitem path that previously skipped tag resolution:
+    a bare name hit the tags codec and exited 5. The successful create alone
+    proves the fix (the old path would have errored); the round-trip confirms
+    the resolved tag actually landed on the subitem.
+    """
+    pm = pm_board_session
+    suffix = uuid.uuid4().hex[:8]
+    parent_id = _scratch_parent(pm, cleanup_plan, suffix)
+
+    # Materialize the subitems board via a throwaway name-only subitem.
+    seed = invoke_json(
+        ["subitem", "create", "--parent", str(parent_id), "--name", f"E2E Seed {suffix}"]
+    )
+    seed_id = int(seed["id"])
+    cleanup_plan.add(f"subitem seed {seed_id}", "subitem", "delete", "--id", str(seed_id), "--hard")
+
+    sub_listing = wait_for(
+        "seed subitem listed",
+        lambda: invoke_json(["subitem", "list", "--parent", str(parent_id)]),
+    )
+    sub_board_id = None
+    for s in sub_listing:
+        if int(s["id"]) == seed_id:
+            sub_board_id = (s.get("board") or {}).get("id")
+            break
+    assert sub_board_id, "could not resolve subitems board id"
+
+    # Ensure a tags column exists on the subitems board (default boards have none).
+    sub_columns = invoke_json(["column", "list", "--board", str(sub_board_id)])
+    tags_col = next((c for c in sub_columns if c.get("type") == "tags"), None)
+    if tags_col is None:
+        created = invoke_json(
+            [
+                "column",
+                "create",
+                "--board",
+                str(sub_board_id),
+                "--title",
+                "E2E Sub Tags",
+                "--type",
+                "tags",
+                "--id",
+                "e2e_sub_tags",
+            ]
+        )
+        tags_col_id = created["id"]
+    else:
+        tags_col_id = tags_col["id"]
+
+    # The actual fix under test: a bare tag NAME on subitem create.
+    tag_name = f"E2ETag{suffix}"
+    sub = invoke_json(
+        [
+            "subitem",
+            "create",
+            "--parent",
+            str(parent_id),
+            "--name",
+            f"E2E Sub Tags {suffix}",
+            "--subitems-board",
+            str(sub_board_id),
+            "--column",
+            f"{tags_col_id}={tag_name}",
+        ]
+    )
+    sub_id = int(sub["id"])
+    cleanup_plan.add(f"subitem tags {sub_id}", "subitem", "delete", "--id", str(sub_id), "--hard")
+
+    def _tag_landed() -> None:
+        got = invoke_json(["subitem", "get", "--id", str(sub_id)])
+        cv = {v["id"]: v for v in got.get("column_values") or []}
+        col = cv.get(tags_col_id)
+        assert col is not None, f"tags column {tags_col_id} missing: {list(cv)}"
+        text = col.get("text") or ""
+        ids: list[int] = []
+        raw_value = col.get("value")
+        if raw_value:
+            try:
+                ids = (json.loads(raw_value) or {}).get("tag_ids") or []
+            except json.JSONDecodeError, TypeError:
+                ids = []
+        assert tag_name in text or ids, f"tag not resolved: text={text!r} value={raw_value!r}"
+
+    wait_for("subitem tag column landed", _tag_landed)
 
 
 @pytest.mark.integration

--- a/tests/unit/test_cli_subitem.py
+++ b/tests/unit/test_cli_subitem.py
@@ -356,6 +356,64 @@ class TestCreate:
             "person9": {"personsAndTeams": [{"id": 37251583, "kind": "person"}]}
         }
 
+    def test_tags_codec_resolves_names_to_ids(self, httpx_mock: HTTPXMock) -> None:
+        """subitem create resolves tag names to ids via create_or_get_tag,
+        matching `item create`. Previously the subitem path skipped tag
+        resolution, so a bare name hit the tags codec and errored."""
+        # 1) preflight fetch of the subitems-board columns (a tags column)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "boards": [
+                        {
+                            "id": "99",
+                            "name": "SubBoard",
+                            "columns": [
+                                {
+                                    "id": "tags9",
+                                    "title": "Tags",
+                                    "type": "tags",
+                                    "settings_str": "{}",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ),
+        )
+        # 2) name -> id resolution via create_or_get_tag
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_or_get_tag": {"id": "111", "name": "urgent"}}),
+        )
+        # 3) the create_subitem mutation
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_subitem": {"id": "20"}}),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "subitem",
+                "create",
+                "--parent",
+                "1",
+                "--name",
+                "Hi",
+                "--subitems-board",
+                "99",
+                "--column",
+                "tags9=urgent",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        v = _last_body(httpx_mock)["variables"]
+        assert json.loads(v["values"]) == {"tags9": {"tag_ids": [111]}}
+
 
 class TestMoveRenameArchive:
     def test_rename(self, httpx_mock: HTTPXMock) -> None:


### PR DESCRIPTION
Behavior-neutral extraction of CLI business logic into a new `src/mondo/services/` layer, leaving the Typer command callbacks as thin argument adapters. Recommended by the Codex audit and deliberately split from the audit-fix branch as its own focused PR.

**Stacked on #49** (`chore/codex-review-fixes`) — merge that first. This PR's diff shows only the extraction commits.

## What moved
| Module | CLI lines | New service | Helpers moved |
|---|---|---|---|
| item | 1320 → 1027 | `services/items.py` | 12 helpers + `PositionRelative` |
| doc | 1272 → 1213 | `services/docs.py` | `last_block_id`, `resolve_doc_id_from_object_id`, `object_id_hint`, `object_id_hint_with_client` |
| board | 1007 → 929 | `services/boards.py` | `type_matches`, `decode_json_string_payload`, `projection_wants_items_count`, `fetch_items_count` + `BoardTypeFilter` |

Pure + client-backed logic (query building, validation, column-value rendering) moved **verbatim** (renamed `_private` → public). `@app.command` callbacks and all emit/exit-coupled helpers stay in the CLI. `GlobalOpts`/`MondayClient` are `TYPE_CHECKING`-only imports to avoid import cycles. The board rename's stale generated-doc cross-reference was fixed at the generator (`scripts/generate_output_contract_matrix.py`) and regenerated.

## Behavior
Identical — no change to CLI output, exit codes, help text, or GraphQL queries. Function **bodies were moved, not modified**.

## Verification
- `uv run pytest -m "not integration and not eval"` → **1639 passed** (unchanged from baseline)
- `uv run ruff check` · `ruff format --check` · `uv run mypy` → all clean
- Live integration suite: 55 passed, 3 documented `xfail` (date/person/timeline filter limits). One pre-existing failure (`test_live_json_error_envelope_for_server_errors`) is **unrelated** to this change — a stale test that contradicts the intentional #28 stdout-mirror; this PR doesn't touch `_exec.py`/`_errors.py`.

Commits: `8df11a2` (item), `3c3c17b` (doc), `b71e608` (board).

🤖 PR opened with assistance from Claude Code.
