### PR TITLE
fix(doc): resilient markdown chunking + clear, table/bold normalization, license hint

### DIFF
--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -691,6 +691,9 @@ EXAMPLES: dict[str, list[Example]] = {
     "doc delete": [
         Example("Delete a doc", "mondo doc delete --doc 7"),
     ],
+    "doc clear": [
+        Example("Remove all blocks but keep the doc", "mondo doc clear --doc 7"),
+    ],
     "doc export-markdown": [
         Example("Export the whole doc as markdown", "mondo doc export-markdown --doc 7"),
         Example(

--- a/src/mondo/cli/_exec.py
+++ b/src/mondo/cli/_exec.py
@@ -32,7 +32,9 @@ if TYPE_CHECKING:
     from mondo.cli.context import GlobalOpts
 
 
-def _emit_error(exc: BaseException, *, human_suffix: str | None = None) -> None:
+def _emit_error(
+    exc: BaseException, *, human_suffix: str | None = None, suggestion: str | None = None
+) -> None:
     """Print the human-readable red `error:` line plus, in machine
     output mode, the JSON envelope on stderr (Phase 5.1).
 
@@ -42,29 +44,38 @@ def _emit_error(exc: BaseException, *, human_suffix: str | None = None) -> None:
 
     `human_suffix` lets callers append a multi-line hint to the human
     output (e.g. `_execute_create_item`'s column-value reminder)
-    without polluting the structured envelope.
+    without polluting the structured envelope. `suggestion` carries an
+    actionable hint into both the human output and the structured
+    `suggestion` envelope field.
     """
     line = f"error: {exc}"
     if human_suffix:
         line = f"{line}\n{human_suffix}"
+    if suggestion:
+        line = f"{line}\n{suggestion}"
     typer.secho(line, fg=typer.colors.RED, err=True)
 
     ctx = click.get_current_context(silent=True)
     opts = ctx.ensure_object(_GlobalOpts) if ctx is not None else None
     if is_machine_output(opts):
-        envelope = error_envelope(exc)
+        envelope = error_envelope(exc, suggestion=suggestion)
         emit_envelope(envelope)
         mirror_envelope_to_stdout(opts, envelope)
 
 
-def handle_mondo_error_or_exit(exc: MondoError, *, human_suffix: str | None = None) -> NoReturn:
+def handle_mondo_error_or_exit(
+    exc: MondoError, *, human_suffix: str | None = None, suggestion: str | None = None
+) -> NoReturn:
     """Standard CLI handler for any `MondoError` raised mid-command.
 
     Collapses the `typer.secho(f"error: {e}", ...) + raise typer.Exit`
     pair so every command module shares one error-rendering path —
     including the Phase 5.1 JSON envelope on stderr in machine mode.
+
+    `suggestion` surfaces an actionable hint in both the human output and
+    the structured `suggestion` envelope field.
     """
-    _emit_error(exc, human_suffix=human_suffix)
+    _emit_error(exc, human_suffix=human_suffix, suggestion=suggestion)
     raise typer.Exit(code=int(exc.exit_code)) from exc
 
 

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -62,6 +62,7 @@ from mondo.services.docs import (
     object_id_hint,
     object_id_hint_with_client,
     resolve_doc_id_from_object_id,
+    top_level_block_ids,
 )
 
 if TYPE_CHECKING:
@@ -853,7 +854,28 @@ def create_cmd(
         "kind": kind.value if kind else None,
         "folder": folder_id,
     }
-    data = execute(opts, CREATE_DOC_IN_WORKSPACE, variables)
+    if opts.dry_run:
+        dry_run_and_exit(opts, CREATE_DOC_IN_WORKSPACE, variables)
+    client = client_or_exit(opts)
+    try:
+        with client:
+            result = client.execute(CREATE_DOC_IN_WORKSPACE, variables=variables)
+            data = result.get("data") or {}
+    except MondoError as e:
+        # A bare USER_UNAUTHORIZED here almost always means the workspace
+        # lacks a doc-creation license/policy for this account — not a broken
+        # token. Surface that so callers don't burn time re-checking auth (#64).
+        if e.code == "USER_UNAUTHORIZED" or "not permitted to create" in str(e):
+            handle_mondo_error_or_exit(
+                e,
+                suggestion=(
+                    "This usually means the workspace lacks a doc-creation "
+                    "license/policy for your account rather than a token-permission "
+                    "bug — ask an admin to verify doc-creation is enabled/licensed "
+                    "for you in this workspace."
+                ),
+            )
+        handle_mondo_error_or_exit(e)
     opts.emit(normalize_doc_entry(data.get("create_doc") or {}))
 
 
@@ -989,24 +1011,51 @@ def add_markdown_cmd(
     from_stdin: bool = typer.Option(False, "--from-stdin", help="Load markdown from stdin."),
     after: str | None = typer.Option(None, "--after", help="Insert after this block ID."),
 ) -> None:
-    """Append markdown using monday's server-side markdown parser."""
+    """Append markdown using monday's server-side markdown parser.
+
+    Large input is auto-chunked on top-level block boundaries and looped, so a
+    single oversized call can't trip monday's INTERNAL_SERVER_ERROR (#59).
+    """
+    from mondo.docs import normalize_markdown_tables
+    from mondo.services.docs import add_markdown_chunked
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    md = _load_markdown(markdown, from_file, from_stdin)
-    data, resolved_doc = _execute_doc_command(
-        opts,
-        ADD_CONTENT_TO_DOC_FROM_MARKDOWN,
-        {"md": md, "after": after},
-        doc_id=doc_id,
-        object_id=object_id,
-    )
-    result = data.get("add_content_to_doc_from_markdown") or {}
-    if not result.get("success"):
-        _fail_with_object_id_hint(
-            opts, result.get("error") or "add_content_to_doc_from_markdown failed", doc_id
+    _require_one_doc_flag(doc_id, object_id)
+    md = normalize_markdown_tables(_load_markdown(markdown, from_file, from_stdin))
+    if not md.strip():
+        handle_mondo_error_or_exit(
+            ValidationError("input produced no blocks (empty or unsupported markdown).")
         )
+
+    if doc_id is not None and opts.dry_run:
+        dry_run_and_exit(
+            opts, f"{ADD_CONTENT_TO_DOC_FROM_MARKDOWN} (chunked)", {"doc": doc_id, "md": md}
+        )
+    client = client_or_exit(opts)
+    try:
+        with client:
+            resolved_doc = _resolve_doc_in_client(opts, client, doc_id=doc_id, object_id=object_id)
+            if opts.dry_run:
+                dry_run_and_exit(
+                    opts,
+                    f"{ADD_CONTENT_TO_DOC_FROM_MARKDOWN} (chunked)",
+                    {"doc": resolved_doc, "md": md},
+                )
+            try:
+                result = add_markdown_chunked(client, resolved_doc, md, after=after)
+            except MondoError as e:
+                # A partial multi-chunk write may have already landed blocks;
+                # drop the now-stale docs_blocks cache before surfacing the error.
+                invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
+                suffix = None
+                if doc_id is not None and int(e.exit_code) in _OBJECT_ID_HINT_EXIT_CODES:
+                    suffix = object_id_hint_with_client(client, doc_id)
+                handle_mondo_error_or_exit(e, human_suffix=suffix)
+    except MondoError as e:
+        handle_mondo_error_or_exit(e)
+
     invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
-    opts.emit(result)
+    opts.emit({**result, "blocks_added": len(result.get("block_ids") or [])})
 
 
 def set_cmd(
@@ -1025,6 +1074,9 @@ def set_cmd(
     blanking the doc. The doc id / object_id / URL are preserved — only the
     body changes. Mirrors `column doc set` overwrite semantics.
     """
+    from mondo.docs import normalize_markdown_tables
+    from mondo.services.docs import add_markdown_chunked
+
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     _require_one_doc_flag(doc_id, object_id)
     md = _load_markdown(markdown, from_file, from_stdin)
@@ -1033,6 +1085,7 @@ def set_cmd(
             "refusing to replace doc content with empty markdown "
             "(use `doc delete` to remove the doc itself)."
         )
+    md = normalize_markdown_tables(md)
 
     _plan = f"{ADD_CONTENT_TO_DOC_FROM_MARKDOWN} + {DELETE_DOC_BLOCK} (per prior block)"
     if doc_id is not None and opts.dry_run:
@@ -1048,27 +1101,33 @@ def set_cmd(
             if existing_doc is None:
                 _emit_doc_id_not_found(client, resolved_doc, probe=doc_id is not None)
                 raise typer.Exit(code=6)
-            old_block_ids = [
-                str(b["id"])
-                for b in (existing_doc.get("blocks") or [])
-                if isinstance(b, dict) and b.get("id")
-            ]
-            # Add the new content first (after the current last block); only
-            # once it lands do we delete the prior blocks. A failed add leaves
-            # the doc untouched — no destructive half-state / data loss.
-            added = exec_or_exit(
-                client,
-                ADD_CONTENT_TO_DOC_FROM_MARKDOWN,
-                {"doc": resolved_doc, "md": md, "after": last_block_id(existing_doc)},
-            )
-            result = added.get("add_content_to_doc_from_markdown") or {}
-            if not result.get("success"):
-                # Nothing deleted yet: the doc still holds its original content.
-                _fail_with_object_id_hint(
-                    opts,
-                    result.get("error") or "add_content_to_doc_from_markdown failed",
-                    doc_id,
+            # Only top-level blocks: deleting a container (e.g. a `table`)
+            # cascades its children, and re-deleting a cascaded child id 400s.
+            old_block_ids = top_level_block_ids(existing_doc)
+            # Add the new content first (after the current last TOP-LEVEL
+            # block); only once it lands do we delete the prior blocks. A failed
+            # add leaves the doc untouched — no destructive half-state / data
+            # loss. The anchor must be a root block: the doc's literal last
+            # block may be a container child (e.g. a table cell), and anchoring
+            # `add_content_to_doc_from_markdown` to a child id is rejected with
+            # INTERNAL_SERVER_ERROR. Large markdown is auto-chunked (#59); all
+            # chunks must succeed before any delete runs.
+            try:
+                result = add_markdown_chunked(
+                    client,
+                    resolved_doc,
+                    md,
+                    after=(old_block_ids[-1] if old_block_ids else None),
                 )
+            except MondoError as e:
+                # No deletes have run, so the original content is intact; but a
+                # partial multi-chunk add may have appended blocks, so drop the
+                # now-stale docs_blocks cache before surfacing the error.
+                invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
+                suffix = None
+                if doc_id is not None and int(e.exit_code) in _OBJECT_ID_HINT_EXIT_CODES:
+                    suffix = object_id_hint_with_client(client, doc_id)
+                handle_mondo_error_or_exit(e, human_suffix=suffix)
             # New content is in place; the doc is mutated now, so drop the cache
             # even if a subsequent delete fails partway.
             invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
@@ -1199,6 +1258,45 @@ def delete_cmd(
     opts.emit(data.get("delete_doc"))
 
 
+@app.command("clear", epilog=epilog_for("doc clear"))
+def clear_cmd(
+    ctx: typer.Context,
+    doc_id: DocIdOpt = None,
+    object_id: DocObjectIdOpt = None,
+) -> None:
+    """Remove all blocks from a doc, keeping the doc itself.
+
+    Unlike `doc delete` (which removes the document), this empties the body
+    while preserving the id / object_id / URL. An already-empty doc is a
+    no-op (`cleared_blocks: 0`).
+    """
+    opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+    _require_one_doc_flag(doc_id, object_id)
+
+    _plan = f"{DELETE_DOC_BLOCK} (per top-level block)"
+    if doc_id is not None and opts.dry_run:
+        dry_run_and_exit(opts, _plan, {"doc": doc_id})
+
+    client = client_or_exit(opts)
+    try:
+        with client:
+            resolved_doc = _resolve_doc_in_client(opts, client, doc_id=doc_id, object_id=object_id)
+            if opts.dry_run:
+                dry_run_and_exit(opts, _plan, {"doc": resolved_doc})
+            existing_doc = _fetch_doc_by_id_all_blocks(client, resolved_doc)
+            if existing_doc is None:
+                _emit_doc_id_not_found(client, resolved_doc, probe=doc_id is not None)
+                raise typer.Exit(code=6)
+            block_ids = top_level_block_ids(existing_doc)
+            for block_id in block_ids:
+                exec_or_exit(client, DELETE_DOC_BLOCK, {"block": block_id})
+    except MondoError as e:
+        handle_mondo_error_or_exit(e)
+
+    invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
+    opts.emit({"id": resolved_doc, "cleared_blocks": len(block_ids)})
+
+
 @app.command("export-markdown", epilog=epilog_for("doc export-markdown"))
 def export_markdown_cmd(
     ctx: typer.Context,
@@ -1268,7 +1366,11 @@ def export_markdown_cmd(
         _fail_with_object_id_hint(
             opts, result.get("error") or "export_markdown_from_doc failed", doc_id
         )
-    markdown = result.get("markdown") or ""
+    from mondo.docs import coalesce_markdown_emphasis
+
+    # Monday's exporter fragments contiguous bold runs into adjacent `**…**`
+    # spans; rejoin them so the markdown reads as one span (#62).
+    markdown = coalesce_markdown_emphasis(result.get("markdown") or "")
     if out is not None:
         from mondo.cli._doc_images import localize_markdown_images
 

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -1059,16 +1059,22 @@ def add_markdown_cmd(
     opts.emit({**result, "blocks_added": len(result.get("block_ids") or [])})
 
 
-def _rollback_added_blocks(client: MondayClient, doc_id: int, *, keep: list[str]) -> None:
-    """Best-effort: delete any top-level blocks added during a failed chunked
-    `set`, restoring the doc to its pre-add block set (`keep`).
+def _rollback_added_blocks(
+    client: MondayClient, doc_id: int, *, added: list[str], keep: list[str]
+) -> None:
+    """Best-effort: delete the top-level blocks a failed chunked `set` already
+    created, restoring the doc to its pre-add block set.
 
-    A multi-chunk add can append some new blocks before a later chunk fails;
-    without this the doc would be left with the old content *plus* a partial
-    replacement. Swallows its own errors — the caller surfaces the original
-    failure, which must not be masked by a rollback hiccup.
+    `added` is the ids the add reported (top-level + nested children); `keep`
+    is the doc's pre-add top-level ids. We delete only blocks that are BOTH
+    currently top-level AND in `added` — so a concurrent edit landing between
+    the original fetch and this rollback is never touched, and child ids (whose
+    parent's deletion cascades them, and which 400 on direct delete) are
+    skipped. Swallows its own errors — the caller surfaces the original failure.
     """
-    keep_set = set(keep)
+    targets = set(added) - set(keep)
+    if not targets:
+        return
     try:
         # _fetch_doc_by_id_all_blocks → exec_or_exit raises typer.Exit (not
         # MondoError) on failure; swallow both so a rollback hiccup can't mask
@@ -1079,7 +1085,7 @@ def _rollback_added_blocks(client: MondayClient, doc_id: int, *, keep: list[str]
     if doc is None:
         return
     for bid in top_level_block_ids(doc):
-        if bid not in keep_set:
+        if bid in targets:
             with contextlib.suppress(MondoError):
                 client.execute(DELETE_DOC_BLOCK, variables={"block": bid})
 
@@ -1103,7 +1109,7 @@ def set_cmd(
     set` overwrite semantics.
     """
     from mondo.docs import normalize_markdown_tables
-    from mondo.services.docs import add_markdown_chunked
+    from mondo.services.docs import PartialDocAddError, add_markdown_chunked
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     _require_one_doc_flag(doc_id, object_id)
@@ -1149,10 +1155,13 @@ def set_cmd(
                 )
             except MondoError as e:
                 # No deletes have run, so the original content is intact; but a
-                # partial multi-chunk add may have appended blocks. Roll those
-                # back (best-effort) so the failed replace leaves the doc as it
-                # was, then drop the now-stale docs_blocks cache.
-                _rollback_added_blocks(client, resolved_doc, keep=old_block_ids)
+                # partial multi-chunk add may have appended blocks. Roll back
+                # exactly the blocks that add created (best-effort) so the failed
+                # replace leaves the doc as it was, then drop the stale cache.
+                if isinstance(e, PartialDocAddError):
+                    _rollback_added_blocks(
+                        client, resolved_doc, added=e.block_ids, keep=old_block_ids
+                    )
                 invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
                 suffix = None
                 if doc_id is not None and int(e.exit_code) in _OBJECT_ID_HINT_EXIT_CODES:

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -16,6 +16,7 @@ workspace with a block-structured body. The CLI covers:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import re
 import sys
@@ -1058,6 +1059,31 @@ def add_markdown_cmd(
     opts.emit({**result, "blocks_added": len(result.get("block_ids") or [])})
 
 
+def _rollback_added_blocks(client: MondayClient, doc_id: int, *, keep: list[str]) -> None:
+    """Best-effort: delete any top-level blocks added during a failed chunked
+    `set`, restoring the doc to its pre-add block set (`keep`).
+
+    A multi-chunk add can append some new blocks before a later chunk fails;
+    without this the doc would be left with the old content *plus* a partial
+    replacement. Swallows its own errors — the caller surfaces the original
+    failure, which must not be masked by a rollback hiccup.
+    """
+    keep_set = set(keep)
+    try:
+        # _fetch_doc_by_id_all_blocks → exec_or_exit raises typer.Exit (not
+        # MondoError) on failure; swallow both so a rollback hiccup can't mask
+        # the original error.
+        doc = _fetch_doc_by_id_all_blocks(client, doc_id)
+    except MondoError, typer.Exit:
+        return
+    if doc is None:
+        return
+    for bid in top_level_block_ids(doc):
+        if bid not in keep_set:
+            with contextlib.suppress(MondoError):
+                client.execute(DELETE_DOC_BLOCK, variables={"block": bid})
+
+
 def set_cmd(
     ctx: typer.Context,
     doc_id: DocIdOpt = None,
@@ -1071,8 +1097,10 @@ def set_cmd(
     Writes the new markdown via monday's server-side parser, then removes the
     doc's prior blocks. The new content is added *before* the old blocks are
     deleted, so a failed write leaves the original content intact rather than
-    blanking the doc. The doc id / object_id / URL are preserved — only the
-    body changes. Mirrors `column doc set` overwrite semantics.
+    blanking the doc; if a multi-chunk add fails partway, the blocks it already
+    appended are rolled back so the doc is left exactly as it was. The doc id /
+    object_id / URL are preserved — only the body changes. Mirrors `column doc
+    set` overwrite semantics.
     """
     from mondo.docs import normalize_markdown_tables
     from mondo.services.docs import add_markdown_chunked
@@ -1121,8 +1149,10 @@ def set_cmd(
                 )
             except MondoError as e:
                 # No deletes have run, so the original content is intact; but a
-                # partial multi-chunk add may have appended blocks, so drop the
-                # now-stale docs_blocks cache before surfacing the error.
+                # partial multi-chunk add may have appended blocks. Roll those
+                # back (best-effort) so the failed replace leaves the doc as it
+                # was, then drop the now-stale docs_blocks cache.
+                _rollback_added_blocks(client, resolved_doc, keep=old_block_ids)
                 invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
                 suffix = None
                 if doc_id is not None and int(e.exit_code) in _OBJECT_ID_HINT_EXIT_CODES:
@@ -1288,12 +1318,15 @@ def clear_cmd(
                 _emit_doc_id_not_found(client, resolved_doc, probe=doc_id is not None)
                 raise typer.Exit(code=6)
             block_ids = top_level_block_ids(existing_doc)
+            if block_ids:
+                # Deletes mutate the doc; drop the cache up front so a failure
+                # partway through the loop can't leave a stale docs_blocks entry.
+                invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
             for block_id in block_ids:
                 exec_or_exit(client, DELETE_DOC_BLOCK, {"block": block_id})
     except MondoError as e:
         handle_mondo_error_or_exit(e)
 
-    invalidate_entity(opts, "docs_blocks", scope=str(resolved_doc))
     opts.emit({"id": resolved_doc, "cleared_blocks": len(block_ids)})
 
 

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -59,6 +59,187 @@ def extract_doc_ids_from_column_value(raw: str | None) -> list[int]:
     return ids
 
 
+# --- markdown preprocessing / chunking --------------------------------------
+
+_TABLE_SEPARATOR_RE = re.compile(r"^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$")
+
+
+def _split_table_row(line: str) -> list[str]:
+    """Split a GFM table row into its cell texts.
+
+    Strips one leading/trailing border pipe, then splits on each remaining
+    cell-separator `|`. A `\\|` escape and any `|` inside an inline-code span
+    (backtick-delimited) stay inside their cell, so a cell like `` `a|b` `` is
+    not mis-split into two columns.
+    """
+    body = line.strip()
+    if body.startswith("|"):
+        body = body[1:]
+    if body.endswith("|"):
+        body = body[:-1]
+    cells: list[str] = []
+    buf: list[str] = []
+    in_code = False
+    prev = ""
+    for ch in body:
+        if ch == "`":
+            in_code = not in_code
+            buf.append(ch)
+        elif ch == "|" and not in_code and prev != "\\":
+            cells.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+        prev = ch
+    cells.append("".join(buf))
+    return [c.strip() for c in cells]
+
+
+def _is_table_header(lines: list[str], i: int) -> bool:
+    """True when line `i` is a GFM table header: a non-blank `| … |` row
+    immediately followed by a `|---|---|` separator row."""
+    return (
+        i + 1 < len(lines)
+        and "|" in lines[i]
+        and bool(lines[i].strip())
+        and _TABLE_SEPARATOR_RE.match(lines[i + 1]) is not None
+        and "|" in lines[i + 1]
+    )
+
+
+def normalize_markdown_tables(md: str) -> str:
+    """Normalize every GFM table body row to its header's column count.
+
+    A runaway body row with MORE cells than the header otherwise spawns an
+    extra column server-side (issue #61). Short rows are padded with empty
+    cells; overflow rows have their extra trailing cells MERGED into the last
+    column (joined with a space) so no data is lost. Pipe characters inside
+    fenced code blocks are left untouched.
+    """
+    lines = md.splitlines()
+    out: list[str] = []
+    in_fence = False
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        if _CODE_FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append(line)
+            i += 1
+            continue
+        if in_fence:
+            out.append(line)
+            i += 1
+            continue
+        # A table is a header row of `| ... |` immediately followed by a
+        # `|---|---|` separator. Detect that pair, then normalize body rows.
+        if _is_table_header(lines, i):
+            col_count = len(_split_table_row(line))
+            out.append(line)
+            out.append(lines[i + 1])
+            i += 2
+            while i < n and "|" in lines[i] and lines[i].strip():
+                cells = _split_table_row(lines[i])
+                if len(cells) > col_count:
+                    cells = [*cells[: col_count - 1], " ".join(cells[col_count - 1 :])]
+                elif len(cells) < col_count:
+                    cells = [*cells, *([""] * (col_count - len(cells)))]
+                out.append("| " + " | ".join(cells) + " |")
+                i += 1
+            continue
+        out.append(line)
+        i += 1
+    trailing_newline = "\n" if md.endswith("\n") else ""
+    return "\n".join(out) + trailing_newline
+
+
+def split_markdown_for_upload(md: str, *, max_chars: int = 8000) -> list[str]:
+    """Split markdown into chunks each under `max_chars`, on blank-line
+    (top-level block) boundaries only.
+
+    Never splits inside a fenced code block (```...```) or in the middle of a
+    contiguous GFM table (header + separator + body rows). A single atomic
+    block larger than `max_chars` is emitted as its own chunk (it can't be
+    split further without corrupting it).
+    """
+    if not md.strip():
+        return []
+
+    blocks = _atomic_blocks(md)
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for block in blocks:
+        block_len = len(block)
+        # +2 accounts for the blank-line separator rejoining blocks.
+        if current and current_len + block_len + 2 > max_chars:
+            chunks.append("\n\n".join(current))
+            current = []
+            current_len = 0
+        current.append(block)
+        current_len += block_len + 2
+
+    if current:
+        chunks.append("\n\n".join(current))
+    return chunks
+
+
+def _atomic_blocks(md: str) -> list[str]:
+    """Break markdown into atomic blocks at blank-line boundaries, keeping
+    fenced code blocks and contiguous GFM tables intact as single units."""
+    lines = md.splitlines()
+    blocks: list[str] = []
+    buf: list[str] = []
+    i = 0
+    n = len(lines)
+
+    def flush() -> None:
+        if buf:
+            text = "\n".join(buf).strip("\n")
+            if text.strip():
+                blocks.append(text)
+            buf.clear()
+
+    while i < n:
+        line = lines[i]
+        if _CODE_FENCE_RE.match(line):
+            # An atomic fenced block starts a fresh block and absorbs every
+            # line through the closing fence (never split inside).
+            flush()
+            fence_lines = [line]
+            i += 1
+            while i < n and not _CODE_FENCE_RE.match(lines[i]):
+                fence_lines.append(lines[i])
+                i += 1
+            if i < n:
+                fence_lines.append(lines[i])
+                i += 1
+            blocks.append("\n".join(fence_lines))
+            continue
+        if _is_table_header(lines, i):
+            # A contiguous table (header + separator + body) is one atomic
+            # block — never split across a chunk boundary.
+            flush()
+            table_lines = [line, lines[i + 1]]
+            i += 2
+            while i < n and "|" in lines[i] and lines[i].strip():
+                table_lines.append(lines[i])
+                i += 1
+            blocks.append("\n".join(table_lines))
+            continue
+        if not line.strip():
+            flush()
+            i += 1
+            continue
+        buf.append(line)
+        i += 1
+
+    flush()
+    return blocks
+
+
 # --- markdown → blocks ------------------------------------------------------
 
 # Monday's `DocBlockContentType` enum (API 2026-01) — note that the old
@@ -191,6 +372,45 @@ def markdown_to_blocks(md: str) -> list[dict[str, Any]]:
 
     flush_paragraph()
     return blocks
+
+
+# --- export markdown post-processing ----------------------------------------
+
+# A fenced code block or an inline backtick span — content we must never touch
+# when coalescing emphasis (a literal `****` there is real, not fragmentation).
+_CODE_SPAN_OR_FENCE_RE = re.compile(r"```.*?```|`[^`\n]*`", re.DOTALL)
+
+# Zero-width bold boundary: a bold-close immediately followed by a bold-open,
+# i.e. a literal `****` that isn't part of a `***bold-italic***` triple span.
+# Bracketed by non-`*` (or string edge) so `***` runs are left intact.
+_FRAGMENTED_BOLD_RE = re.compile(r"(?<!\*)\*\*\*\*(?!\*)")
+
+
+def coalesce_markdown_emphasis(md: str) -> str:
+    """Merge fragmented bold runs in server-exported markdown (issue #62).
+
+    `export_markdown_from_doc` returns contiguous bold text as many adjacent
+    `**…**` spans, e.g. `**a ****b****c**`, leaving a zero-width `****` at each
+    seam. Collapsing every `****` (a bold-close immediately followed by a
+    bold-open) in a single pass rejoins them into one span: the regex
+    guards each match with non-`*` boundaries, so a removal joins two
+    non-`*` chars and can never manufacture a fresh seam.
+
+    Content inside backtick code spans / fenced blocks is preserved verbatim,
+    and `***bold-italic***` triple-asterisk spans are left intact (the pattern
+    only matches an isolated four-asterisk seam).
+    """
+    if "****" not in md:
+        return md
+
+    segments: list[str] = []
+    last = 0
+    for m in _CODE_SPAN_OR_FENCE_RE.finditer(md):
+        segments.append(_FRAGMENTED_BOLD_RE.sub("", md[last : m.start()]))
+        segments.append(m.group(0))  # code content: untouched
+        last = m.end()
+    segments.append(_FRAGMENTED_BOLD_RE.sub("", md[last:]))
+    return "".join(segments)
 
 
 # --- blocks → markdown ------------------------------------------------------

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -121,6 +121,7 @@ def _is_table_header(lines: list[str], i: int) -> bool:
     return (
         i + 1 < len(lines)
         and not _is_indented_code(lines[i])
+        and not _is_indented_code(lines[i + 1])
         and "|" in lines[i]
         and bool(lines[i].strip())
         and _TABLE_SEPARATOR_RE.match(lines[i + 1]) is not None
@@ -399,7 +400,10 @@ def markdown_to_blocks(md: str) -> list[dict[str, Any]]:
 
 # A fenced code block or an inline backtick span — content we must never touch
 # when coalescing emphasis (a literal `****` there is real, not fragmentation).
-_CODE_SPAN_OR_FENCE_RE = re.compile(r"```.*?```|`[^`\n]*`", re.DOTALL)
+# The inline alternative matches a run of N backticks closed by a matching run
+# (via the \1 backreference), so multi-backtick spans like `` ``a****b`` `` are
+# protected too, not just single-backtick ones.
+_CODE_SPAN_OR_FENCE_RE = re.compile(r"```[\s\S]*?```|(`+)(?:(?!\1).)+?\1")
 
 # Zero-width bold boundary: a bold-close immediately followed by a bold-open,
 # i.e. a literal `****` that isn't part of a `***bold-italic***` triple span.

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -95,11 +95,20 @@ def _split_table_row(line: str) -> list[str]:
     return [c.strip() for c in cells]
 
 
+def _is_indented_code(line: str) -> bool:
+    """True when `line` is a markdown indented code block (4+ leading spaces or
+    a leading tab). Such a line is code, never a GFM table row — even if it
+    happens to contain pipes."""
+    return line[:1] == "\t" or (len(line) - len(line.lstrip(" "))) >= 4
+
+
 def _is_table_header(lines: list[str], i: int) -> bool:
     """True when line `i` is a GFM table header: a non-blank `| … |` row
-    immediately followed by a `|---|---|` separator row."""
+    immediately followed by a `|---|---|` separator row. Indented code blocks
+    are excluded so a code sample containing pipes is never rewritten."""
     return (
         i + 1 < len(lines)
+        and not _is_indented_code(lines[i])
         and "|" in lines[i]
         and bool(lines[i].strip())
         and _TABLE_SEPARATOR_RE.match(lines[i + 1]) is not None
@@ -382,8 +391,24 @@ _CODE_SPAN_OR_FENCE_RE = re.compile(r"```.*?```|`[^`\n]*`", re.DOTALL)
 
 # Zero-width bold boundary: a bold-close immediately followed by a bold-open,
 # i.e. a literal `****` that isn't part of a `***bold-italic***` triple span.
-# Bracketed by non-`*` (or string edge) so `***` runs are left intact.
+# Bracketed by non-`*` (or string edge) so `***` runs are left intact. The
+# exporter scatters these seams next to spaces too (`here, ****an`, `it**** **
+# **i`), so no non-space guard — instead `_collapse_bold_seams` skips whole
+# lines that are thematic breaks (a lone `****`), the one false positive.
 _FRAGMENTED_BOLD_RE = re.compile(r"(?<!\*)\*\*\*\*(?!\*)")
+
+# A line that is *only* asterisks (3+) is a thematic break / horizontal rule,
+# not a fragmented-bold seam — never strip its asterisks.
+_THEMATIC_BREAK_RE = re.compile(r"^\s*\*{3,}\s*$")
+
+
+def _collapse_bold_seams(text: str) -> str:
+    """Strip `****` seams from `text`, but leave a standalone thematic-break
+    line (a lone `****`) intact."""
+    return "\n".join(
+        line if _THEMATIC_BREAK_RE.match(line) else _FRAGMENTED_BOLD_RE.sub("", line)
+        for line in text.split("\n")
+    )
 
 
 def coalesce_markdown_emphasis(md: str) -> str:
@@ -397,8 +422,9 @@ def coalesce_markdown_emphasis(md: str) -> str:
     non-`*` chars and can never manufacture a fresh seam.
 
     Content inside backtick code spans / fenced blocks is preserved verbatim,
-    and `***bold-italic***` triple-asterisk spans are left intact (the pattern
-    only matches an isolated four-asterisk seam).
+    `***bold-italic***` triple-asterisk spans are left intact (the pattern only
+    matches an isolated four-asterisk seam), and a standalone `****` line — a
+    thematic break / horizontal rule — is never stripped.
     """
     if "****" not in md:
         return md
@@ -406,10 +432,10 @@ def coalesce_markdown_emphasis(md: str) -> str:
     segments: list[str] = []
     last = 0
     for m in _CODE_SPAN_OR_FENCE_RE.finditer(md):
-        segments.append(_FRAGMENTED_BOLD_RE.sub("", md[last : m.start()]))
+        segments.append(_collapse_bold_seams(md[last : m.start()]))
         segments.append(m.group(0))  # code content: untouched
         last = m.end()
-    segments.append(_FRAGMENTED_BOLD_RE.sub("", md[last:]))
+    segments.append(_collapse_bold_seams(md[last:]))
     return "".join(segments)
 
 

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -69,8 +69,9 @@ def _split_table_row(line: str) -> list[str]:
 
     Strips one leading/trailing border pipe, then splits on each remaining
     cell-separator `|`. A `\\|` escape and any `|` inside an inline-code span
-    (backtick-delimited) stay inside their cell, so a cell like `` `a|b` `` is
-    not mis-split into two columns.
+    stay inside their cell, so a cell like `` `a|b` `` is not mis-split. Code
+    spans may use a run of N backticks, closed only by another run of N (GFM),
+    so `` ``a|b`` `` is handled too — not just single-backtick spans.
     """
     body = line.strip()
     if body.startswith("|"):
@@ -79,18 +80,29 @@ def _split_table_row(line: str) -> list[str]:
         body = body[:-1]
     cells: list[str] = []
     buf: list[str] = []
-    in_code = False
-    prev = ""
-    for ch in body:
+    fence = 0  # length of the backtick run that opened the current span; 0 = outside code
+    i = 0
+    n = len(body)
+    while i < n:
+        ch = body[i]
         if ch == "`":
-            in_code = not in_code
-            buf.append(ch)
-        elif ch == "|" and not in_code and prev != "\\":
+            j = i
+            while j < n and body[j] == "`":
+                j += 1
+            run = j - i
+            if fence == 0:
+                fence = run  # open a span
+            elif run == fence:
+                fence = 0  # a matching run closes it
+            buf.append("`" * run)
+            i = j
+            continue
+        if ch == "|" and fence == 0 and (i == 0 or body[i - 1] != "\\"):
             cells.append("".join(buf))
             buf = []
         else:
             buf.append(ch)
-        prev = ch
+        i += 1
     cells.append("".join(buf))
     return [c.strip() for c in cells]
 

--- a/src/mondo/services/docs.py
+++ b/src/mondo/services/docs.py
@@ -131,31 +131,38 @@ def add_markdown_chunked(
     all_block_ids: list[str] = []
     prev_after = after
     for idx, chunk in enumerate(chunks):
-        data = client.execute(
-            ADD_CONTENT_TO_DOC_FROM_MARKDOWN,
-            variables={"doc": doc_id, "md": chunk, "after": prev_after},
-        )
-        result = (data.get("data") or {}).get("add_content_to_doc_from_markdown") or {}
-        if not result.get("success"):
-            base = result.get("error") or "add_content_to_doc_from_markdown failed"
-            if idx > 0:
-                raise PartialDocAddError(
-                    f"{base} (partial content added: {len(all_block_ids)} blocks "
-                    f"from {idx} of {len(chunks)} chunks before the failure)",
-                    list(all_block_ids),
-                )
-            raise ValidationError(base)
-        chunk_block_ids = result.get("block_ids") or []
-        all_block_ids.extend(chunk_block_ids)
-        # Only re-fetch the anchor when more chunks remain (saves one read on
-        # the common single-chunk path). Anchor to the last root block *this
-        # chunk* produced, so the next chunk lands right after it — not after
-        # the whole doc's tail (which would scatter chunks when `after` points
-        # mid-doc).
-        if idx < len(chunks) - 1:
-            prev_after = (
-                _last_root_block_id(client, doc_id, among=set(chunk_block_ids)) or prev_after
+        try:
+            data = client.execute(
+                ADD_CONTENT_TO_DOC_FROM_MARKDOWN,
+                variables={"doc": doc_id, "md": chunk, "after": prev_after},
             )
+            result = (data.get("data") or {}).get("add_content_to_doc_from_markdown") or {}
+            if not result.get("success"):
+                raise ValidationError(
+                    result.get("error") or "add_content_to_doc_from_markdown failed"
+                )
+            all_block_ids.extend(result.get("block_ids") or [])
+            # Only re-fetch the anchor when more chunks remain (saves one read on
+            # the common single-chunk path). Anchor to the last root block *this
+            # chunk* produced, so the next chunk lands right after it — not after
+            # the whole doc's tail (which would scatter chunks when `after`
+            # points mid-doc).
+            if idx < len(chunks) - 1:
+                prev_after = (
+                    _last_root_block_id(client, doc_id, among=set(result.get("block_ids") or []))
+                    or prev_after
+                )
+        except MondoError as e:
+            # ANY failure (success:false, a raised network/server error, or a
+            # failed anchor re-fetch) after earlier chunks already wrote blocks
+            # must carry the created ids so `doc set` can roll back exactly that
+            # content. A first-chunk failure wrote nothing, so it surfaces as-is.
+            if all_block_ids and not isinstance(e, PartialDocAddError):
+                raise PartialDocAddError(
+                    f"{e} (partial content added: {len(all_block_ids)} blocks before the failure)",
+                    list(all_block_ids),
+                ) from e
+            raise
 
     return {"success": True, "block_ids": all_block_ids, "error": None}
 

--- a/src/mondo/services/docs.py
+++ b/src/mondo/services/docs.py
@@ -19,6 +19,18 @@ from mondo.api.queries import (
 
 _DOC_BLOCKS_PAGE_SIZE = 100
 
+
+class PartialDocAddError(ValidationError):
+    """A multi-chunk add that failed *after* earlier chunks already wrote
+    blocks. Carries the ids those chunks created (top-level + nested children)
+    so the caller can roll back exactly that content — never a concurrent edit.
+    """
+
+    def __init__(self, message: str, block_ids: list[str]) -> None:
+        super().__init__(message)
+        self.block_ids = block_ids
+
+
 if TYPE_CHECKING:
     from mondo.api.client import MondayClient
     from mondo.cli.context import GlobalOpts
@@ -127,9 +139,10 @@ def add_markdown_chunked(
         if not result.get("success"):
             base = result.get("error") or "add_content_to_doc_from_markdown failed"
             if idx > 0:
-                raise ValidationError(
+                raise PartialDocAddError(
                     f"{base} (partial content added: {len(all_block_ids)} blocks "
-                    f"from {idx} of {len(chunks)} chunks before the failure)"
+                    f"from {idx} of {len(chunks)} chunks before the failure)",
+                    list(all_block_ids),
                 )
             raise ValidationError(base)
         chunk_block_ids = result.get("block_ids") or []

--- a/src/mondo/services/docs.py
+++ b/src/mondo/services/docs.py
@@ -10,8 +10,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from mondo.api.errors import MondoError
-from mondo.api.queries import DOC_HEAD_BY_OBJECT_ID
+from mondo.api.errors import MondoError, ValidationError
+from mondo.api.queries import (
+    ADD_CONTENT_TO_DOC_FROM_MARKDOWN,
+    DOC_GET_BY_ID_BLOCKS_PAGE,
+    DOC_HEAD_BY_OBJECT_ID,
+)
+
+_DOC_BLOCKS_PAGE_SIZE = 100
 
 if TYPE_CHECKING:
     from mondo.api.client import MondayClient
@@ -27,6 +33,118 @@ def last_block_id(doc: dict[str, Any]) -> str | None:
         return None
     last_id = last.get("id")
     return str(last_id) if last_id else None
+
+
+def top_level_block_ids(doc: dict[str, Any]) -> list[str]:
+    """Ids of a doc's top-level blocks (those without a `parent_block_id`).
+
+    Deleting a container block (e.g. a `table`) cascades its child blocks
+    server-side, and a follow-up delete of an already-cascaded child id 400s,
+    so callers that delete a doc's blocks must restrict to top-level ids.
+    """
+    return [
+        str(b["id"])
+        for b in (doc.get("blocks") or [])
+        if isinstance(b, dict) and b.get("id") and not b.get("parent_block_id")
+    ]
+
+
+def _last_root_block_id(
+    client: MondayClient, doc_id: int, *, among: set[str] | None = None
+) -> str | None:
+    """Return the id of a doc's last TOP-LEVEL block (no `parent_block_id`).
+
+    `add_content_to_doc_from_markdown`'s `block_ids` return list also contains
+    nested child blocks (e.g. table cells); anchoring the next chunk's
+    `afterBlockId` to such a child is rejected server-side with
+    INTERNAL_SERVER_ERROR. We re-read the doc and take a root block as the safe
+    insertion anchor instead.
+
+    `among` restricts the result to blocks whose id is in that set — used to
+    anchor the next chunk to the *previous chunk's* own last root block, so a
+    multi-chunk insert stays contiguous even when the initial `after` points
+    into the middle of the doc. Without this, the anchor would jump to the
+    whole doc's tail and scatter later chunks past pre-existing content.
+    """
+    page = 1
+    last_root: str | None = None
+    while True:
+        data = client.execute(
+            DOC_GET_BY_ID_BLOCKS_PAGE,
+            variables={"ids": [doc_id], "limit": _DOC_BLOCKS_PAGE_SIZE, "page": page},
+        )
+        docs = (data.get("data") or {}).get("docs") or []
+        if not docs:
+            break
+        blocks = docs[0].get("blocks") or []
+        for b in blocks:
+            if isinstance(b, dict) and b.get("id") and not b.get("parent_block_id"):
+                bid = str(b["id"])
+                if among is None or bid in among:
+                    last_root = bid
+        if len(blocks) < _DOC_BLOCKS_PAGE_SIZE:
+            break
+        page += 1
+    return last_root
+
+
+def add_markdown_chunked(
+    client: MondayClient,
+    doc_id: int,
+    md: str,
+    *,
+    after: str | None,
+) -> dict[str, Any]:
+    """Add markdown to a doc via `add_content_to_doc_from_markdown`, splitting
+    large input into safe chunks (issue #59).
+
+    A single call with a large doc (~18KB) returns INTERNAL_SERVER_ERROR and
+    writes nothing, so we split on top-level block boundaries and loop. Between
+    chunks the next `afterBlockId` is re-resolved to the doc's last *root*
+    block — the returned `block_ids` can include nested children (e.g. table
+    cells), and anchoring to one of those is itself rejected with
+    INTERNAL_SERVER_ERROR. Block ids are accumulated across chunks. Returns the
+    merged `{success, block_ids, error}` envelope.
+
+    A failed chunk short-circuits and surfaces a clear error noting how much
+    content (if any) was already added — the caller decides what to do with a
+    partial write.
+    """
+    from mondo.docs import split_markdown_for_upload
+
+    chunks = split_markdown_for_upload(md)
+    if not chunks:
+        return {"success": True, "block_ids": [], "error": None}
+
+    all_block_ids: list[str] = []
+    prev_after = after
+    for idx, chunk in enumerate(chunks):
+        data = client.execute(
+            ADD_CONTENT_TO_DOC_FROM_MARKDOWN,
+            variables={"doc": doc_id, "md": chunk, "after": prev_after},
+        )
+        result = (data.get("data") or {}).get("add_content_to_doc_from_markdown") or {}
+        if not result.get("success"):
+            base = result.get("error") or "add_content_to_doc_from_markdown failed"
+            if idx > 0:
+                raise ValidationError(
+                    f"{base} (partial content added: {len(all_block_ids)} blocks "
+                    f"from {idx} of {len(chunks)} chunks before the failure)"
+                )
+            raise ValidationError(base)
+        chunk_block_ids = result.get("block_ids") or []
+        all_block_ids.extend(chunk_block_ids)
+        # Only re-fetch the anchor when more chunks remain (saves one read on
+        # the common single-chunk path). Anchor to the last root block *this
+        # chunk* produced, so the next chunk lands right after it — not after
+        # the whole doc's tail (which would scatter chunks when `after` points
+        # mid-doc).
+        if idx < len(chunks) - 1:
+            prev_after = (
+                _last_root_block_id(client, doc_id, among=set(chunk_block_ids)) or prev_after
+            )
+
+    return {"success": True, "block_ids": all_block_ids, "error": None}
 
 
 def resolve_doc_id_from_object_id(

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -2104,6 +2104,70 @@ class TestDocSetChunking:
         # Only the partially-added block is rolled back; the old content stays.
         assert deleted == ["n0"]
 
+    def test_rollback_spares_concurrent_block(self, httpx_mock: HTTPXMock) -> None:
+        # A block another user added between the initial fetch and the rollback
+        # is NOT in the add's reported ids, so rollback must not delete it.
+        big = "\n\n".join("para " + str(i) + " " + "x" * 9000 for i in range(3))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "10", "blocks": [{"id": "old1"}]}]}),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["n0"],
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "10", "blocks": [{"id": "n0"}]}]}),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": False,
+                        "block_ids": None,
+                        "error": "INTERNAL_SERVER_ERROR",
+                    }
+                }
+            ),
+        )
+        # rollback re-fetch: old1, the added n0, AND a concurrent block "conc1"
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {"docs": [{"id": "10", "blocks": [{"id": "old1"}, {"id": "n0"}, {"id": "conc1"}]}]}
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"delete_doc_block": {"id": "n0"}})
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"docs": []}), is_reusable=True
+        )
+        result = runner.invoke(app, ["doc", "set", "--doc", "10", "--markdown", big])
+        assert result.exit_code != 0
+        deleted = [
+            json.loads(r.content)["variables"].get("block")
+            for r in httpx_mock.get_requests()
+            if "delete_doc_block" in json.loads(r.content).get("query", "")
+        ]
+        # n0 (added by the failed run) is rolled back; conc1 (concurrent) is spared.
+        assert deleted == ["n0"]
+
 
 class TestDocClear:
     """Issue #60: `doc clear` empties a doc but keeps the document."""

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -1466,6 +1466,13 @@ class TestDocNewOps:
         body = _last_body(httpx_mock)
         assert body["variables"] == {"doc": 10, "md": "# Hi", "after": None}
 
+    def test_add_markdown_empty_input_errors_without_api_call(self, httpx_mock: HTTPXMock) -> None:
+        # Whitespace-only markdown must not silently report success; it errors
+        # before any client/API call (mirrors `add-content`'s no-blocks guard).
+        result = runner.invoke(app, ["doc", "add-markdown", "--doc", "10", "--markdown", "   "])
+        assert result.exit_code != 0
+        assert httpx_mock.get_requests() == []
+
     def test_import_html(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(
             url=ENDPOINT,
@@ -1610,6 +1617,105 @@ class TestDocSet:
         bodies = [json.loads(r.content) for r in httpx_mock.get_requests()]
         # the delete loop never runs, so the original blocks are not lost
         assert "delete_doc_block" not in json.dumps(bodies)
+
+    def test_set_deletes_only_top_level_blocks(self, httpx_mock: HTTPXMock) -> None:
+        # Deleting a container cascades its children server-side; re-deleting an
+        # already-cascaded child id 400s. So a child block (parent_block_id set)
+        # must NOT appear in the delete loop — only top-level ids are deleted.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "docs": [
+                        {
+                            "id": "10",
+                            "blocks": [
+                                {"id": "t1"},
+                                {"id": "c1", "parent_block_id": "t1"},
+                                {"id": "b2"},
+                            ],
+                        }
+                    ]
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["n1"],
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"delete_doc_block": {"id": "t1"}})
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"delete_doc_block": {"id": "b2"}})
+        )
+        result = runner.invoke(app, ["doc", "set", "--doc", "10", "--markdown", "# New"])
+        assert result.exit_code == 0, result.stdout
+        bodies = [json.loads(r.content) for r in httpx_mock.get_requests()]
+        deleted = [
+            b["variables"]["block"] for b in bodies if "delete_doc_block" in b.get("query", "")
+        ]
+        assert deleted == ["t1", "b2"]
+        assert json.loads(result.stdout)["replaced_blocks"] == 2
+
+    def test_set_anchors_add_to_last_root_not_child(self, httpx_mock: HTTPXMock) -> None:
+        # The doc ends with a container child (c1, parent t1). The add must
+        # anchor to the last TOP-LEVEL block (t1), never the child — anchoring
+        # `add_content_to_doc_from_markdown` to a child id 500s server-side.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "docs": [
+                        {
+                            "id": "10",
+                            "blocks": [
+                                {"id": "b1"},
+                                {"id": "t1"},
+                                {"id": "c1", "parent_block_id": "t1"},
+                            ],
+                        }
+                    ]
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["n1"],
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"delete_doc_block": {"id": "b1"}})
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"delete_doc_block": {"id": "t1"}})
+        )
+        result = runner.invoke(app, ["doc", "set", "--doc", "10", "--markdown", "# New"])
+        assert result.exit_code == 0, result.stdout
+        bodies = [json.loads(r.content) for r in httpx_mock.get_requests()]
+        add_body = next(
+            b for b in bodies if "add_content_to_doc_from_markdown" in b.get("query", "")
+        )
+        assert add_body["variables"]["after"] == "t1"
 
     def test_empty_markdown_rejected_without_mutating(self, httpx_mock: HTTPXMock) -> None:
         result = runner.invoke(app, ["doc", "set", "--doc", "10", "--markdown", "   "])
@@ -1774,3 +1880,358 @@ class TestImageExportOutputGuards:
         md = out.read_text()
         assert "![](https://x/img.png)" in md
         assert json.loads(result.stdout)["images"] == []
+
+
+class TestAddMarkdownChunking:
+    """Issues #59 / #63: auto-chunk large markdown and report blocks_added."""
+
+    def test_blocks_added_counts_block_ids(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["b1", "b2", "b3"],
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        result = runner.invoke(app, ["doc", "add-markdown", "--doc", "10", "--markdown", "# Hi"])
+        assert result.exit_code == 0, result.stdout
+        emitted = json.loads(result.stdout)
+        assert emitted["blocks_added"] == 3
+        assert emitted["block_ids"] == ["b1", "b2", "b3"]
+
+    def test_large_input_chunks_with_chained_after(self, httpx_mock: HTTPXMock) -> None:
+        # Three big paragraphs, each its own chunk under the (small) limit.
+        big = "\n\n".join("para " + str(i) + " " + "x" * 9000 for i in range(3))
+        # The loop interleaves: add chunk → re-fetch last ROOT block → add next
+        # chunk, anchoring afterBlockId to the re-fetched root (NOT the raw
+        # block_ids[-1], which can be a nested child).
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["c0"],
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        # Re-fetch after chunk 0: its root c0 plus a pre-existing tail block.
+        # The anchor must be c0 (this chunk's root), NOT the later tail.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "10", "blocks": [{"id": "c0"}, {"id": "tail"}]}]}),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["c1"],
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {"docs": [{"id": "10", "blocks": [{"id": "c0"}, {"id": "c1"}, {"id": "tail"}]}]}
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["c2"],
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        result = runner.invoke(app, ["doc", "add-markdown", "--doc", "10", "--markdown", big])
+        assert result.exit_code == 0, result.stdout
+        bodies = [json.loads(r.content) for r in httpx_mock.get_requests()]
+        # add, fetch, add, fetch, add = 5 requests.
+        assert len(bodies) == 5
+        adds = [b for b in bodies if "markdown:" in b["query"] or "add_content" in b["query"]]
+        # First chunk uses the supplied after (None); each later chunk anchors
+        # to the last root block *that chunk* produced (per the intervening
+        # re-fetch), never the doc's pre-existing tail.
+        assert adds[0]["variables"]["after"] is None
+        assert adds[1]["variables"]["after"] == "c0"
+        assert adds[2]["variables"]["after"] == "c1"
+        emitted = json.loads(result.stdout)
+        assert emitted["block_ids"] == ["c0", "c1", "c2"]
+        assert emitted["blocks_added"] == 3
+
+    def test_code_fence_not_split_across_chunks(self, httpx_mock: HTTPXMock) -> None:
+        # A fence with internal blank lines must stay one chunk (one call).
+        fence = "```\n" + "\n\n".join(f"line {i}" for i in range(5)) + "\n```"
+        md = f"# Title\n\n{fence}"
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["b1"],
+                        "error": None,
+                    }
+                }
+            ),
+            is_reusable=True,
+        )
+        result = runner.invoke(app, ["doc", "add-markdown", "--doc", "10", "--markdown", md])
+        assert result.exit_code == 0, result.stdout
+        # Whichever chunk carries the fence keeps both ``` delimiters together.
+        sent = [
+            json.loads(r.content)["variables"].get("md")
+            for r in httpx_mock.get_requests()
+            if "md" in json.loads(r.content)["variables"]
+        ]
+        fence_payloads = [s for s in sent if s and "```" in s]
+        assert len(fence_payloads) == 1
+        assert fence_payloads[0].count("```") == 2
+
+    def test_table_normalized_before_send(self, httpx_mock: HTTPXMock) -> None:
+        # #61 wired into add-markdown: a ragged body row is normalized first.
+        md = "| A | B | C |\n| --- | --- | --- |\n| 1 | 2 | 3 | 4 |\n"
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["b1"],
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        result = runner.invoke(app, ["doc", "add-markdown", "--doc", "10", "--markdown", md])
+        assert result.exit_code == 0, result.stdout
+        sent_md = json.loads(httpx_mock.get_requests()[-1].content)["variables"]["md"]
+        # The 4th cell is merged into column C; no runaway extra column.
+        assert "| 3 4 |" in sent_md
+
+
+class TestDocSetChunking:
+    """Issue #59: `doc set` chunks too, and never deletes on a failed add."""
+
+    def test_failed_add_chunk_does_not_delete(self, httpx_mock: HTTPXMock) -> None:
+        big = "\n\n".join("para " + str(i) + " " + "x" * 9000 for i in range(3))
+        # 1) fetch existing blocks
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "10", "blocks": [{"id": "old1"}, {"id": "old2"}]}]}),
+        )
+        # 2) first add chunk succeeds
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["n0"],
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        # 2b) re-fetch the last root block to anchor the next chunk
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "10", "blocks": [{"id": "n0"}]}]}),
+        )
+        # 3) second add chunk FAILS — no deletes must follow
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": False,
+                        "block_ids": None,
+                        "error": "INTERNAL_SERVER_ERROR",
+                    }
+                }
+            ),
+        )
+        # any further calls (object-id probe) answer "no match"
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"docs": []}), is_reusable=True
+        )
+        result = runner.invoke(app, ["doc", "set", "--doc", "10", "--markdown", big])
+        assert result.exit_code != 0
+        bodies = json.dumps([json.loads(r.content) for r in httpx_mock.get_requests()])
+        # The original blocks are preserved — the delete loop never ran.
+        assert "delete_doc_block" not in bodies
+
+
+class TestDocClear:
+    """Issue #60: `doc clear` empties a doc but keeps the document."""
+
+    def test_clears_all_blocks(self, httpx_mock: HTTPXMock) -> None:
+        # 1) fetch existing blocks
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "10", "blocks": [{"id": "b1"}, {"id": "b2"}]}]}),
+        )
+        # 2) delete b1, 3) delete b2
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"delete_doc_block": {"id": "b1"}})
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"delete_doc_block": {"id": "b2"}})
+        )
+        result = runner.invoke(app, ["doc", "clear", "--doc", "10"])
+        assert result.exit_code == 0, result.stdout
+        bodies = [json.loads(r.content) for r in httpx_mock.get_requests()]
+        assert len(bodies) == 3
+        assert bodies[1]["variables"]["block"] == "b1"
+        assert bodies[2]["variables"]["block"] == "b2"
+        emitted = json.loads(result.stdout)
+        assert emitted == {"id": 10, "cleared_blocks": 2}
+
+    def test_empty_doc_is_noop(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"docs": [{"id": "10", "blocks": []}]})
+        )
+        result = runner.invoke(app, ["doc", "clear", "--doc", "10"])
+        assert result.exit_code == 0, result.stdout
+        # Only the fetch happened — no deletes.
+        assert len(httpx_mock.get_requests()) == 1
+        assert json.loads(result.stdout) == {"id": 10, "cleared_blocks": 0}
+
+    def test_requires_one_doc_flag(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(app, ["doc", "clear"])
+        assert result.exit_code == 2
+
+    def test_dry_run_prints_plan(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(app, ["--dry-run", "doc", "clear", "--doc", "10"])
+        assert result.exit_code == 0, result.stdout
+        assert httpx_mock.get_requests() == []
+        plan = json.loads(result.stdout)
+        assert plan["variables"] == {"doc": 10}
+        assert "delete_doc_block" in plan["query"].lower() or "DELETE" in plan["query"]
+
+
+class TestExportMarkdownCoalesce:
+    """Issue #62: fragmented bold runs are rejoined in export-markdown output."""
+
+    def test_fragmented_bold_collapsed(self, httpx_mock: HTTPXMock) -> None:
+        fragmented = "**Caching is ****not**** a win**"
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "export_markdown_from_doc": {
+                        "success": True,
+                        "error": None,
+                        "markdown": fragmented,
+                    }
+                }
+            ),
+        )
+        result = runner.invoke(app, ["doc", "export-markdown", "--doc", "10"])
+        assert result.exit_code == 0, result.stdout
+        assert "**Caching is not a win**" in result.stdout
+        assert "****" not in result.stdout
+
+    def test_coalesce_applied_to_out_path(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        fragmented = "**a ****b**"
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "export_markdown_from_doc": {
+                        "success": True,
+                        "error": None,
+                        "markdown": fragmented,
+                    }
+                }
+            ),
+        )
+        out = tmp_path / "exported.md"
+        result = runner.invoke(
+            app, ["doc", "export-markdown", "--doc", "10", "--out", str(out), "--no-images"]
+        )
+        assert result.exit_code == 0, result.stdout
+        assert out.read_text() == "**a b**"
+
+
+class TestDocCreateUnauthorizedSuggestion:
+    """Issue #64: actionable suggestion on USER_UNAUTHORIZED doc create."""
+
+    def test_unauthorized_carries_license_suggestion(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={
+                "errors": [
+                    {
+                        "message": "User is not permitted to create public doc in this workspace",
+                        "extensions": {"code": "USER_UNAUTHORIZED", "request_id": "r"},
+                    }
+                ]
+            },
+        )
+        result = runner.invoke(
+            app,
+            ["-o", "json", "doc", "create", "--workspace", "42", "--name", "Spec"],
+        )
+        assert result.exit_code == 3
+        # The structured envelope (stderr) carries the suggestion field.
+        env_line = [
+            line
+            for line in result.stderr.splitlines()
+            if line.strip().startswith("{") and "suggestion" in line
+        ]
+        assert env_line, result.stderr
+        env = json.loads(env_line[-1])
+        assert env["code"] == "USER_UNAUTHORIZED"
+        assert "doc-creation license/policy" in env["suggestion"]
+
+    def test_other_errors_unchanged(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={
+                "errors": [
+                    {
+                        "message": "Workspace not found",
+                        "extensions": {"code": "ResourceNotFoundException", "request_id": "r"},
+                    }
+                ]
+            },
+        )
+        result = runner.invoke(
+            app,
+            ["-o", "json", "doc", "create", "--workspace", "42", "--name", "Spec"],
+        )
+        assert result.exit_code == 6
+        assert "doc-creation license" not in (result.stderr + result.stdout)

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -2036,7 +2036,7 @@ class TestAddMarkdownChunking:
 class TestDocSetChunking:
     """Issue #59: `doc set` chunks too, and never deletes on a failed add."""
 
-    def test_failed_add_chunk_does_not_delete(self, httpx_mock: HTTPXMock) -> None:
+    def test_failed_add_chunk_rolls_back_partial_and_keeps_old(self, httpx_mock: HTTPXMock) -> None:
         big = "\n\n".join("para " + str(i) + " " + "x" * 9000 for i in range(3))
         # 1) fetch existing blocks
         httpx_mock.add_response(
@@ -2044,7 +2044,7 @@ class TestDocSetChunking:
             method="POST",
             json=_ok({"docs": [{"id": "10", "blocks": [{"id": "old1"}, {"id": "old2"}]}]}),
         )
-        # 2) first add chunk succeeds
+        # 2) first add chunk succeeds, appending n0
         httpx_mock.add_response(
             url=ENDPOINT,
             method="POST",
@@ -2064,7 +2064,7 @@ class TestDocSetChunking:
             method="POST",
             json=_ok({"docs": [{"id": "10", "blocks": [{"id": "n0"}]}]}),
         )
-        # 3) second add chunk FAILS — no deletes must follow
+        # 3) second add chunk FAILS
         httpx_mock.add_response(
             url=ENDPOINT,
             method="POST",
@@ -2078,15 +2078,31 @@ class TestDocSetChunking:
                 }
             ),
         )
+        # 4) rollback re-fetch: doc now holds the old blocks + the appended n0
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {"docs": [{"id": "10", "blocks": [{"id": "old1"}, {"id": "old2"}, {"id": "n0"}]}]}
+            ),
+        )
+        # 5) rollback deletes the partial block
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"delete_doc_block": {"id": "n0"}})
+        )
         # any further calls (object-id probe) answer "no match"
         httpx_mock.add_response(
             url=ENDPOINT, method="POST", json=_ok({"docs": []}), is_reusable=True
         )
         result = runner.invoke(app, ["doc", "set", "--doc", "10", "--markdown", big])
         assert result.exit_code != 0
-        bodies = json.dumps([json.loads(r.content) for r in httpx_mock.get_requests()])
-        # The original blocks are preserved — the delete loop never ran.
-        assert "delete_doc_block" not in bodies
+        deleted = [
+            json.loads(r.content)["variables"].get("block")
+            for r in httpx_mock.get_requests()
+            if "delete_doc_block" in json.loads(r.content).get("query", "")
+        ]
+        # Only the partially-added block is rolled back; the old content stays.
+        assert deleted == ["n0"]
 
 
 class TestDocClear:

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -2168,6 +2168,61 @@ class TestDocSetChunking:
         # n0 (added by the failed run) is rolled back; conc1 (concurrent) is spared.
         assert deleted == ["n0"]
 
+    def test_raised_error_mid_chunk_still_rolls_back(self, httpx_mock: HTTPXMock) -> None:
+        # When a later chunk *raises* (server/network error) rather than
+        # returning success:false, the already-added blocks must still roll back.
+        big = "\n\n".join("para " + str(i) + " " + "x" * 9000 for i in range(3))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "10", "blocks": [{"id": "old1"}]}]}),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "add_content_to_doc_from_markdown": {
+                        "success": True,
+                        "block_ids": ["n0"],
+                        "error": None,
+                    }
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "10", "blocks": [{"id": "n0"}]}]}),
+        )
+        # chunk 2 raises (GraphQL error envelope → MondoError), not success:false
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={
+                "errors": [{"message": "boom", "extensions": {"code": "BANG", "request_id": "r"}}]
+            },
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "10", "blocks": [{"id": "old1"}, {"id": "n0"}]}]}),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"delete_doc_block": {"id": "n0"}})
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_ok({"docs": []}), is_reusable=True
+        )
+        result = runner.invoke(app, ["doc", "set", "--doc", "10", "--markdown", big])
+        assert result.exit_code != 0
+        deleted = [
+            json.loads(r.content)["variables"].get("block")
+            for r in httpx_mock.get_requests()
+            if "delete_doc_block" in json.loads(r.content).get("query", "")
+        ]
+        assert deleted == ["n0"]
+
 
 class TestDocClear:
     """Issue #60: `doc clear` empties a doc but keeps the document."""

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -768,6 +768,13 @@ class TestNormalizeMarkdownTables:
         out = normalize_markdown_tables(md)
         assert out.splitlines()[2] == "| x \\| y | z |"
 
+    def test_multi_backtick_inline_code_pipe_not_split(self) -> None:
+        # A double-backtick code span closes only on another double backtick,
+        # so a `|` inside it is cell content, not a separator.
+        md = "| Cmd | Note |\n| --- | --- |\n| ``a | b`` | ok |\n"
+        out = normalize_markdown_tables(md)
+        assert out.splitlines()[2] == "| ``a | b`` | ok |"
+
     def test_indented_code_block_not_treated_as_table(self) -> None:
         # A 4-space indented code block whose lines look like a ragged table
         # is code, not a GFM table — it must be left byte-for-byte unchanged.

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -6,9 +6,12 @@ import pytest
 
 from mondo.docs import (
     blocks_to_markdown,
+    coalesce_markdown_emphasis,
     collect_image_asset_ids,
     extract_doc_ids_from_column_value,
     markdown_to_blocks,
+    normalize_markdown_tables,
+    split_markdown_for_upload,
 )
 
 
@@ -671,3 +674,120 @@ class TestRoundTrip:
                 content = line.lstrip("# -1234567890.>").strip()
                 if content and content != "---":
                     assert content in back
+
+
+class TestSplitMarkdownForUpload:
+    """Issue #59: auto-chunk large markdown on top-level block boundaries."""
+
+    def test_small_input_single_chunk(self) -> None:
+        assert split_markdown_for_upload("# Hi\n\nBody") == ["# Hi\n\nBody"]
+
+    def test_empty_returns_empty(self) -> None:
+        assert split_markdown_for_upload("   \n\n") == []
+
+    def test_splits_on_blank_lines_under_limit(self) -> None:
+        blocks = [f"Paragraph number {i} " + "x" * 50 for i in range(10)]
+        md = "\n\n".join(blocks)
+        chunks = split_markdown_for_upload(md, max_chars=200)
+        assert len(chunks) > 1
+        # Every chunk stays under the limit and round-trips to the original set.
+        assert all(len(c) <= 200 for c in chunks)
+        rejoined = "\n\n".join(chunks)
+        for b in blocks:
+            assert b in rejoined
+
+    def test_never_splits_inside_code_fence(self) -> None:
+        # A fenced block longer than the limit must stay a single chunk.
+        code = "```\n" + "\n".join(f"line {i}" for i in range(40)) + "\n```"
+        md = f"# Title\n\n{code}\n\nAfter"
+        chunks = split_markdown_for_upload(md, max_chars=80)
+        # Exactly one chunk contains the fence, fully intact.
+        fence_chunks = [c for c in chunks if "```" in c]
+        assert len(fence_chunks) == 1
+        assert fence_chunks[0].count("```") == 2
+        assert "line 0" in fence_chunks[0] and "line 39" in fence_chunks[0]
+
+    def test_never_splits_inside_table(self) -> None:
+        rows = "\n".join(f"| a{i} | b{i} |" for i in range(30))
+        table = "| H1 | H2 |\n| --- | --- |\n" + rows
+        md = f"Intro\n\n{table}\n\nOutro"
+        chunks = split_markdown_for_upload(md, max_chars=120)
+        table_chunks = [c for c in chunks if "| H1 | H2 |" in c]
+        assert len(table_chunks) == 1
+        # The whole table (header + separator + every body row) is one unit.
+        assert "| a0 | b0 |" in table_chunks[0]
+        assert "| a29 | b29 |" in table_chunks[0]
+
+    def test_oversized_atomic_block_is_own_chunk(self) -> None:
+        big = "word " * 4000  # one paragraph well over the limit
+        chunks = split_markdown_for_upload(big, max_chars=1000)
+        assert len(chunks) == 1
+        assert chunks[0].strip() == big.strip()
+
+
+class TestNormalizeMarkdownTables:
+    """Issue #61: normalize ragged GFM table rows to the header column count."""
+
+    def test_overflow_row_merges_into_last_column(self) -> None:
+        md = (
+            "| Date | iOS | Android | Web | Backend | DB | Notes |\n"
+            "| --- | --- | --- | --- | --- | --- | --- |\n"
+            "| 2024-01 | 1 | 2 | 3 | 4 | 5 | release | <- iOS 4407 released |\n"
+        )
+        out = normalize_markdown_tables(md)
+        body = out.splitlines()[2]
+        cells = [c.strip() for c in body.strip().strip("|").split("|")]
+        assert len(cells) == 7
+        # The 8th trailing cell is merged into the last (7th) column.
+        assert cells[-1] == "release <- iOS 4407 released"
+
+    def test_short_row_is_padded(self) -> None:
+        md = "| A | B | C |\n| --- | --- | --- |\n| 1 | 2 |\n"
+        out = normalize_markdown_tables(md)
+        body = out.splitlines()[2]
+        cells = [c.strip() for c in body.strip().strip("|").split("|")]
+        assert cells == ["1", "2", ""]
+
+    def test_code_fence_pipes_untouched(self) -> None:
+        md = "```\n| a | b | c | d |\n```\n"
+        assert normalize_markdown_tables(md) == md
+
+    def test_non_table_text_unchanged(self) -> None:
+        md = "# Title\n\nA paragraph with a | pipe but no table.\n"
+        assert normalize_markdown_tables(md) == md
+
+    def test_inline_code_pipe_in_cell_not_split(self) -> None:
+        # A `|` inside an inline-code span is cell content, not a separator, so
+        # a well-formed row keeps its column count instead of being mangled.
+        md = "| Cmd | Note |\n| --- | --- |\n| `a | b` | ok |\n"
+        out = normalize_markdown_tables(md)
+        assert out.splitlines()[2] == "| `a | b` | ok |"
+
+    def test_escaped_pipe_in_cell_not_split(self) -> None:
+        md = "| A | B |\n| --- | --- |\n| x \\| y | z |\n"
+        out = normalize_markdown_tables(md)
+        assert out.splitlines()[2] == "| x \\| y | z |"
+
+
+class TestCoalesceMarkdownEmphasis:
+    """Issue #62: rejoin fragmented bold runs from the server exporter."""
+
+    def test_fragmented_bold_collapses_to_single_span(self) -> None:
+        fragmented = (
+            "**Caching is not a clear win here, ****an****d ****it**** ****i****s "
+            "****not what resolved the incident**"
+        )
+        assert coalesce_markdown_emphasis(fragmented) == (
+            "**Caching is not a clear win here, and it is not what resolved the incident**"
+        )
+
+    def test_bold_italic_triple_span_left_intact(self) -> None:
+        assert coalesce_markdown_emphasis("***x***") == "***x***"
+
+    def test_code_span_pipes_not_corrupted(self) -> None:
+        md = "before `a****b` after"
+        assert coalesce_markdown_emphasis(md) == md
+
+    def test_no_op_without_fragmentation(self) -> None:
+        md = "**bold** and *italic* text"
+        assert coalesce_markdown_emphasis(md) == md

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -768,6 +768,12 @@ class TestNormalizeMarkdownTables:
         out = normalize_markdown_tables(md)
         assert out.splitlines()[2] == "| x \\| y | z |"
 
+    def test_indented_code_block_not_treated_as_table(self) -> None:
+        # A 4-space indented code block whose lines look like a ragged table
+        # is code, not a GFM table — it must be left byte-for-byte unchanged.
+        md = "    | A | B |\n    | --- | --- |\n    | 1 |\n"
+        assert normalize_markdown_tables(md) == md
+
 
 class TestCoalesceMarkdownEmphasis:
     """Issue #62: rejoin fragmented bold runs from the server exporter."""
@@ -791,3 +797,9 @@ class TestCoalesceMarkdownEmphasis:
     def test_no_op_without_fragmentation(self) -> None:
         md = "**bold** and *italic* text"
         assert coalesce_markdown_emphasis(md) == md
+
+    def test_standalone_thematic_break_preserved(self) -> None:
+        # A lone `****` line is a horizontal rule, not a bold seam — keep it,
+        # while still collapsing a real seam elsewhere in the same document.
+        md = "**a ****b**\n\n****\n\nmore"
+        assert coalesce_markdown_emphasis(md) == "**a b**\n\n****\n\nmore"

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -781,6 +781,12 @@ class TestNormalizeMarkdownTables:
         md = "    | A | B |\n    | --- | --- |\n    | 1 |\n"
         assert normalize_markdown_tables(md) == md
 
+    def test_indented_separator_not_treated_as_table(self) -> None:
+        # Header is unindented but the separator is indented 4 spaces (code),
+        # so this is not a GFM table and following pipe text must be left as-is.
+        md = "| A | B |\n    | --- | --- |\n| 1 |\n"
+        assert normalize_markdown_tables(md) == md
+
 
 class TestCoalesceMarkdownEmphasis:
     """Issue #62: rejoin fragmented bold runs from the server exporter."""
@@ -799,6 +805,12 @@ class TestCoalesceMarkdownEmphasis:
 
     def test_code_span_pipes_not_corrupted(self) -> None:
         md = "before `a****b` after"
+        assert coalesce_markdown_emphasis(md) == md
+
+    def test_multi_backtick_code_span_not_corrupted(self) -> None:
+        # A literal `****` inside a double-backtick code span is real content,
+        # not an export seam — leave it untouched.
+        md = "before ``a****b`` after"
         assert coalesce_markdown_emphasis(md) == md
 
     def test_no_op_without_fragmentation(self) -> None:


### PR DESCRIPTION
## What & why

Fixes six `mondo doc` issues, all touching `src/mondo/cli/doc.py` / `src/mondo/docs.py` (so they share one branch — separate branches off `main` would collide on those files).

Resolves #59, resolves #60, resolves #61, resolves #62, resolves #63, resolves #64.

| Issue | Fix |
|---|---|
| **#63** | `doc add-markdown` emits a reliable `blocks_added` count (len of returned `block_ids`) alongside the raw envelope. Empty/whitespace input now errors before any API call (was a silent `success: true, blocks_added: 0`). |
| **#59** | Auto-chunk large markdown for `add-markdown` and `set`. `split_markdown_for_upload` splits only on blank-line block boundaries, never inside a fenced code block or a contiguous GFM table. **Root cause** turned out not to be raw size: `add_content_to_doc_from_markdown` returns nested child block ids (table cells), and anchoring the next chunk's `afterBlockId` to a child is what monday rejects with `INTERNAL_SERVER_ERROR`. The loop re-resolves each subsequent anchor to the last *root* block **that chunk produced**, so multi-chunk inserts stay contiguous even with a mid-doc `--after`. |
| **#60** | New `doc clear` command empties a doc's body (preserving id/object_id/URL); `--dry-run`, cache-invalidating. Combined with the chunked `doc set`/`replace` (already write-first/delete-after), this gives in-place replacement without minting a new URL. |
| **#61** | `normalize_markdown_tables` pads short GFM rows and merges overflow trailing cells into the last column before sending. The cell splitter ignores `|` inside inline-code spans and `\|` escapes; fenced-code pipes are untouched. |
| **#62** | `coalesce_markdown_emphasis` collapses the zero-width `****` seams monday's `export-markdown` leaves between fragmented bold runs (single pass; `***x***` and backtick spans preserved), on both stdout and `--out`. (`doc get --format markdown` strips bold and is unaffected — fix targets only the server export path.) |
| **#64** | `doc create` attaches an actionable `suggestion` (workspace doc-creation license/policy) on `USER_UNAUTHORIZED` / "not permitted to create" errors, threaded through `handle_mondo_error_or_exit` into both the human message and the JSON error envelope. |

## Testing

- **Unit:** full non-integration suite green (**1719 passed**); ~40 new tests across `tests/unit/test_docs.py` (split/normalize/coalesce, inline-code & escaped pipes) and `tests/unit/test_cli_doc.py` (blocks_added, chunk chaining via root-block re-fetch, code-fence/table integrity, set-no-delete-on-failed-add, **set deletes only top-level blocks**, **set anchors to last root not child**, clear no-op, export coalesce, create-unauthorized suggestion). `ruff` clean.
- **Live (playground ws 592446, all cleaned up):** `add-markdown` of a ~380-line/21KB doc (code block + ragged table) → `blocks_added: 228`; a single un-chunked call reproducibly 500s. `doc set` on a **table-bearing** doc now succeeds (21→11 blocks) — previously `INTERNAL_SERVER_ERROR`. `doc clear` 186→0. Multi-chunk `add-markdown --after <middle>` keeps all new content contiguous after the anchor (0 scattered).

## What review caught

`/simplify` removed a dead fixpoint loop, hoisted a regex, and de-duplicated the table-header predicate. `/code-review` (high) + `/codex review` (gpt-5.5, high) surfaced and fixed real correctness bugs that **only manifest on docs containing container blocks (tables)**:
- `set` deleted *all* old block ids including cascaded children → 400 + half-replaced doc. Now deletes only top-level blocks (shared `top_level_block_ids` helper with `clear`).
- `set` anchored its add to the doc's literal last block, which can be a table cell child → `INTERNAL_SERVER_ERROR`, new content never landed. Now anchors to the last top-level block. (Caught only by **live** verification.)
- Multi-chunk reordering with a mid-doc `--after` (codex) → chunk anchor now restricted to the previous chunk's own roots.
- Partial multi-chunk failure now invalidates the `docs_blocks` cache before erroring.

## Known limitations (documented, out of scope for these issues)

Markdown with `~~~`/attributed code fences, multi-backtick inline-code spans containing `|`/`****`, or an escaped `\|` ending a borderless table row are not fully handled (the fenced-code regex is pre-existing and shared with `markdown_to_blocks`). Common cases (single-backtick inline code, standard ``` fences, bordered rows) are covered and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
