### PR TITLE
feat(graphql): unwrap data by default, add --raw for full envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,7 +811,17 @@ mondo graphql 'query ($ids:[ID!]!){items(ids:$ids){id name}}' --vars '{"ids":[1,
 # From a file or stdin:
 mondo graphql @query.graphql
 cat mutation.graphql | mondo graphql -
+
+# Unwrapped `data` by default (no `.data` prefix); `--raw` keeps the envelope:
+mondo graphql 'query { boards { id } }' | jq '.boards[]'
+mondo graphql 'query { me { id } }' --raw
 ```
+
+> **Output is the unwrapped `data` object by default**, matching the typed
+> subcommands — so `-q`/jq paths address the result directly (no `.data`
+> prefix), and a GraphQL `errors` response fails non-zero instead of
+> emitting `null`. Pass `--raw` for the full `{data, errors, extensions}`
+> envelope.
 
 > **`--dry-run` is rejected on `mondo graphql`.** Unlike typed mutations,
 > the raw passthrough can't safely preview your query (mondo doesn't
@@ -830,7 +840,7 @@ cat mutation.graphql | mondo graphql -
 ```
 
 All three live in the "Output / Query" panel of every `--help` page.
-Pipeline: `-q` first (envelope extraction / filtering), then `--fields`
+Pipeline: `-q` first (payload projection / filtering), then `--fields`
 (row-shape narrowing), then `-o` (serialize).
 
 Global flags are accepted **anywhere on the command line** (az-style):
@@ -848,7 +858,7 @@ mondo item list --board 42 --fields id,name,status
 
 # Find boards by name (server has no name filter; JMESPath handles it):
 mondo graphql 'query { boards(limit:200) { id name items_count } }' \
-    -q "data.boards[?contains(name,'Pager')]" -o table
+    -q "boards[?contains(name,'Pager')]" -o table
 
 # Extract a scalar with --output none for shell pipelines:
 count=$(mondo item list --board 42 -q "length(@)" -o none)

--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -777,12 +777,10 @@
     "command": "graphql",
     "output_type": "dynamic object",
     "fields": [
-      "data?",
-      "errors?",
-      "extensions?"
+      "<unwrapped data> | data?, errors?, extensions? (--raw)"
     ],
-    "notes": "Raw GraphQL response envelope from monday; shape depends entirely on the submitted query. --dry-run is not supported (refused with exit 2 — mondo can't safely preview a query it doesn't parse).",
-    "source": "client.execute(..., raw=True)"
+    "notes": "Default emits the unwrapped `data` object, so shape depends entirely on the submitted query; --raw keeps monday's full {data, errors, extensions} envelope. Erroring queries fail non-zero on both paths. --dry-run is not supported (refused with exit 2 — mondo can't safely preview a query it doesn't parse).",
+    "source": "client.execute(..., raw=True) → data (or full envelope with --raw)"
   },
   {
     "command": "group archive",

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -346,9 +346,9 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
 
 - `graphql`
   type: `dynamic object`
-  fields: `data?`, `errors?`, `extensions?`
-  source: `client.execute(..., raw=True)`
-  notes: Raw GraphQL response envelope from monday; shape depends entirely on the submitted query. --dry-run is not supported (refused with exit 2 — mondo can't safely preview a query it doesn't parse).
+  fields: `<unwrapped data> | data?, errors?, extensions? (--raw)`
+  source: `client.execute(..., raw=True) → data (or full envelope with --raw)`
+  notes: Default emits the unwrapped `data` object, so shape depends entirely on the submitted query; --raw keeps monday's full {data, errors, extensions} envelope. Erroring queries fail non-zero on both paths. --dry-run is not supported (refused with exit 2 — mondo can't safely preview a query it doesn't parse).
 
 ## group
 

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -535,13 +535,15 @@ MANUAL_ROWS: dict[str, Row] = {
     "graphql": Row(
         command="graphql",
         output_type="dynamic object",
-        fields=["data?", "errors?", "extensions?"],
+        fields=["<unwrapped data> | data?, errors?, extensions? (--raw)"],
         notes=(
-            "Raw GraphQL response envelope from monday; shape depends entirely "
-            "on the submitted query. --dry-run is not supported (refused with "
+            "Default emits the unwrapped `data` object, so shape depends "
+            "entirely on the submitted query; --raw keeps monday's full "
+            "{data, errors, extensions} envelope. Erroring queries fail "
+            "non-zero on both paths. --dry-run is not supported (refused with "
             "exit 2 — mondo can't safely preview a query it doesn't parse)."
         ),
-        source="client.execute(..., raw=True)",
+        source="client.execute(..., raw=True) → data (or full envelope with --raw)",
     ),
     "help": Row(
         command="help",

--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -63,6 +63,14 @@ EXAMPLES: dict[str, list[Example]] = {
             "cat mutation.graphql | mondo graphql -",
         ),
         Example(
+            "Project the unwrapped data (no `.data` prefix)",
+            "mondo graphql 'query { me { id name } }' -q 'me.name'",
+        ),
+        Example(
+            "Keep the full {data, errors, extensions} envelope",
+            "mondo graphql 'query { me { id } }' --raw",
+        ),
+        Example(
             "Tip: prefer positional GraphQL; a GraphQL-looking `-q` value is "
             "accepted as the query (JMESPath disabled)",
             "mondo graphql 'query { me { id } }'",

--- a/src/mondo/cli/graphql.py
+++ b/src/mondo/cli/graphql.py
@@ -1,8 +1,9 @@
 """`mondo graphql '<query>'` — raw GraphQL passthrough.
 
 Reads a query (positional, from stdin via `-`, or from a file via `@path`) and
-emits the parsed response envelope `{data, errors, extensions}` through the
-global formatter pipeline (so `-o json` / `-q` / etc. work uniformly).
+emits the unwrapped `data` object through the global formatter pipeline (so
+`-o json` / `-q` / etc. work uniformly, matching typed subcommands). Pass
+`--raw` to emit the full `{data, errors, extensions}` envelope instead.
 """
 
 from __future__ import annotations
@@ -47,8 +48,20 @@ def graphql_command(
         metavar="JSON",
         help="Variables as a JSON string. Use `@path` to read from a file.",
     ),
+    raw: bool = typer.Option(
+        False,
+        "--raw",
+        help="Emit the full {data, errors, extensions} envelope instead of "
+        "just the unwrapped `data` object.",
+    ),
 ) -> None:
     """Send a raw GraphQL query to monday.com and print the response.
+
+    By default the unwrapped `data` object is printed (matching typed
+    subcommands), so `-q`/jq paths address the result directly — e.g.
+    `mondo graphql 'query { boards { id } }' | jq '.boards[]'`. GraphQL
+    errors fail loudly (non-zero exit), just like typed subcommands. Pass
+    `--raw` to print the full `{data, errors, extensions}` envelope.
 
     Pass the query positionally. As a convenience, a GraphQL document
     passed to the global `-q/--query` (JMESPath projection) flag is run
@@ -101,8 +114,15 @@ def graphql_command(
 
     try:
         with client:
+            # raw=True keeps the user's query verbatim (no complexity rewrite).
+            # GraphQL-layer errors still raise here (and retry on transient ones
+            # like rate-limit/complexity), exactly as typed subcommands do, so a
+            # failing query fails loudly via the handler below.
             result = client.execute(query_text, variables=vars_dict, raw=True)
     except MondoError as e:
         handle_mondo_error_or_exit(e)
 
-    opts.emit(result)
+    # Success: emit the full {data, errors, extensions} envelope under --raw, or
+    # the unwrapped `data` object by default (matching typed subcommands, so
+    # `-q`/jq paths address the payload directly without a `.data` prefix).
+    opts.emit(result if raw else result.get("data"))

--- a/src/mondo/help/filters.md
+++ b/src/mondo/help/filters.md
@@ -106,7 +106,7 @@ each entry as `_fuzzy_score` and sorts by it.
 For ad-hoc predicates not covered above, use JMESPath:
 
     mondo graphql 'query { boards(limit:200) { id name } }' \
-        -q "data.boards[?contains(name,'Pager')]" -o table
+        -q "boards[?contains(name,'Pager')]" -o table
 
 See also: `mondo help output` for JMESPath projection, `mondo help
 complexity` for how filtering affects cost.

--- a/src/mondo/help/graphql.md
+++ b/src/mondo/help/graphql.md
@@ -27,7 +27,22 @@ when you need to:
 > and runs the value as the GraphQL document anyway (with a stderr
 > note), but the JMESPath projection is disabled for that invocation —
 > the value can't be both. Pass the query positionally to combine it
-> with a projection: `mondo graphql 'query { … }' -q 'data.me'`.
+> with a projection: `mondo graphql 'query { … }' -q 'me'`.
+
+## Output: unwrapped `data` by default
+
+Like the typed subcommands, `mondo graphql` prints the **unwrapped `data`
+object** — not the full `{data, errors, extensions}` envelope. So `-q`
+and jq paths address the result directly, with no `.data` prefix:
+
+    mondo graphql 'query { me { id name } }' -q 'me.name'
+    mondo graphql 'query { boards { id } }' | jq '.boards[]'
+
+A response that carries a GraphQL `errors` array fails loudly (non-zero
+exit), just like a typed subcommand — it does not emit a misleading
+`null`. Pass `--raw` to print the full envelope verbatim instead:
+
+    mondo graphql 'query { me { id } }' --raw
 
 ## Variables
 

--- a/src/mondo/help/output.md
+++ b/src/mondo/help/output.md
@@ -29,7 +29,7 @@ payload into a table-friendly form and still get a rendered table:
 
     # Filter client-side (server has no name filter on `boards`):
     mondo graphql 'query { boards(limit:200) { id name } }' \
-        -q "data.boards[?contains(name,'Pager')]" -o table
+        -q "boards[?contains(name,'Pager')]" -o table
 
 ## CSV-style field projection (`--fields`)
 
@@ -46,7 +46,7 @@ walk nested dicts:
     # Works on single-dict responses too
     mondo item get --id 987 --fields id,name,url --with-url
 
-Pipeline order: `-q` runs first (envelope extraction), then `--fields`
+Pipeline order: `-q` runs first (payload projection), then `--fields`
 (row-shape narrowing). Both compose freely. Reach for `-q` when you
 need filtering / aggregation / re-shaping; reach for `--fields` when you
 just want a smaller dict per row.

--- a/tests/integration/test_live_readonly.py
+++ b/tests/integration/test_live_readonly.py
@@ -77,10 +77,12 @@ def test_live_favorite_list(live_workspace_id: int) -> None:
 
 @pytest.mark.integration
 def test_live_graphql_read_query(live_workspace_id: int) -> None:
-    """Raw passthrough returns monday's `{data: {...}}` envelope."""
+    """Default unwraps `data`; `--raw` keeps monday's full envelope."""
     del live_workspace_id
     out = invoke_json(["graphql", "query { me { id name } }"])
-    assert out["data"]["me"]["id"], out
+    assert out["me"]["id"], out
+    raw = invoke_json(["graphql", "--raw", "query { me { id name } }"])
+    assert raw["data"]["me"]["id"], raw
 
 
 @pytest.mark.integration

--- a/tests/unit/test_cli_fields_option.py
+++ b/tests/unit/test_cli_fields_option.py
@@ -52,7 +52,7 @@ def test_fields_trims_a_list_payload(httpx_mock: HTTPXMock) -> None:
             "--fields",
             "id,name",
             "-q",
-            "data.users",
+            "users",
             "-o",
             "json",
             "graphql",
@@ -79,7 +79,7 @@ def test_fields_with_csv_output(httpx_mock: HTTPXMock) -> None:
             "--fields",
             "id,name",
             "-q",
-            "data.users",
+            "users",
             "-o",
             "csv",
             "graphql",
@@ -93,16 +93,16 @@ def test_fields_with_csv_output(httpx_mock: HTTPXMock) -> None:
 
 
 def test_fields_without_query_projects_dict(httpx_mock: HTTPXMock) -> None:
-    """--fields without -q operates on the whole envelope, not just the data
-    payload. That mirrors how -q sees the entire envelope by default."""
+    """--fields without -q operates on the unwrapped `data` object that
+    `mondo graphql` emits by default (the same payload -q would see)."""
     _graphql_ok(httpx_mock, {"me": {"id": "1", "name": "Alice", "email": "a@x"}})
     result = runner.invoke(
         app,
-        ["--fields", "data", "-o", "json", "graphql", "query { me { id name email } }"],
+        ["--fields", "me", "-o", "json", "graphql", "query { me { id name email } }"],
     )
     assert result.exit_code == 0, result.output
     parsed = json.loads(result.stdout)
-    assert parsed == {"data": {"me": {"id": "1", "name": "Alice", "email": "a@x"}}}
+    assert parsed == {"me": {"id": "1", "name": "Alice", "email": "a@x"}}
 
 
 def test_fields_appears_in_help_as_global_option() -> None:
@@ -129,13 +129,13 @@ def test_query_runs_before_fields(httpx_mock: HTTPXMock) -> None:
             ]
         },
     )
-    # Without --fields, -q 'data.users' returns the list.
+    # Without --fields, -q 'users' returns the list.
     # With --fields id, each row is trimmed to {id}.
     result = runner.invoke(
         app,
         [
             "-q",
-            "data.users",
+            "users",
             "--fields",
             "id",
             "-o",

--- a/tests/unit/test_cli_graphql.py
+++ b/tests/unit/test_cli_graphql.py
@@ -24,7 +24,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("MONDAY_API_TOKEN", "test-token-12345-abcdef-long-enough")
 
 
-def test_graphql_sends_query_and_prints_envelope(httpx_mock: HTTPXMock) -> None:
+def test_graphql_unwraps_data_by_default(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         url=ENDPOINT,
         method="POST",
@@ -33,7 +33,49 @@ def test_graphql_sends_query_and_prints_envelope(httpx_mock: HTTPXMock) -> None:
     result = runner.invoke(app, ["graphql", "query { me { id name } }"])
     assert result.exit_code == 0, result.stdout
     out = json.loads(result.stdout)
+    # Unwrapped: the `data` object is emitted directly, no envelope.
+    assert out == {"me": {"id": "1", "name": "Alice"}}
+    assert "extensions" not in out
+
+
+def test_graphql_raw_prints_full_envelope(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url=ENDPOINT,
+        method="POST",
+        json={"data": {"me": {"id": "1", "name": "Alice"}}, "extensions": {"request_id": "r"}},
+    )
+    result = runner.invoke(app, ["graphql", "--raw", "query { me { id name } }"])
+    assert result.exit_code == 0, result.stdout
+    out = json.loads(result.stdout)
     assert out["data"]["me"]["name"] == "Alice"
+    assert out["extensions"] == {"request_id": "r"}
+
+
+def test_graphql_graphql_errors_fail_nonzero(httpx_mock: HTTPXMock) -> None:
+    """A 200 response carrying a GraphQL `errors` array must fail loudly in
+    the unwrap path, not emit a misleading null `data`."""
+    httpx_mock.add_response(
+        url=ENDPOINT,
+        method="POST",
+        json={"data": None, "errors": [{"message": "Field 'bogus' doesn't exist"}]},
+    )
+    result = runner.invoke(app, ["graphql", "query { bogus }"])
+    assert result.exit_code != 0
+    combined = ((result.stdout or "") + (result.stderr or "")).lower()
+    assert "bogus" in combined
+
+
+def test_graphql_raw_errors_fail_nonzero(httpx_mock: HTTPXMock) -> None:
+    """`--raw` also fails loudly on a GraphQL error: the client raises (and
+    retries transient ones) rather than emitting an error envelope, matching
+    typed-subcommand exit codes."""
+    httpx_mock.add_response(
+        url=ENDPOINT,
+        method="POST",
+        json={"data": None, "errors": [{"message": "Field 'bogus' doesn't exist"}]},
+    )
+    result = runner.invoke(app, ["graphql", "--raw", "query { bogus }"])
+    assert result.exit_code != 0
 
 
 def test_graphql_with_variables(httpx_mock: HTTPXMock) -> None:
@@ -103,9 +145,9 @@ def test_graphql_query_flag_runs_as_document(httpx_mock: HTTPXMock) -> None:
     assert result.exit_code == 0, result.output
     body = json.loads(httpx_mock.get_request().content)  # type: ignore[union-attr]
     assert body["query"] == "query { me { id name } }"
-    # Projection is disabled: the full envelope is printed, un-projected.
+    # Projection is disabled: the unwrapped `data` object is printed.
     out = json.loads(result.stdout)
-    assert out["data"]["me"]["name"] == "Alice"
+    assert out == {"me": {"id": "1", "name": "Alice"}}
     assert "note:" in (result.stderr or "")
     assert "positionally" in (result.stderr or "")
 
@@ -130,7 +172,7 @@ def test_graphql_query_flag_through_main(
     except SystemExit as e:  # main() may sys.exit(0)
         assert not e.code, f"expected success, got exit {e.code}"
     captured = capsys.readouterr()
-    assert json.loads(captured.out)["data"]["me"]["id"] == "1"
+    assert json.loads(captured.out) == {"me": {"id": "1"}}
     assert "note:" in captured.err
 
 
@@ -141,9 +183,7 @@ def test_graphql_positional_plus_projection_unchanged(httpx_mock: HTTPXMock) -> 
         method="POST",
         json={"data": {"me": {"id": "1", "name": "Alice"}}, "extensions": {"request_id": "r"}},
     )
-    result = runner.invoke(
-        app, ["-o", "json", "-q", "data.me", "graphql", "query { me { id name } }"]
-    )
+    result = runner.invoke(app, ["-o", "json", "-q", "me", "graphql", "query { me { id name } }"])
     assert result.exit_code == 0, result.output
     body = json.loads(httpx_mock.get_request().content)  # type: ignore[union-attr]
     assert body["query"] == "query { me { id name } }"

--- a/tests/unit/test_cli_output.py
+++ b/tests/unit/test_cli_output.py
@@ -42,7 +42,7 @@ class TestGraphqlFormats:
         result = runner.invoke(app, ["graphql", "query { me { id } }"])
         assert result.exit_code == 0
         parsed = json.loads(result.stdout)
-        assert parsed["data"]["me"]["id"] == "1"
+        assert parsed["me"]["id"] == "1"
 
     def test_output_yaml(self, httpx_mock: HTTPXMock) -> None:
         _graphql_ok(httpx_mock, {"me": {"id": "1"}})
@@ -54,7 +54,7 @@ class TestGraphqlFormats:
         _graphql_ok(httpx_mock, {"me": {"id": "42", "name": "Alice"}})
         result = runner.invoke(
             app,
-            ["-q", "data.me.name", "-o", "none", "graphql", "query { me { id name } }"],
+            ["-q", "me.name", "-o", "none", "graphql", "query { me { id name } }"],
         )
         assert result.exit_code == 0
         assert result.stdout.strip() == "Alice"
@@ -73,7 +73,7 @@ class TestGraphqlFormats:
             app,
             [
                 "-q",
-                "data.users",
+                "users",
                 "-o",
                 "csv",
                 "graphql",


### PR DESCRIPTION
## What & why

Resolves #65.

`mondo graphql` emitted the full `{data, errors, extensions}` envelope, so `-q`/jq paths had to start at `.data` and `mondo graphql '…' | jq '.boards[]'` failed with "Cannot iterate over null" — inconsistent with every typed subcommand, which emits the unwrapped data object.

- **Default** now emits the unwrapped `data` object, so projections address the payload directly:
  `mondo graphql 'query { boards(workspace_ids:[123]){ id name } }' -q 'boards[0].name'`
- **`--raw`** keeps the full `{data, errors, extensions}` envelope.
- The query is still sent with `raw=True` (no complexity-field rewrite of the user's query). GraphQL-layer errors raise — and retry on transient ones (rate-limit/complexity) — exactly as typed subcommands do, so an erroring query fails loudly with matching exit codes on both the default and `--raw` paths (no misleading `null` data).

Docstring, `--help`, `README`, and the bundled `graphql`/`output`/`filters` help topics + examples were updated to drop the stale `.data` prefix and document `--raw`.

## Testing

- **Unit:** full non-integration suite green (**1690 passed**); new tests cover default-unwrap, `--raw` envelope, and errors-fail-nonzero on both paths; 7 pre-existing tests that used `graphql` as a formatter vehicle updated to the unwrapped shape. `ruff` clean.
- **Live (ws 592446):** `… -q 'boards[0].name'` returns the value with no `.data` prefix; `--raw` shows the `{data, extensions}` envelope; an erroring query exits non-zero on the default path.

## What review caught

`/code-review` + `/codex review` (gpt-5.5, high) flagged that an initial attempt to also surface error envelopes under `--raw` (via `surface_partial_errors=True`) would have **bypassed the client's retry loop** for retryable GraphQL errors — a regression vs typed subcommands. Reverted to the minimal design (plain `raw=True`, retry preserved, no dead code), and corrected a stale "`-q` envelope extraction" description in `README`/`output.md`.

> Note: shares a one-line addition in `src/mondo/cli/_examples.py` with the `doc` PR (#59–#64); whichever merges second may need a trivial rebase there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
