### PR TITLE
fix: reduce agent friction surfaced by usage audit

### DIFF
--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -1351,7 +1351,7 @@ def update_block_cmd(
     ignored: block IDs are globally unique, so the block ID alone targets it.
     """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    del doc_id, object_id  # tolerated for ergonomic symmetry; block ID suffices
+    del doc_id, object_id  # flags kept for symmetry; block ID alone targets the block
     block_id = resolve_required_id(id_pos, id_flag, flag_name="--id", resource="block")
     parsed_content = parse_json_flag(content, flag_name="--content")
     # monday's JSON scalar wants the content as a JSON-encoded string (matches
@@ -1377,7 +1377,7 @@ def delete_block_cmd(
     ignored: block IDs are globally unique, so the block ID alone targets it.
     """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    del doc_id, object_id  # tolerated for ergonomic symmetry; block ID suffices
+    del doc_id, object_id  # flags kept for symmetry; block ID alone targets the block
     block_id = resolve_required_id(id_pos, id_flag, flag_name="--id", resource="block")
     variables = {"block": block_id}
     data = execute(opts, DELETE_DOC_BLOCK, variables)

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -1339,12 +1339,19 @@ def update_block_cmd(
     ctx: typer.Context,
     id_pos: str | None = typer.Argument(None, metavar="[BLOCK_ID]", help="Block ID (positional)."),
     id_flag: str | None = typer.Option(None, "--id", "--block", help="Block ID (flag form)."),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
     content: str = typer.Option(
         ..., "--content", metavar="JSON", help="Replacement content as JSON."
     ),
 ) -> None:
-    """Replace a single block's content."""
+    """Replace a single block's content.
+
+    `--doc`/`--object-id` are accepted for symmetry with `add-block` but
+    ignored: block IDs are globally unique, so the block ID alone targets it.
+    """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+    del doc_id, object_id  # tolerated for ergonomic symmetry; block ID suffices
     block_id = resolve_required_id(id_pos, id_flag, flag_name="--id", resource="block")
     parsed_content = parse_json_flag(content, flag_name="--content")
     # monday's JSON scalar wants the content as a JSON-encoded string (matches
@@ -1361,9 +1368,16 @@ def delete_block_cmd(
     ctx: typer.Context,
     id_pos: str | None = typer.Argument(None, metavar="[BLOCK_ID]", help="Block ID (positional)."),
     id_flag: str | None = typer.Option(None, "--id", "--block", help="Block ID (flag form)."),
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
 ) -> None:
-    """Delete a single block from a doc."""
+    """Delete a single block from a doc.
+
+    `--doc`/`--object-id` are accepted for symmetry with `add-block` but
+    ignored: block IDs are globally unique, so the block ID alone targets it.
+    """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+    del doc_id, object_id  # tolerated for ergonomic symmetry; block ID suffices
     block_id = resolve_required_id(id_pos, id_flag, flag_name="--id", resource="block")
     variables = {"block": block_id}
     data = execute(opts, DELETE_DOC_BLOCK, variables)

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mondo
 description: Use when the user wants to do anything against monday.com via the `mondo` CLI — reading or writing workspaces, folders, boards, groups, items, subitems, columns, updates, docs, files, users, teams, webhooks, or when they paste a monday.com URL.
-version: "1.5.0"
+version: "1.6.0"
 ---
 
 # mondo
@@ -79,7 +79,7 @@ Consult these *before* improvising. Each is a Goal / Command / Output / Gotcha s
 - **Never `2>/dev/null` a mondo call.** Errors, recovery hints, and the JSON error envelope live on stderr; suppressed, a failure is just empty stdout + a nonzero exit. Benign notices (cache hits, skill-freshness) are withheld in non-TTY runs, so stderr is errors-only in pipelines — use `2>&1` or leave it attached and branch on the exit code.
 - **Name search over directories is cached.** `board / doc list --name-contains` serves from an 8h directory cache (folders have no name filter — use `folder tree` or plain `folder list`); the first cold search of the day pays the full directory fetch (parallelized, but still the expensive step). Don't add `--no-cache` to name searches out of caution — the cache IS the fast path; use `--refresh-cache` only when you have a concrete staleness reason.
 - **Cleanup:** delete commands soft-archive by default; pass `--hard` for true delete.
-- **Escape hatch:** `mondo graphql '<query>'` for anything no subcommand wraps. **Pass the query as a positional** — `-q/--query` is the global JMESPath projection, not the GraphQL query. If a GraphQL document lands in `--query` anyway, mondo runs it as the query (stderr note) but disables the projection for that call; pass it positionally to combine with `-q`.
+- **Escape hatch:** `mondo graphql '<query>'` for anything no subcommand wraps. **Pass the query as a positional** — `-q/--query` is the global JMESPath projection, not the GraphQL query. If a GraphQL document lands in `--query` anyway, mondo runs it as the query (stderr note) but disables the projection for that call; pass it positionally to combine with `-q`. Before reaching for `graphql`, check there isn't already a subcommand: a file/asset download link is `mondo file url --asset <id> -q '[0].public_url'`, **not** a hand-written `graphql 'query { assets(ids:[…]) { public_url } }'`.
 - **Cache notice:** read commands may emit `cache: hit (entity=…, age=…)` to stderr. Suppress with `MONDO_NO_CACHE_NOTICE=1`. Force refresh with `--no-cache` or `--refresh-cache` on any cached read (`<entity> list/get` directories plus per-board / per-item / per-doc caches — `item get`, `item list` bare board scope (60s TTL), `subitem list/get`, `update list --item`, `doc get`, `board get`, `webhook list`, `tag list/get`). Filtered `item list` variants, account-wide `update list`, and `mondo graphql` stay live. See `docs/caching.md` for the per-entity TTL table.
 
 ## When references aren't enough

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -1143,6 +1143,43 @@ class TestBlocks:
         result = runner.invoke(app, ["doc", "delete-block", "--id", "b1"])
         assert result.exit_code == 0, result.stdout
 
+    def test_delete_block_tolerates_object_id(self, httpx_mock: HTTPXMock) -> None:
+        # Agents extrapolate --object-id from add-block / doc get; block edits
+        # only need the (globally unique) block id, so the flag is accepted and
+        # ignored rather than rejected with "No such option".
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"delete_doc_block": {"id": "b1"}}),
+        )
+        result = runner.invoke(
+            app, ["doc", "delete-block", "--object-id", "5098716806", "--id", "b1"]
+        )
+        assert result.exit_code == 0, result.stdout
+        assert _last_body(httpx_mock)["variables"] == {"block": "b1"}
+
+    def test_update_block_tolerates_doc(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"update_doc_block": {"id": "b1", "type": "normal_text"}}),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "doc",
+                "update-block",
+                "--doc",
+                "1777684749",
+                "--id",
+                "b1",
+                "--content",
+                '{"deltaFormat":[{"insert":"new"}]}',
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        assert _last_body(httpx_mock)["variables"]["block"] == "b1"
+
 
 class TestDocPagination:
     def test_get_markdown_paginates_blocks(self, httpx_mock: HTTPXMock) -> None:


### PR DESCRIPTION
Driven by `/mondo-usage-audit` over the v0.9.0..v0.10.0 window (480 transcripts, 96 sessions using mondo, 759 invocations, 94% success). The audit found the CLI itself is healthy — most failures were agent shell bugs or permission-classifier denials, not mondo. These two changes address the small set of *real* mondo-side friction.

## Changes

### 1. `doc update-block` / `delete-block` tolerate `--doc` / `--object-id`
`add-block` **requires** a doc id (`--doc`/`--object-id`); `doc get`/`export-markdown` take it too. Agents learn that pattern and extrapolate it to the block-edit commands, which previously rejected `--object-id` with a bare `No such option` (2 failures in the window, one project). Block IDs are globally-unique UUIDs, so the doc id isn't needed — the commands now **accept and ignore** it so the natural guess succeeds. Non-breaking; the GraphQL payload is unchanged (still `{block: <id>}`).

### 2. SKILL.md points at `file url --asset` instead of hand-written graphql
~8 raw graphql escapes in the window hand-wrote `query { assets(ids:[…]) { public_url } }` to get an asset download link — a capability `mondo file url --asset <id> -q '[0].public_url'` already provides and that `references/files.md` already documents. Added a one-line pointer to the escape-hatch note so it's visible before improvising. Bundled skill version bumped 1.5.0 → 1.6.0.

## Testing
- Added 2 unit tests: `delete-block --object-id … --id …` and `update-block --doc … --id …` both exit 0 and send only `{block}`.
- Full non-integration suite green: **1693 passed**, 141 deselected.
- `ruff check` / `ruff format --check` clean on changed files.
- Verified `--help` renders the new flags on both commands.

Not live-verified on the playground: the change is purely "accept and ignore an extra flag" with an unchanged API payload, fully covered by the mocked round-trip tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)