### PR TITLE
test(integration): strengthen weak postcondition assertions in live tests

### DIFF
--- a/tests/integration/test_live_boards.py
+++ b/tests/integration/test_live_boards.py
@@ -354,6 +354,14 @@ def test_live_board_update_and_set_permission(
 
     wait_for("board renamed", _renamed)
 
+    # set-permission --role contributor restricts editing to collaborators: the
+    # readable `permissions` field flips from "everyone" to "collaborators".
+    def _restricted() -> None:
+        b = invoke_json(["board", "get", "--id", str(board_id)])
+        assert b.get("permissions") == "collaborators", f"permissions={b.get('permissions')!r}"
+
+    wait_for("board permission restricted", _restricted)
+
 
 @pytest.mark.integration
 def test_live_board_archive(pm_board_session: PmBoard, cleanup_plan: CleanupPlan) -> None:

--- a/tests/integration/test_live_subitems.py
+++ b/tests/integration/test_live_subitems.py
@@ -6,7 +6,6 @@ up — never touches the original 5 fixture items.
 
 from __future__ import annotations
 
-import json
 import uuid
 from typing import Any
 
@@ -253,14 +252,7 @@ def test_live_subitem_create_with_tags_codec_resolves_names(
         col = cv.get(tags_col_id)
         assert col is not None, f"tags column {tags_col_id} missing: {list(cv)}"
         text = col.get("text") or ""
-        ids: list[int] = []
-        raw_value = col.get("value")
-        if raw_value:
-            try:
-                ids = (json.loads(raw_value) or {}).get("tag_ids") or []
-            except json.JSONDecodeError, TypeError:
-                ids = []
-        assert tag_name in text or ids, f"tag not resolved: text={text!r} value={raw_value!r}"
+        assert tag_name in text, f"tag not resolved: text={text!r}"
 
     wait_for("subitem tag column landed", _tag_landed)
 

--- a/tests/integration/test_live_updates.py
+++ b/tests/integration/test_live_updates.py
@@ -155,12 +155,42 @@ def test_live_update_pin_and_like_lifecycle(
         # The CLI's update list returns enriched fields; tolerate variations.
         likes = match.get("likes") or match.get("liked_by") or []
         assert likes, f"update has no likes recorded: {match}"
+        # Assert the pin landed too, otherwise the later unpin postcondition
+        # (pinned_to_top falsy) would pass even if `update pin` never worked.
+        assert match.get("pinned_to_top"), f"update not pinned: {match.get('pinned_to_top')}"
 
     wait_for("pinned + liked", _pinned_and_liked)
 
     invoke_json(["update", "unlike", str(update_id)])
+
+    def _unliked() -> None:
+        ups = invoke_json(["update", "list", "--item", str(item_id)])
+        match = next((u for u in ups if int(u.get("id", 0)) == update_id), None)
+        assert match is not None, f"update {update_id} not visible after unlike"
+        likes = match.get("likes") or match.get("liked_by") or []
+        assert not likes, f"update still has likes after unlike: {likes}"
+
+    wait_for("unliked", _unliked)
+
     invoke_json(["update", "unpin", str(update_id)])
+
+    def _unpinned() -> None:
+        ups = invoke_json(["update", "list", "--item", str(item_id)])
+        match = next((u for u in ups if int(u.get("id", 0)) == update_id), None)
+        assert match is not None, f"update {update_id} not visible after unpin"
+        assert not match.get("pinned_to_top"), f"update still pinned: {match.get('pinned_to_top')}"
+
+    wait_for("unpinned", _unpinned)
+
     invoke_json(["update", "delete", str(update_id)])
+
+    def _deleted() -> None:
+        ups = invoke_json(["update", "list", "--item", str(item_id)])
+        assert not any(int(u.get("id", 0)) == update_id for u in ups), (
+            f"deleted update {update_id} still visible"
+        )
+
+    wait_for("deleted", _deleted)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Resolves #54.

Three live integration tests invoked commands but didn't verify their effect, so a silent regression would pass. Each gap is now closed with `wait_for`-wrapped postconditions (monday is eventually-consistent).

## 1. `update unlike` / `unpin` / `delete` not verified — `test_live_updates.py`
*(gap introduced in #52)* The lifecycle test called unlike/unpin/delete with only an exit-0 check. Now:
- after **unlike** → re-fetch and assert `likes` is empty;
- after **unpin** → assert `pinned_to_top` is falsy;
- after **delete** → assert the update no longer appears in `update list --item`.

Also strengthened the precondition: `_pinned_and_liked` now asserts `pinned_to_top` is **truthy** before unpinning — otherwise the unpin postcondition could pass even if `update pin` never worked (caught by the `/codex` review).

## 2. Tag-codec test accepted any resolved tag — `test_live_subitems.py`
*(pre-existing)* The assertion `tag_name in text or ids` passed as long as *any* tag id landed. Tightened to `assert tag_name in text` (a tags column's `text` is the comma-joined tag names), removing the `or ids` escape hatch and the now-dead `value`/`json` parsing (and its orphaned `import json`).

## 3. `board set-permission` invoked but not verified — `test_live_boards.py`
*(pre-existing)* Now reads the board back and asserts `permissions == "collaborators"`. Verified live that `set-permission --role contributor` flips the readable `permissions` field `everyone → collaborators` — so this is observable on read (the stronger of the issue's two suggested options; no exit-code-only fallback needed).

## Testing
- Non-integration suite: **1691 passed**.
- All three affected live tests pass against the playground board; the pin lifecycle re-verified live after the `/codex` fix. Tests self-clean via cleanup fixtures.
- `ruff check` / `ruff format`: clean.

## Review
- `/simplify`: clean (repeated update-lookup lambda matches existing `_pinned_and_liked` style — left as-is).
- `/code-review` (high): no correctness findings; all new blocks guard `match is not None` before dereferencing.
- `/codex` (gpt-5.5): caught the missing positive-pin precondition (item #1 above), now fixed and re-verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)