### PR TITLE
test(integration): stop cache-tag test leaking tags on shared board

### DIFF
--- a/tests/integration/test_live_cache.py
+++ b/tests/integration/test_live_cache.py
@@ -68,7 +68,11 @@ def test_live_cache_tags_invalidated_on_create_or_get(
 
     # Mint a tag (or get an existing one with this name). Either way, the
     # cache file should be dropped by `invalidate_entity(opts, "tags")`.
-    tag_name = f"e2e-cache-{uuid.uuid4().hex[:8]}"
+    # Use a stable name so `create-or-get` is idempotent across runs: there
+    # is no `tag delete` CLI path, so a unique name would leak a new tag onto
+    # the shared board every run. The name's uniqueness isn't load-bearing —
+    # any create-or-get call proves the cache invalidation.
+    tag_name = "e2e-cache-tag"
     invoke(["tag", "create-or-get", "--name", tag_name, "--board", str(live_test_board_id)])
     assert not tags_file.exists(), "tag create-or-get did not invalidate tags cache"
 


### PR DESCRIPTION
Resolves #53.

## Problem
`tests/integration/test_live_cache.py::test_live_cache_tags_invalidated_on_create_or_get` minted a uniquely-named tag (`e2e-cache-{uuid}`) on every run against the **long-lived** `MONDO_TEST_BOARD_ID` board, with no cleanup. monday board tags are effectively permanent and there is **no `tag delete` CLI command**, so each run permanently accumulated another `e2e-cache-*` tag on the shared board.

## Fix
Make the tag name **deterministic and reusable** (`e2e-cache-tag`) so `create-or-get` is idempotent across runs — only ever one leftover `e2e-cache-tag`, reused each run, instead of unbounded growth. The test only needs *a* `create-or-get` call to prove cache invalidation; the name's uniqueness was never load-bearing. Added a comment documenting why the name is stable. `import uuid` is retained (still used by 5 other tests in the file).

## Testing
- Non-integration suite: green (collection verified; this file is integration-only).
- Affected live test run **twice in a row**: both passed — second run reused tag id `6087226` rather than minting a new one (idempotency proof).
- `ruff check` / `ruff format`: clean.

## Review
- `/simplify`: clean (one-line change, no orphaned imports).
- `/code-review` (high): no correctness findings — cache invalidation is unconditional after the mutation; per-test `tmp_path` cache dirs mean the shared tag name causes no cross-test interference.
- `/codex` (gpt-5.5): clean.

## Manual cleanup needed (no CLI delete path)
The following pre-existing leaked tags on board `5094861043` should be deleted by hand from the monday UI (keep the new stable `e2e-cache-tag`, id `6087226`):

| id | name |
|----|------|
| 6052259 | e2e-cache-8b926152 |
| 6052260 | e2e-cache-e1977094 |
| 6052261 | e2e-cache-532d5f3e |
| 6087156 | e2e-cache-0999b96b |
| 6087170 | e2e-cache-f8f7f142 |
| 6087216 | e2e-cache-135db434 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)