### PR TITLE
fix(subitem): resolve tag names on create + dedup column-value logic

### DIFF
--- a/src/mondo/cli/subitem.py
+++ b/src/mondo/cli/subitem.py
@@ -17,7 +17,7 @@ Without it, `--column` values are sent as raw strings/JSON.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import typer
 
@@ -31,7 +31,7 @@ from mondo.api.queries import (
     SUBITEM_CREATE,
     SUBITEMS_LIST,
 )
-from mondo.cli._column_cache import fetch_board_columns, invalidate_columns_cache
+from mondo.cli._column_cache import invalidate_columns_cache
 from mondo.cli._confirm import confirm_or_abort as _confirm
 from mondo.cli._examples import epilog_for
 from mondo.cli._exec import (
@@ -42,75 +42,13 @@ from mondo.cli._exec import (
 from mondo.cli._resolve import resolve_required_id
 from mondo.cli._url import MondayIdParam
 from mondo.cli.context import GlobalOpts
+from mondo.services.items import build_column_values
 from mondo.util.kvparse import parse_column_kv
-
-if TYPE_CHECKING:
-    from mondo.api.client import MondayClient
 
 app = typer.Typer(
     no_args_is_help=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-
-
-# ----- helpers -----
-
-
-def _parse_settings(raw: str | None) -> dict[str, Any]:
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
-
-
-def _build_column_values(
-    opts: GlobalOpts,
-    client: MondayClient,
-    subitems_board_id: int | None,
-    pairs: list[str],
-    *,
-    create_labels: bool = False,
-) -> dict[str, Any]:
-    """Turn `--column K=V` pairs into the write JSON shape.
-
-    With `subitems_board_id` set, does codec dispatch via the subitems-board
-    column types. Without it, values pass through verbatim.
-    """
-    from mondo.columns import UnknownColumnTypeError, parse_value
-
-    parsed_pairs = [parse_column_kv(p) for p in pairs]
-    if subitems_board_id is None:
-        return dict(parsed_pairs)
-    try:
-        columns = fetch_board_columns(opts, client, subitems_board_id)
-    except NotFoundError:
-        return dict(parsed_pairs)
-    defs = {c["id"]: c for c in columns}
-    out: dict[str, Any] = {}
-    for col_id, raw_value in parsed_pairs:
-        definition = defs.get(col_id)
-        # dict/list/None: structured JSON the user crafted — pass through as raw.
-        # Bare scalars (int, float, bool) are valid codec shorthand and must be
-        # stringified so the codec sees them (mirror of mondo.services.items.build_column_values).
-        if definition is None or isinstance(raw_value, (dict, list)) or raw_value is None:
-            out[col_id] = raw_value
-            continue
-        col_type = definition.get("type")
-        if not isinstance(col_type, str):
-            out[col_id] = raw_value
-            continue
-        settings = _parse_settings(definition.get("settings_str"))
-        str_value = raw_value if isinstance(raw_value, str) else json.dumps(raw_value)
-        try:
-            out[col_id] = parse_value(col_type, str_value, settings, create_labels=create_labels)
-        except UnknownColumnTypeError:
-            out[col_id] = raw_value
-        except ValueError as e:
-            raise ValueError(f"--column {col_id}={raw_value!r}: {e}") from e
-    return out
 
 
 # ----- read commands -----
@@ -316,11 +254,12 @@ def create_cmd(
             client = client_or_exit(opts)
             try:
                 with client:
-                    col_values = _build_column_values(
+                    col_values = build_column_values(
                         opts,
                         client,
                         subitems_board,
                         columns,
+                        raw_mode=False,
                         create_labels=create_labels_if_missing,
                     )
             except MondoError as e:

--- a/tests/integration/test_live_subitems.py
+++ b/tests/integration/test_live_subitems.py
@@ -6,6 +6,7 @@ up — never touches the original 5 fixture items.
 
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any
 
@@ -169,6 +170,99 @@ def test_live_subitem_set_and_get_column_value(
         assert values.get(text_col_id) == text_value, f"text col={values.get(text_col_id)!r}"
 
     wait_for("subitem text column landed", _value_landed)
+
+
+@pytest.mark.integration
+def test_live_subitem_create_with_tags_codec_resolves_names(
+    pm_board_session: PmBoard, cleanup_plan: CleanupPlan
+) -> None:
+    """`subitem create --subitems-board --column <tags>=name` resolves the tag
+    name to an id via create_or_get_tag, matching `item create`.
+
+    Regression for the subitem path that previously skipped tag resolution:
+    a bare name hit the tags codec and exited 5. The successful create alone
+    proves the fix (the old path would have errored); the round-trip confirms
+    the resolved tag actually landed on the subitem.
+    """
+    pm = pm_board_session
+    suffix = uuid.uuid4().hex[:8]
+    parent_id = _scratch_parent(pm, cleanup_plan, suffix)
+
+    # Materialize the subitems board via a throwaway name-only subitem.
+    seed = invoke_json(
+        ["subitem", "create", "--parent", str(parent_id), "--name", f"E2E Seed {suffix}"]
+    )
+    seed_id = int(seed["id"])
+    cleanup_plan.add(f"subitem seed {seed_id}", "subitem", "delete", "--id", str(seed_id), "--hard")
+
+    sub_listing = wait_for(
+        "seed subitem listed",
+        lambda: invoke_json(["subitem", "list", "--parent", str(parent_id)]),
+    )
+    sub_board_id = None
+    for s in sub_listing:
+        if int(s["id"]) == seed_id:
+            sub_board_id = (s.get("board") or {}).get("id")
+            break
+    assert sub_board_id, "could not resolve subitems board id"
+
+    # Ensure a tags column exists on the subitems board (default boards have none).
+    sub_columns = invoke_json(["column", "list", "--board", str(sub_board_id)])
+    tags_col = next((c for c in sub_columns if c.get("type") == "tags"), None)
+    if tags_col is None:
+        created = invoke_json(
+            [
+                "column",
+                "create",
+                "--board",
+                str(sub_board_id),
+                "--title",
+                "E2E Sub Tags",
+                "--type",
+                "tags",
+                "--id",
+                "e2e_sub_tags",
+            ]
+        )
+        tags_col_id = created["id"]
+    else:
+        tags_col_id = tags_col["id"]
+
+    # The actual fix under test: a bare tag NAME on subitem create.
+    tag_name = f"E2ETag{suffix}"
+    sub = invoke_json(
+        [
+            "subitem",
+            "create",
+            "--parent",
+            str(parent_id),
+            "--name",
+            f"E2E Sub Tags {suffix}",
+            "--subitems-board",
+            str(sub_board_id),
+            "--column",
+            f"{tags_col_id}={tag_name}",
+        ]
+    )
+    sub_id = int(sub["id"])
+    cleanup_plan.add(f"subitem tags {sub_id}", "subitem", "delete", "--id", str(sub_id), "--hard")
+
+    def _tag_landed() -> None:
+        got = invoke_json(["subitem", "get", "--id", str(sub_id)])
+        cv = {v["id"]: v for v in got.get("column_values") or []}
+        col = cv.get(tags_col_id)
+        assert col is not None, f"tags column {tags_col_id} missing: {list(cv)}"
+        text = col.get("text") or ""
+        ids: list[int] = []
+        raw_value = col.get("value")
+        if raw_value:
+            try:
+                ids = (json.loads(raw_value) or {}).get("tag_ids") or []
+            except json.JSONDecodeError, TypeError:
+                ids = []
+        assert tag_name in text or ids, f"tag not resolved: text={text!r} value={raw_value!r}"
+
+    wait_for("subitem tag column landed", _tag_landed)
 
 
 @pytest.mark.integration

--- a/tests/unit/test_cli_subitem.py
+++ b/tests/unit/test_cli_subitem.py
@@ -356,6 +356,64 @@ class TestCreate:
             "person9": {"personsAndTeams": [{"id": 37251583, "kind": "person"}]}
         }
 
+    def test_tags_codec_resolves_names_to_ids(self, httpx_mock: HTTPXMock) -> None:
+        """subitem create resolves tag names to ids via create_or_get_tag,
+        matching `item create`. Previously the subitem path skipped tag
+        resolution, so a bare name hit the tags codec and errored."""
+        # 1) preflight fetch of the subitems-board columns (a tags column)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "boards": [
+                        {
+                            "id": "99",
+                            "name": "SubBoard",
+                            "columns": [
+                                {
+                                    "id": "tags9",
+                                    "title": "Tags",
+                                    "type": "tags",
+                                    "settings_str": "{}",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ),
+        )
+        # 2) name -> id resolution via create_or_get_tag
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_or_get_tag": {"id": "111", "name": "urgent"}}),
+        )
+        # 3) the create_subitem mutation
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_subitem": {"id": "20"}}),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "subitem",
+                "create",
+                "--parent",
+                "1",
+                "--name",
+                "Hi",
+                "--subitems-board",
+                "99",
+                "--column",
+                "tags9=urgent",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        v = _last_body(httpx_mock)["variables"]
+        assert json.loads(v["values"]) == {"tags9": {"tag_ids": [111]}}
+
 
 class TestMoveRenameArchive:
     def test_rename(self, httpx_mock: HTTPXMock) -> None:


### PR DESCRIPTION
Routes `subitem create`'s column-value building through the shared `mondo.services.items.build_column_values` (introduced in #50), removing the last duplicate of the column-value codec pipeline.

**Stacked on #50** (`refactor/item-service-layer`) — merge that first. This PR's diff shows only the subitem commits.

## ⚠️ Behavior change (intentional bug fix)
subitem's local `_build_column_values` never resolved `tags` column values from **names → IDs**, so:

```
mondo subitem create --subitems-board <id> --column <tags-col>=urgent
# before: error "tags codec accepts integer IDs only (got 'urgent')" (exit 5)
# after:  resolves "urgent" via create_or_get_tag, like `mondo item create`
```

All other codecs (status / people / dropdown / …) and raw passthrough are **unchanged** — they share the exact code path the service already used.

## Verification
- **Unit:** new regression test (red before the fix, green after); full suite **1640 passed**
- **Live (real monday.com):** new `test_live_subitem_create_with_tags_codec_resolves_names` creates a subitem with a bare tag name and round-trips to confirm the resolved tag lands — **4/4 live subitem tests passed**
- `ruff check` · `ruff format --check` · `mypy` → clean
- `subitem.py`: 435 → 374 lines

Commits: `efc2091` (fix + dedup + unit test), `f58a9eb` (live test).

🤖 PR opened with assistance from Claude Code.
