### PR TITLE
feat(doc): add HTML and MDX export to `doc get --format`

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,8 @@ mondo doc get            --object-id 77   # URL-visible id
 mondo doc get            --id 7 --format markdown    # render blocks → markdown
 mondo doc get            --id 7 --format markdown --out ./doc.md  # +download images beside the file
 mondo doc get            --id 7 --format markdown --out ./doc.md --no-images  # skip download, keep URLs
+mondo doc get            --id 7 --format mdx --out ./doc.mdx      # MDX (JSX-safe markdown)
+mondo doc get            --id 7 --format html --out ./doc.html    # single self-contained HTML, images base64-embedded
 mondo doc export-markdown --doc 7                    # always-live markdown export (--no-cache/--refresh-cache accepted as no-ops)
 mondo doc export-markdown --doc 7 --out ./doc.md     # +download images, rewrite URLs to local files
 mondo doc export-markdown --doc 7 --out ./doc.md --no-images  # skip download, keep URLs

--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -542,7 +542,7 @@
       "created_by{id,name}",
       "blocks{id,type,content,parent_block_id}"
     ],
-    "notes": "Default format is JSON object above. --format markdown prints markdown text instead. With --format markdown --out FILE, writes the markdown to FILE and emits {out, images} where images is the list of localized image filenames downloaded beside it (empty with --no-images). --out requires --format markdown (exit 2 otherwise).",
+    "notes": "Default format is JSON object above. --format markdown/mdx/html render to stdout instead (mdx is JSX-safe markdown; html is a single self-contained document). With --out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is the list of localized image filenames downloaded beside it; html embeds images as base64 and emits {out, images} where images is the embedded count. --no-images keeps the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise).",
     "source": "DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]"
   },
   {

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -239,7 +239,7 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   type: `object | string`
   fields: `id`, `object_id`, `name`, `doc_kind`, `doc_folder_id`, `created_at`, `updated_at`, `url`, `relative_url`, `workspace_id`, `created_by{id,name}`, `blocks{id,type,content,parent_block_id}`
   source: `DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]`
-  notes: Default format is JSON object above. --format markdown prints markdown text instead. With --format markdown --out FILE, writes the markdown to FILE and emits {out, images} where images is the list of localized image filenames downloaded beside it (empty with --no-images). --out requires --format markdown (exit 2 otherwise).
+  notes: Default format is JSON object above. --format markdown/mdx/html render to stdout instead (mdx is JSX-safe markdown; html is a single self-contained document). With --out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is the list of localized image filenames downloaded beside it; html embeds images as base64 and emits {out, images} where images is the embedded count. --no-images keeps the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise).
 - `doc import-html`
   type: `object`
   fields: `error`, `success`, `doc_id`

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -389,10 +389,12 @@ MANUAL_ROWS: dict[str, Row] = {
             "blocks{id,type,content,parent_block_id}",
         ],
         notes=(
-            "Default format is JSON object above. --format markdown prints markdown text "
-            "instead. With --format markdown --out FILE, writes the markdown to FILE and emits "
-            "{out, images} where images is the list of localized image filenames downloaded "
-            "beside it (empty with --no-images). --out requires --format markdown (exit 2 otherwise)."
+            "Default format is JSON object above. --format markdown/mdx/html render to stdout "
+            "instead (mdx is JSX-safe markdown; html is a single self-contained document). With "
+            "--out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is "
+            "the list of localized image filenames downloaded beside it; html embeds images as "
+            "base64 and emits {out, images} where images is the embedded count. --no-images keeps "
+            "the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise)."
         ),
         source="DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]",
     ),

--- a/src/mondo/cli/_doc_images.py
+++ b/src/mondo/cli/_doc_images.py
@@ -15,6 +15,7 @@ share the name `image-from-clipboard.png` — don't collide.
 
 from __future__ import annotations
 
+import base64
 import re
 from pathlib import Path
 from typing import Any
@@ -138,6 +139,64 @@ def download_doc_images(
     asset_ids = collect_image_asset_ids(blocks)
     downloaded = _download_assets(opts, asset_ids, folder)
     return {str(aid): (info["name"], info["filename"]) for aid, info in downloaded.items()}
+
+
+# Map a monday asset `file_extension` to a MIME type when the download
+# response carries no usable Content-Type header.
+_EXT_MIME = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "svg": "image/svg+xml",
+    "bmp": "image/bmp",
+    "tiff": "image/tiff",
+}
+
+
+def _download_bytes(url: str) -> tuple[bytes, str | None]:
+    """Fetch an asset into memory, returning `(bytes, content_type)`."""
+    try:
+        resp = httpx.get(url, follow_redirects=True)
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        raise NetworkError(f"image download failed: HTTP {e.response.status_code}") from e
+    except httpx.RequestError as e:
+        raise NetworkError(f"image download failed: {e}") from e
+    return resp.content, resp.headers.get("content-type")
+
+
+def embed_doc_images(
+    opts: GlobalOpts, blocks: list[dict[str, Any]]
+) -> dict[str, tuple[str, str]]:
+    """Resolve + download every image block's asset and base64-embed it.
+
+    Returns the map `blocks_to_html` expects: `str(assetId)` → `(alt_text,
+    data_uri)`, with the asset name as alt. Unlike `download_doc_images` this
+    writes nothing to disk — the bytes go inline as `data:` URIs so the HTML is
+    a single self-contained file.
+    """
+    asset_ids = collect_image_asset_ids(blocks)
+    meta = _resolve_assets(opts, asset_ids)
+    if not meta:
+        return {}
+    embedded: dict[str, tuple[str, str]] = {}
+    for aid in asset_ids:
+        asset = meta.get(aid)
+        if asset is None:
+            continue
+        url = asset.get("public_url") or asset.get("url")
+        if not url:
+            continue
+        data, ctype = _download_bytes(url)
+        mime = (ctype or "").split(";")[0].strip()
+        if not mime:
+            ext = (asset.get("file_extension") or "").lstrip(".").lower()
+            mime = _EXT_MIME.get(ext, "application/octet-stream")
+        b64 = base64.b64encode(data).decode("ascii")
+        embedded[str(aid)] = (asset.get("name") or "", f"data:{mime};base64,{b64}")
+    return embedded
 
 
 def localize_markdown_images(

--- a/src/mondo/cli/_doc_images.py
+++ b/src/mondo/cli/_doc_images.py
@@ -155,21 +155,43 @@ _EXT_MIME = {
 }
 
 
+# Hard ceiling on a single embedded asset. base64-inlining holds the whole
+# image in memory *and* in the HTML string, so an unbounded read is an
+# OOM/denial-of-service risk on a pathologically large asset.
+_MAX_EMBED_BYTES = 25 * 1024 * 1024
+
+
 def _download_bytes(url: str) -> tuple[bytes, str | None]:
-    """Fetch an asset into memory, returning `(bytes, content_type)`."""
+    """Fetch an asset into memory (capped at `_MAX_EMBED_BYTES`), returning
+    `(bytes, content_type)`. Streams with a hard byte limit so an oversized
+    asset is rejected instead of exhausting memory."""
     try:
-        resp = httpx.get(url, follow_redirects=True)
-        resp.raise_for_status()
+        with httpx.stream("GET", url, follow_redirects=True) as resp:
+            resp.raise_for_status()
+            declared = resp.headers.get("content-length")
+            if declared is not None and declared.isdigit() and int(declared) > _MAX_EMBED_BYTES:
+                raise NetworkError(
+                    f"image too large to embed: {int(declared)} bytes exceeds the "
+                    f"{_MAX_EMBED_BYTES}-byte limit"
+                )
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in resp.iter_bytes():
+                total += len(chunk)
+                if total > _MAX_EMBED_BYTES:
+                    raise NetworkError(
+                        f"image too large to embed: exceeds the {_MAX_EMBED_BYTES}-byte limit"
+                    )
+                chunks.append(chunk)
+            content_type = resp.headers.get("content-type")
     except httpx.HTTPStatusError as e:
         raise NetworkError(f"image download failed: HTTP {e.response.status_code}") from e
     except httpx.RequestError as e:
         raise NetworkError(f"image download failed: {e}") from e
-    return resp.content, resp.headers.get("content-type")
+    return b"".join(chunks), content_type
 
 
-def embed_doc_images(
-    opts: GlobalOpts, blocks: list[dict[str, Any]]
-) -> dict[str, tuple[str, str]]:
+def embed_doc_images(opts: GlobalOpts, blocks: list[dict[str, Any]]) -> dict[str, tuple[str, str]]:
     """Resolve + download every image block's asset and base64-embed it.
 
     Returns the map `blocks_to_html` expects: `str(assetId)` → `(alt_text,

--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -610,6 +610,14 @@ EXAMPLES: dict[str, list[Example]] = {
             "Save to a file but keep image URLs (skip download)",
             "mondo doc get --id 7 --format markdown --out ./doc.md --no-images",
         ),
+        Example(
+            "Render as MDX (JSX-safe markdown)",
+            "mondo doc get --id 7 --format mdx --out ./doc.mdx",
+        ),
+        Example(
+            "Render as a single self-contained HTML file (images base64-embedded)",
+            "mondo doc get --id 7 --format html --out ./doc.html",
+        ),
         Example("Just the doc name", "mondo doc get --id 7 -q name -o none"),
     ],
     "doc create": [

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -87,6 +87,8 @@ class DocsOrderBy(StrEnum):
 class DocFormat(StrEnum):
     json = "json"
     markdown = "markdown"
+    mdx = "mdx"
+    html = "html"
 
 
 class DuplicateDocType(StrEnum):
@@ -529,23 +531,25 @@ def get_cmd(
     fmt: DocFormat = typer.Option(
         DocFormat.json,
         "--format",
-        help="Emit raw JSON (blocks as-is) or render blocks to markdown.",
+        help="Emit raw JSON (blocks as-is) or render blocks to markdown, mdx, or html.",
         case_sensitive=False,
     ),
     out: Path | None = typer.Option(
         None,
         "--out",
         help=(
-            "Write markdown to this file and download embedded images into "
-            "the same folder, referenced by local filename (requires "
-            "--format markdown). Without it, markdown goes to stdout and "
-            "images keep their (browser-only) monday URLs."
+            "Write the rendered doc to this file (requires --format "
+            "markdown/mdx/html). For markdown/mdx, embedded images are "
+            "downloaded into the same folder and referenced by local filename; "
+            "for html they are base64-embedded so the file is self-contained. "
+            "Without --out, output goes to stdout (markdown/mdx keep monday "
+            "image URLs; html still embeds images)."
         ),
     ),
     no_images: bool = typer.Option(
         False,
         "--no-images",
-        help="With --out, skip downloading images; keep their monday URLs.",
+        help="Skip downloading/embedding images; keep their (browser-only) monday URLs.",
     ),
     with_url: bool = typer.Option(
         False,
@@ -580,13 +584,13 @@ def get_cmd(
     """
     from mondo.cli._cache_flags import emit_cache_provenance, reject_mutually_exclusive
     from mondo.cli._normalize import normalize_doc_entry
-    from mondo.docs import blocks_to_markdown
 
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     reject_mutually_exclusive(no_cache, refresh_cache)
     del with_url  # docs always carry `url` from monday; flag kept for symmetry
-    if out is not None and fmt is not DocFormat.markdown:
-        usage_error_or_exit("--out is only valid with --format markdown.")
+    _RENDER_FORMATS = {DocFormat.markdown, DocFormat.mdx, DocFormat.html}
+    if out is not None and fmt not in _RENDER_FORMATS:
+        usage_error_or_exit("--out is only valid with --format markdown, mdx, or html.")
     sources = sum(x is not None for x in (doc_id, object_id))
     if sources != 1:
         usage_error_or_exit("pass exactly one of --id or --object-id.")
@@ -652,16 +656,37 @@ def get_cmd(
     except MondoError as e:
         handle_mondo_error_or_exit(e)
 
-    if fmt is DocFormat.markdown:
+    if fmt is DocFormat.html:
+        from mondo.docs import blocks_to_html
+
+        blocks = doc.get("blocks") or []
+        images: dict[str, tuple[str, str]] = {}
+        if not no_images:
+            from mondo.cli._doc_images import embed_doc_images
+
+            images = embed_doc_images(opts, blocks)
+        html_text = blocks_to_html(blocks, images=images, title=doc.get("name"))
+        if out is not None:
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(html_text)
+            opts.emit({"out": str(out), "images": len(images)})
+            return
+        typer.echo(html_text)
+        return
+
+    if fmt in (DocFormat.markdown, DocFormat.mdx):
+        from mondo.docs import blocks_to_markdown, blocks_to_mdx
+
+        render = blocks_to_markdown if fmt is DocFormat.markdown else blocks_to_mdx
         blocks = doc.get("blocks") or []
         if out is not None:
-            images: dict[str, tuple[str, str]] = {}
+            images = {}
             if not no_images:
                 from mondo.cli._doc_images import download_doc_images
 
                 images = download_doc_images(opts, blocks, out.parent)
             out.parent.mkdir(parents=True, exist_ok=True)
-            out.write_text(blocks_to_markdown(blocks, images=images))
+            out.write_text(render(blocks, images=images))
             opts.emit(
                 {
                     "out": str(out),
@@ -669,7 +694,7 @@ def get_cmd(
                 }
             )
             return
-        typer.echo(blocks_to_markdown(blocks))
+        typer.echo(render(blocks))
         return
     doc = normalize_doc_entry(doc)
     opts.emit(doc)

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -668,7 +668,7 @@ def get_cmd(
         html_text = blocks_to_html(blocks, images=images, title=doc.get("name"))
         if out is not None:
             out.parent.mkdir(parents=True, exist_ok=True)
-            out.write_text(html_text)
+            out.write_text(html_text, encoding="utf-8")
             opts.emit({"out": str(out), "images": len(images)})
             return
         typer.echo(html_text)
@@ -686,7 +686,7 @@ def get_cmd(
 
                 images = download_doc_images(opts, blocks, out.parent)
             out.parent.mkdir(parents=True, exist_ok=True)
-            out.write_text(render(blocks, images=images))
+            out.write_text(render(blocks, images=images), encoding="utf-8")
             opts.emit(
                 {
                     "out": str(out),

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -584,6 +584,33 @@ def _mdx_escape(text: str) -> str:
     return text.replace("\\", "\\\\").replace("<", r"\<").replace("{", r"\{")
 
 
+# MDX parses a line that begins (after up to 3 spaces) with `import`/`export`
+# as an ESM statement, so doc prose starting with either word would be compiled
+# as module code instead of rendered as text — a hard failure, not cosmetic. A
+# 4+ space indent is an indented code block, not ESM, so it's excluded.
+_MDX_ESM_LINE_RE = re.compile(r"^( {0,3})(import|export)\b")
+
+
+def _neutralize_mdx_esm(md: str) -> str:
+    """Stop a prose line that opens with `import`/`export` from being parsed as
+    MDX ESM by encoding its leading letter as a numeric character reference:
+    the line no longer starts with the bare keyword, but renders identically.
+    Fenced code blocks are left untouched."""
+    out: list[str] = []
+    in_fence = False
+    for line in md.split("\n"):
+        if _CODE_FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        m = None if in_fence else _MDX_ESM_LINE_RE.match(line)
+        if m:
+            kw = m.group(2)
+            line = f"{m.group(1)}&#{ord(kw[0])};{kw[1:]}{line[m.end() :]}"
+        out.append(line)
+    return "\n".join(out)
+
+
 def blocks_to_mdx(
     blocks: list[dict[str, Any]],
     images: dict[str, tuple[str, str]] | None = None,
@@ -594,9 +621,10 @@ def blocks_to_mdx(
     rendering with JSX-significant characters escaped in prose. monday's
     notice/callout containers stay as GFM `> [!NOTE]` blockquotes — MDX renders
     them as ordinary blockquotes, and we make no assumption about the caller's
-    component library.
+    component library. A prose line opening with `import`/`export` is
+    neutralized so MDX doesn't compile it as an ESM statement.
     """
-    return blocks_to_markdown(blocks, images=images, text_filter=_mdx_escape)
+    return _neutralize_mdx_esm(blocks_to_markdown(blocks, images=images, text_filter=_mdx_escape))
 
 
 # --- blocks → HTML ----------------------------------------------------------
@@ -644,9 +672,7 @@ def _html_text(content: Any) -> str:
     return html.escape(_extract_text(content))
 
 
-def _render_html_image(
-    block: dict[str, Any], images: dict[str, tuple[str, str]] | None
-) -> str:
+def _render_html_image(block: dict[str, Any], images: dict[str, tuple[str, str]] | None) -> str:
     """`<img>` for an image block; `src` is the embedded data URI (or, without
     a map, the browser-only monday url so the image isn't dropped)."""
     content = _as_content_dict(block.get("content")) or {}

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -595,26 +595,36 @@ def _mdx_escape(text: str) -> str:
 # 4+ space indent is an indented code block, not ESM, so it's excluded.
 _MDX_ESM_LINE_RE = re.compile(r"^( {0,3})(import|export)\b")
 
-# Any fenced-code delimiter line, regardless of info string. Unlike
-# `_CODE_FENCE_RE` (whose `[\w-]*` info string misses `c++`, `c#`, etc.), this
-# only needs to recognize the opening/closing run so fence tracking can't
-# desync and rewrite real code as prose.
-_MDX_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+# A fenced-code opener, regardless of info string. Unlike `_CODE_FENCE_RE`
+# (whose `[\w-]*` info string misses `c++`, `c#`, etc.), this recognizes any
+# ``` or ~~~ run so fence tracking can't desync and rewrite real code as prose.
+_MDX_FENCE_OPEN_RE = re.compile(r"^\s*(`{3,}|~{3,})")
 
 
 def _neutralize_mdx_esm(md: str) -> str:
     """Stop a prose line that opens with `import`/`export` from being parsed as
     MDX ESM by encoding its leading letter as a numeric character reference:
     the line no longer starts with the bare keyword, but renders identically.
-    Fenced code blocks are left untouched."""
+    Fenced code blocks are left untouched — a fence closes only on a run of the
+    *same* delimiter char (length ≥ the opener), so e.g. a `~~~` line inside a
+    ```` ``` ```` block doesn't prematurely end tracking (GFM rule)."""
     out: list[str] = []
-    in_fence = False
+    fence_char = ""  # "" when outside a fence; "`" or "~" inside one
+    fence_len = 0
     for line in md.split("\n"):
-        if _MDX_FENCE_RE.match(line):
-            in_fence = not in_fence
+        if fence_char:
+            stripped = line.strip()
+            if stripped and stripped == fence_char * len(stripped) and len(stripped) >= fence_len:
+                fence_char, fence_len = "", 0
             out.append(line)
             continue
-        m = None if in_fence else _MDX_ESM_LINE_RE.match(line)
+        opener = _MDX_FENCE_OPEN_RE.match(line)
+        if opener:
+            fence_char = opener.group(1)[0]
+            fence_len = len(opener.group(1))
+            out.append(line)
+            continue
+        m = _MDX_ESM_LINE_RE.match(line)
         if m:
             kw = m.group(2)
             line = f"{m.group(1)}&#{ord(kw[0])};{kw[1:]}{line[m.end() :]}"

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -373,6 +373,28 @@ def _container_marker(btype: str, has_children: bool) -> str | None:
     return None
 
 
+def _build_block_tree(
+    blocks: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, list[dict[str, Any]]]]:
+    """Split the flat `parent_block_id` graph into `(roots, children_of)`.
+
+    A block is a root when it has no parent, its parent is missing from this
+    list (orphan — surfaced at top level so it's never silently dropped), or it
+    points at itself (self-cycle). Shared by the markdown and HTML renderers.
+    """
+    by_id = {str(b["id"]): b for b in blocks if b.get("id") is not None}
+    children_of: dict[str, list[dict[str, Any]]] = {}
+    roots: list[dict[str, Any]] = []
+    for b in blocks:
+        parent = b.get("parent_block_id")
+        bid = b.get("id")
+        if parent is None or str(parent) == str(bid) or str(parent) not in by_id:
+            roots.append(b)
+        else:
+            children_of.setdefault(str(parent), []).append(b)
+    return roots, children_of
+
+
 def blocks_to_markdown(
     blocks: list[dict[str, Any]],
     images: dict[str, tuple[str, str]] | None = None,
@@ -397,24 +419,7 @@ def blocks_to_markdown(
     if not blocks:
         return ""
 
-    by_id: dict[str, dict[str, Any]] = {}
-    for b in blocks:
-        bid = b.get("id")
-        if bid is not None:
-            by_id[str(bid)] = b
-
-    children_of: dict[str, list[dict[str, Any]]] = {}
-    roots: list[dict[str, Any]] = []
-    for b in blocks:
-        bid = b.get("id")
-        parent = b.get("parent_block_id")
-        # Treat as root when: no parent set, parent missing from this list
-        # (orphan — render at top so we don't silently drop), or self-cycle.
-        if parent is None or str(parent) == str(bid) or str(parent) not in by_id:
-            roots.append(b)
-        else:
-            children_of.setdefault(str(parent), []).append(b)
-
+    roots, children_of = _build_block_tree(blocks)
     lines: list[str] = []
     _render_block_list(roots, children_of, "", lines, images, text_filter)
     return "\n".join(lines).rstrip() + "\n"
@@ -590,6 +595,12 @@ def _mdx_escape(text: str) -> str:
 # 4+ space indent is an indented code block, not ESM, so it's excluded.
 _MDX_ESM_LINE_RE = re.compile(r"^( {0,3})(import|export)\b")
 
+# Any fenced-code delimiter line, regardless of info string. Unlike
+# `_CODE_FENCE_RE` (whose `[\w-]*` info string misses `c++`, `c#`, etc.), this
+# only needs to recognize the opening/closing run so fence tracking can't
+# desync and rewrite real code as prose.
+_MDX_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+
 
 def _neutralize_mdx_esm(md: str) -> str:
     """Stop a prose line that opens with `import`/`export` from being parsed as
@@ -599,7 +610,7 @@ def _neutralize_mdx_esm(md: str) -> str:
     out: list[str] = []
     in_fence = False
     for line in md.split("\n"):
-        if _CODE_FENCE_RE.match(line):
+        if _MDX_FENCE_RE.match(line):
             in_fence = not in_fence
             out.append(line)
             continue
@@ -852,22 +863,7 @@ def blocks_to_html(
     the file works offline with no sibling assets. Without the map, image
     `src`s keep their browser-only monday urls.
     """
-    by_id: dict[str, dict[str, Any]] = {}
-    for b in blocks:
-        bid = b.get("id")
-        if bid is not None:
-            by_id[str(bid)] = b
-
-    children_of: dict[str, list[dict[str, Any]]] = {}
-    roots: list[dict[str, Any]] = []
-    for b in blocks:
-        parent = b.get("parent_block_id")
-        bid = b.get("id")
-        if parent is None or str(parent) == str(bid) or str(parent) not in by_id:
-            roots.append(b)
-        else:
-            children_of.setdefault(str(parent), []).append(b)
-
+    roots, children_of = _build_block_tree(blocks)
     body = _render_html_blocks(roots, children_of, images)
     doc_title = title or "Document"
     heading = f'<h1 class="doc-title">{html.escape(doc_title)}</h1>\n' if title else ""

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -19,8 +19,10 @@ Unsupported markdown (nested lists, inline formatting) round-trips through
 
 from __future__ import annotations
 
+import html
 import json
 import re
+from collections.abc import Callable
 from typing import Any
 
 # --- doc column value parser ------------------------------------------------
@@ -325,7 +327,11 @@ _LEAF_TYPES = frozenset(
 )
 
 
-def _render_image(block: dict[str, Any], images: dict[str, tuple[str, str]] | None) -> str:
+def _render_image(
+    block: dict[str, Any],
+    images: dict[str, tuple[str, str]] | None,
+    text_filter: Callable[[str], str] | None = None,
+) -> str:
     """`![alt](ref)` for an `image` block.
 
     With an `images` map the asset's downloaded local filename (ref) and name
@@ -340,6 +346,8 @@ def _render_image(block: dict[str, Any], images: dict[str, tuple[str, str]] | No
         entry = images.get(str(asset_id))
         if entry is not None:
             alt, ref = entry
+    if text_filter is not None:
+        alt = text_filter(alt)
     # Escape `]` so an asset name like "a]b.png" can't close the alt span
     # early and corrupt the surrounding markdown.
     return f"![{alt.replace(']', r'\]')}]({ref})"
@@ -368,6 +376,7 @@ def _container_marker(btype: str, has_children: bool) -> str | None:
 def blocks_to_markdown(
     blocks: list[dict[str, Any]],
     images: dict[str, tuple[str, str]] | None = None,
+    text_filter: Callable[[str], str] | None = None,
 ) -> str:
     """Render a list of monday doc blocks as a markdown string.
 
@@ -379,6 +388,11 @@ def blocks_to_markdown(
     `images` maps `str(assetId)` → `(alt_text, ref)`; when an `image` block's
     asset is in the map its `ref` (a downloaded local filename) is emitted
     instead of the browser-only monday `url`.
+
+    `text_filter`, when given, post-processes every piece of *prose* text
+    (titles, list items, quotes, paragraphs, table cells, image alt) — code
+    block contents are passed through untouched. `blocks_to_mdx` uses it to
+    escape JSX-significant characters; markdown callers leave it `None`.
     """
     if not blocks:
         return ""
@@ -402,7 +416,7 @@ def blocks_to_markdown(
             children_of.setdefault(str(parent), []).append(b)
 
     lines: list[str] = []
-    _render_block_list(roots, children_of, "", lines, images)
+    _render_block_list(roots, children_of, "", lines, images, text_filter)
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -412,6 +426,7 @@ def _render_table(
     prefix: str,
     lines: list[str],
     images: dict[str, tuple[str, str]] | None = None,
+    text_filter: Callable[[str], str] | None = None,
 ) -> bool:
     """Render a `table` block as a markdown pipe table.
 
@@ -447,11 +462,11 @@ def _render_table(
             pieces: list[str] = []
             for child in children_of.get(cell_id, []):
                 if _normalize_type(child.get("type") or "") == "image":
-                    pieces.append(_render_image(child, images))
+                    pieces.append(_render_image(child, images, text_filter))
                     continue
                 t = _extract_text(child.get("content"))
                 if t:
-                    pieces.append(t)
+                    pieces.append(text_filter(t) if text_filter else t)
             cell_text = " ".join(pieces)
             # Escape pipes and collapse newlines so the row syntax stays valid.
             cell_text = cell_text.replace("|", r"\|").replace("\n", " ")
@@ -480,6 +495,7 @@ def _render_block_list(
     prefix: str,
     lines: list[str],
     images: dict[str, tuple[str, str]] | None = None,
+    text_filter: Callable[[str], str] | None = None,
 ) -> None:
     """Render a sibling group at indentation `prefix`.
 
@@ -490,13 +506,18 @@ def _render_block_list(
     for block in siblings:
         btype = _normalize_type(block.get("type") or "")
         text = _extract_text(block.get("content"))
+        # Prose text is filtered (e.g. MDX escaping); code content is not —
+        # MDX never parses inside a fenced code block.
+        ptext = text_filter(text) if text_filter else text
         bid = str(block.get("id") or "")
         kids = children_of.get(bid, [])
 
         if btype != "numbered_list":
             numbered_counter = 0
 
-        if btype == "table" and _render_table(block, children_of, prefix, lines, images):
+        if btype == "table" and _render_table(
+            block, children_of, prefix, lines, images, text_filter
+        ):
             continue
 
         marker = _container_marker(btype, has_children=bool(kids))
@@ -504,7 +525,7 @@ def _render_block_list(
             child_prefix = prefix + "> " if marker else prefix
             if marker:
                 lines.append(f"{prefix}> {marker}")
-            _render_block_list(kids, children_of, child_prefix, lines, images)
+            _render_block_list(kids, children_of, child_prefix, lines, images, text_filter)
             lines.append("")
             continue
 
@@ -512,21 +533,21 @@ def _render_block_list(
         if btype == "divider":
             lines.append(f"{prefix}---")
         elif btype == "large_title":
-            lines.append(f"{prefix}# {text}")
+            lines.append(f"{prefix}# {ptext}")
         elif btype == "medium_title":
-            lines.append(f"{prefix}## {text}")
+            lines.append(f"{prefix}## {ptext}")
         elif btype == "small_title":
-            lines.append(f"{prefix}### {text}")
+            lines.append(f"{prefix}### {ptext}")
         elif btype == "bulleted_list":
-            lines.append(f"{prefix}- {text}")
+            lines.append(f"{prefix}- {ptext}")
         elif btype == "numbered_list":
             numbered_counter += 1
-            lines.append(f"{prefix}{numbered_counter}. {text}")
+            lines.append(f"{prefix}{numbered_counter}. {ptext}")
         elif btype == "check_list":
             mark = "x" if _extract_checked(block.get("content")) else " "
-            lines.append(f"{prefix}- [{mark}] {text}")
+            lines.append(f"{prefix}- [{mark}] {ptext}")
         elif btype == "quote":
-            lines.append(f"{prefix}> {text}")
+            lines.append(f"{prefix}> {ptext}")
         elif btype == "code":
             content = _as_content_dict(block.get("content")) or {}
             lang = content.get("language", "")
@@ -535,14 +556,301 @@ def _render_block_list(
                 lines.append(f"{prefix}{text}")
             lines.append(f"{prefix}```")
         elif btype == "image":
-            lines.append(f"{prefix}{_render_image(block, images)}")
-        elif text:
+            lines.append(f"{prefix}{_render_image(block, images, text_filter)}")
+        elif ptext:
             # normal_text + any other leaf type we haven't taught.
-            lines.append(f"{prefix}{text}")
+            lines.append(f"{prefix}{ptext}")
 
         # Defensive: a leaf block with unexpected children would otherwise
         # drop them. Render at same prefix so content survives.
         if kids:
-            _render_block_list(kids, children_of, prefix, lines, images)
+            _render_block_list(kids, children_of, prefix, lines, images, text_filter)
 
         lines.append("")
+
+
+# --- blocks → MDX -----------------------------------------------------------
+
+
+def _mdx_escape(text: str) -> str:
+    """Escape characters MDX would otherwise parse as JSX.
+
+    MDX treats `<` as the start of a JSX element and `{` as the start of a JS
+    expression; an unescaped one in plain prose is a hard compile error, not a
+    cosmetic glitch. Backslash is escaped first so we don't double-process the
+    escapes we add. Code-block contents are never passed here (see
+    `blocks_to_markdown`'s `text_filter` contract).
+    """
+    return text.replace("\\", "\\\\").replace("<", r"\<").replace("{", r"\{")
+
+
+def blocks_to_mdx(
+    blocks: list[dict[str, Any]],
+    images: dict[str, tuple[str, str]] | None = None,
+) -> str:
+    """Render doc blocks as MDX.
+
+    MDX is GitHub-flavored markdown plus JSX, so the output is the markdown
+    rendering with JSX-significant characters escaped in prose. monday's
+    notice/callout containers stay as GFM `> [!NOTE]` blockquotes — MDX renders
+    them as ordinary blockquotes, and we make no assumption about the caller's
+    component library.
+    """
+    return blocks_to_markdown(blocks, images=images, text_filter=_mdx_escape)
+
+
+# --- blocks → HTML ----------------------------------------------------------
+
+_HTML_STYLE = """\
+:root { color-scheme: light dark; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.6; max-width: 48rem; margin: 2rem auto; padding: 0 1rem;
+  color: #1a1a1a;
+}
+h1, h2, h3 { line-height: 1.25; margin: 1.4em 0 0.5em; }
+h1.doc-title { margin-top: 0; }
+img { max-width: 100%; height: auto; }
+hr { border: none; border-top: 1px solid #ddd; margin: 1.5em 0; }
+blockquote {
+  margin: 1em 0; padding: 0.2em 1em; border-left: 4px solid #ddd; color: #555;
+}
+pre {
+  background: #f5f5f5; padding: 0.8em 1em; border-radius: 6px; overflow-x: auto;
+}
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.9em; }
+pre code { background: none; padding: 0; }
+table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+th, td { border: 1px solid #ddd; padding: 0.4em 0.7em; text-align: left; }
+th { background: #f5f5f5; }
+ul.checklist { list-style: none; padding-left: 1.2em; }
+ul.checklist li { text-indent: -1.2em; }
+aside.notice {
+  margin: 1em 0; padding: 0.8em 1em; border-left: 4px solid #4a90d9;
+  background: #eef5fc; border-radius: 0 6px 6px 0;
+}
+.layout { display: flow-root; }
+@media (prefers-color-scheme: dark) {
+  body { color: #e6e6e6; background: #1a1a1a; }
+  pre, th { background: #2a2a2a; }
+  blockquote, hr, th, td { border-color: #444; }
+  aside.notice { background: #16283a; }
+}
+"""
+
+
+def _html_text(content: Any) -> str:
+    """Extract a block's text and HTML-escape it."""
+    return html.escape(_extract_text(content))
+
+
+def _render_html_image(
+    block: dict[str, Any], images: dict[str, tuple[str, str]] | None
+) -> str:
+    """`<img>` for an image block; `src` is the embedded data URI (or, without
+    a map, the browser-only monday url so the image isn't dropped)."""
+    content = _as_content_dict(block.get("content")) or {}
+    asset_id = content.get("assetId")
+    alt = ""
+    src = content.get("url") or ""
+    if images is not None and asset_id is not None:
+        entry = images.get(str(asset_id))
+        if entry is not None:
+            alt, src = entry
+    return f'<img src="{html.escape(src, quote=True)}" alt="{html.escape(alt, quote=True)}">'
+
+
+def _render_html_table(
+    block: dict[str, Any],
+    children_of: dict[str, list[dict[str, Any]]],
+    images: dict[str, tuple[str, str]] | None,
+) -> list[str] | None:
+    """Render a `table` block as an HTML `<table>`.
+
+    Mirrors `_render_table`'s reading of `content.cells` (a row-major matrix of
+    `{"blockId": ...}` references). Returns None when the schema is
+    missing/malformed so the caller can fall back to a generic container.
+    """
+    content = _as_content_dict(block.get("content"))
+    if content is None:
+        return None
+    cells_matrix = content.get("cells")
+    if not isinstance(cells_matrix, list) or not cells_matrix:
+        return None
+
+    grid: list[list[str]] = []
+    for row in cells_matrix:
+        if not isinstance(row, list):
+            return None
+        row_html: list[str] = []
+        for cell_ref in row:
+            cell_id = ""
+            if isinstance(cell_ref, dict) and cell_ref.get("blockId") is not None:
+                cell_id = str(cell_ref["blockId"])
+            pieces: list[str] = []
+            for child in children_of.get(cell_id, []):
+                if _normalize_type(child.get("type") or "") == "image":
+                    pieces.append(_render_html_image(child, images))
+                else:
+                    t = _html_text(child.get("content"))
+                    if t:
+                        pieces.append(t)
+            row_html.append(" ".join(pieces))
+        grid.append(row_html)
+
+    if not grid or not grid[0]:
+        return None
+    col_count = max(len(row) for row in grid)
+    grid = [row + [""] * (col_count - len(row)) for row in grid]
+
+    out = ["<table>", "<thead><tr>"]
+    out += [f"<th>{c}</th>" for c in grid[0]]
+    out.append("</tr></thead>")
+    out.append("<tbody>")
+    for row in grid[1:]:
+        out.append("<tr>" + "".join(f"<td>{c}</td>" for c in row) + "</tr>")
+    out += ["</tbody>", "</table>"]
+    return out
+
+
+_HTML_HEADINGS = {"large_title": "h1", "medium_title": "h2", "small_title": "h3"}
+_HTML_LIST_TYPES = ("bulleted_list", "numbered_list", "check_list")
+
+
+def _render_html_blocks(
+    siblings: list[dict[str, Any]],
+    children_of: dict[str, list[dict[str, Any]]],
+    images: dict[str, tuple[str, str]] | None,
+) -> list[str]:
+    """Render a sibling group to HTML fragment lines.
+
+    Consecutive list items of the same type are grouped into one `<ul>`/`<ol>`,
+    which the line-oriented markdown renderer doesn't need to do.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(siblings)
+    while i < n:
+        block = siblings[i]
+        btype = _normalize_type(block.get("type") or "")
+        if btype in _HTML_LIST_TYPES:
+            tag = "ol" if btype == "numbered_list" else "ul"
+            cls = ' class="checklist"' if btype == "check_list" else ""
+            out.append(f"<{tag}{cls}>")
+            while i < n and _normalize_type(siblings[i].get("type") or "") == btype:
+                out.append(_render_html_list_item(siblings[i], btype, children_of, images))
+                i += 1
+            out.append(f"</{tag}>")
+            continue
+        out += _render_html_block(block, children_of, images)
+        i += 1
+    return out
+
+
+def _render_html_list_item(
+    block: dict[str, Any],
+    btype: str,
+    children_of: dict[str, list[dict[str, Any]]],
+    images: dict[str, tuple[str, str]] | None,
+) -> str:
+    text = _html_text(block.get("content"))
+    if btype == "check_list":
+        checked = " checked" if _extract_checked(block.get("content")) else ""
+        text = f'<input type="checkbox" disabled{checked}> {text}'
+    kids = children_of.get(str(block.get("id") or ""), [])
+    inner = "".join(_render_html_blocks(kids, children_of, images)) if kids else ""
+    return f"<li>{text}{inner}</li>"
+
+
+def _render_html_block(
+    block: dict[str, Any],
+    children_of: dict[str, list[dict[str, Any]]],
+    images: dict[str, tuple[str, str]] | None,
+) -> list[str]:
+    """Render a single non-list block to HTML fragment lines."""
+    btype = _normalize_type(block.get("type") or "")
+    bid = str(block.get("id") or "")
+    kids = children_of.get(bid, [])
+    text = _html_text(block.get("content"))
+
+    if btype == "table":
+        table = _render_html_table(block, children_of, images)
+        if table is not None:
+            return table
+        # malformed schema → fall through to the generic container below.
+
+    marker = _container_marker(btype, has_children=bool(kids))
+    if marker is not None:
+        inner = _render_html_blocks(kids, children_of, images)
+        if btype in ("notice_box", "notice", "callout"):
+            return ['<aside class="notice">', *inner, "</aside>"]
+        if btype == "layout":
+            return ['<div class="layout">', *inner, "</div>"]
+        return ['<div class="container">', *inner, "</div>"]
+
+    if btype == "divider":
+        return ["<hr>"]
+    if btype in _HTML_HEADINGS:
+        tag = _HTML_HEADINGS[btype]
+        return [f"<{tag}>{text}</{tag}>"]
+    if btype == "quote":
+        return [f"<blockquote>{text}</blockquote>"]
+    if btype == "code":
+        content = _as_content_dict(block.get("content")) or {}
+        lang = content.get("language", "")
+        cls = f' class="language-{html.escape(lang, quote=True)}"' if lang else ""
+        # Code text is escaped directly (not via _html_text) for clarity.
+        return [f"<pre><code{cls}>{html.escape(_extract_text(content))}</code></pre>"]
+    if btype == "image":
+        out = [_render_html_image(block, images)]
+    elif text:
+        out = [f"<p>{text}</p>"]
+    else:
+        out = []
+
+    # Defensive: a leaf with unexpected children — render them rather than drop.
+    if kids:
+        out += _render_html_blocks(kids, children_of, images)
+    return out
+
+
+def blocks_to_html(
+    blocks: list[dict[str, Any]],
+    images: dict[str, tuple[str, str]] | None = None,
+    title: str | None = None,
+) -> str:
+    """Render doc blocks as a single self-contained HTML document.
+
+    The result has an inline `<style>` and (when an `images` map of
+    `str(assetId)` → `(alt, data-uri)` is supplied) base64-embedded images, so
+    the file works offline with no sibling assets. Without the map, image
+    `src`s keep their browser-only monday urls.
+    """
+    by_id: dict[str, dict[str, Any]] = {}
+    for b in blocks:
+        bid = b.get("id")
+        if bid is not None:
+            by_id[str(bid)] = b
+
+    children_of: dict[str, list[dict[str, Any]]] = {}
+    roots: list[dict[str, Any]] = []
+    for b in blocks:
+        parent = b.get("parent_block_id")
+        bid = b.get("id")
+        if parent is None or str(parent) == str(bid) or str(parent) not in by_id:
+            roots.append(b)
+        else:
+            children_of.setdefault(str(parent), []).append(b)
+
+    body = _render_html_blocks(roots, children_of, images)
+    doc_title = title or "Document"
+    heading = f'<h1 class="doc-title">{html.escape(doc_title)}</h1>\n' if title else ""
+    body_html = "\n".join(body)
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        f"<title>{html.escape(doc_title)}</title>\n"
+        f"<style>\n{_HTML_STYLE}</style>\n</head>\n<body>\n"
+        f"{heading}{body_html}\n</body>\n</html>\n"
+    )

--- a/src/mondo/skill/references/docs.md
+++ b/src/mondo/skill/references/docs.md
@@ -29,7 +29,7 @@ mondo doc list --workspace 592446 --workspace 699169 -o json   # multiple worksp
 
 *Gotcha:* `id` is monday's internal numeric doc id; `object_id` is the (also numeric) URL-visible doc id (`/docs/<object_id>`). `--no-cache` is a good idea immediately after a write — the docs directory cache TTL is 8h, and `doc get` has its own short-TTL per-doc cache (`docs_blocks/<id>.json`, 5m) which is invalidated by every doc-write path (`add-block`, `add-content`, `add-markdown`, `import-html`, `rename`, `delete`, `update-block`, `delete-block`, plus `column doc set/append/clear`). Name filters (`--name-contains`, `--name-matches`, `--name-fuzzy`) are client-side and work with or without `--workspace`.
 
-## Get a doc — JSON or Markdown
+## Get a doc — JSON, Markdown, MDX, or HTML
 
 ```bash
 # Structured JSON (blocks, deltas, types):
@@ -42,20 +42,28 @@ mondo doc get --object-id 5098297247 --format json -o json
 mondo doc export-markdown --object-id 5098297247
 mondo doc export-markdown --doc 5095668848
 
-# Client-side render via `doc get` (prints markdown to stdout):
+# Client-side render via `doc get` (prints to stdout) — markdown, mdx, or html:
 mondo doc get --object-id 5098297247 --format markdown
+mondo doc get --object-id 5098297247 --format mdx
+mondo doc get --object-id 5098297247 --format html
 ```
 
-Two markdown paths exist: `doc export-markdown` (monday's server-side renderer) and `doc get --format markdown` (mondo's client-side block renderer). Both print to stdout by default.
+`doc get --format` renders client-side and supports `markdown`, `mdx`, and `html`; `doc export-markdown` is monday's server-side markdown renderer (markdown only — the API offers no server-side HTML/MDX export). All print to stdout by default.
+
+- **mdx** is the markdown rendering with JSX-significant characters (`<`, `{`) escaped in prose (never inside code fences); monday notice/callout boxes stay as GFM `> [!NOTE]` blockquotes.
+- **html** is a single self-contained document (inline `<style>`, base64-embedded images) — see below.
 
 *Note:* `export-markdown` is always live (it has no per-doc cache), so `--no-cache` / `--refresh-cache` are accepted as no-ops purely for symmetry with the other doc commands.
 
-### Write markdown to a file (and download embedded images)
+### Write to a file (and handle embedded images)
 
-Add `--out FILE` to either command to write the markdown to a file. Embedded monday images are downloaded into the **same folder** and referenced by a local `<assetId>-<name>` filename — because the raw `protected_static` image URLs only resolve in a logged-in browser, so the bare markdown is useless off-platform.
+Add `--out FILE` to write the rendered doc to a file (valid for `markdown`, `mdx`, and `html`; rejected with exit 2 for `json`).
+
+For **markdown** and **mdx**, embedded monday images are downloaded into the **same folder** and referenced by a local `<assetId>-<name>` filename — because the raw `protected_static` image URLs only resolve in a logged-in browser, so the bare file is useless off-platform.
 
 ```bash
 mondo doc get --object-id 5098297247 --format markdown --out ./spec.md
+mondo doc get --object-id 5098297247 --format mdx --out ./spec.mdx
 mondo doc export-markdown --object-id 5098297247 --out ./spec.md
 ```
 
@@ -63,7 +71,17 @@ mondo doc export-markdown --object-id 5098297247 --out ./spec.md
 {"out": "spec.md", "images": ["238776078-image-from-clipboard.png", "238776079-diagram.png"]}
 ```
 
-*Gotchas:* `--out` requires `--format markdown` on `doc get` (it's rejected with exit 2 for JSON). Pass `--no-images` to skip the download and leave the original monday URLs in place. The `images` field lists the local filenames actually written next to the markdown (images inside table cells are downloaded too, so references aren't orphaned).
+For **html**, images are base64-embedded directly in the file (no sidecar assets), so the output is a single portable file — this holds even when printing to stdout. The summary reports the embedded image *count*, not filenames:
+
+```bash
+mondo doc get --object-id 5098297247 --format html --out ./spec.html
+```
+
+```json
+{"out": "spec.html", "images": 3}
+```
+
+*Gotchas:* Pass `--no-images` to skip downloading/embedding and leave the original (browser-only) monday URLs in place — for markdown/mdx the `images` field then lists the local filenames actually written (images inside table cells are downloaded too, so references aren't orphaned).
 
 ```json
 {

--- a/tests/integration/test_live_doc_export_formats.py
+++ b/tests/integration/test_live_doc_export_formats.py
@@ -46,8 +46,15 @@ def test_live_doc_get_html_no_images_keeps_urls(live_test_doc_id: int, tmp_path)
     out = tmp_path / "doc.html"
     invoke_json(
         [
-            "doc", "get", "--object-id", str(live_test_doc_id),
-            "--format", "html", "--out", str(out), "--no-images",
+            "doc",
+            "get",
+            "--object-id",
+            str(live_test_doc_id),
+            "--format",
+            "html",
+            "--out",
+            str(out),
+            "--no-images",
         ]
     )
     html = out.read_text()
@@ -80,8 +87,14 @@ def test_live_doc_get_mdx_downloads_images(live_test_doc_id: int, tmp_path) -> N
 def test_live_doc_get_html_out_rejected_for_json(live_test_doc_id: int, tmp_path) -> None:
     result = invoke(
         [
-            "doc", "get", "--object-id", str(live_test_doc_id),
-            "--format", "json", "--out", str(tmp_path / "doc.json"),
+            "doc",
+            "get",
+            "--object-id",
+            str(live_test_doc_id),
+            "--format",
+            "json",
+            "--out",
+            str(tmp_path / "doc.json"),
         ],
         expect_exit=None,
     )

--- a/tests/integration/test_live_doc_export_formats.py
+++ b/tests/integration/test_live_doc_export_formats.py
@@ -1,0 +1,89 @@
+"""Live integration tests for HTML and MDX doc export.
+
+`doc get --format html|mdx` are client-side renderers (monday's API offers no
+server-side HTML/MDX export). HTML produces a single self-contained file with
+base64-embedded images; MDX reuses the markdown image pipeline (local files).
+
+Gated by MONDO_TEST_DOC_ID; the prepared doc carries a notice box, table,
+check list, code block, and image blocks (one top-level, two inside a table).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from ._helpers import invoke, invoke_json
+
+_LOCAL_IMAGE_RE = re.compile(r"!\[[^\]]*\]\((\d+-[^)]+)\)")
+
+
+@pytest.mark.integration
+def test_live_doc_get_html_is_self_contained(live_test_doc_id: int, tmp_path) -> None:
+    out = tmp_path / "doc.html"
+    summary = invoke_json(
+        ["doc", "get", "--object-id", str(live_test_doc_id), "--format", "html", "--out", str(out)]
+    )
+    assert out.exists(), "html file not written"
+    html = out.read_text()
+
+    assert html.startswith("<!DOCTYPE html>")
+    assert "<title>" in html and "<style>" in html
+    # Images are base64-embedded, so the file needs no sidecar assets and no
+    # browser-only monday URL survives.
+    assert summary.get("images", 0) > 0, summary
+    assert "data:image/" in html
+    assert "protected_static" not in html, "image URL leaked instead of embedding"
+    assert not list(tmp_path.glob("*.png")), "html export must not write sidecar images"
+    # Block fidelity: the prepared doc's notice box and table must render.
+    assert '<aside class="notice">' in html
+    assert "<table>" in html
+
+
+@pytest.mark.integration
+def test_live_doc_get_html_no_images_keeps_urls(live_test_doc_id: int, tmp_path) -> None:
+    out = tmp_path / "doc.html"
+    invoke_json(
+        [
+            "doc", "get", "--object-id", str(live_test_doc_id),
+            "--format", "html", "--out", str(out), "--no-images",
+        ]
+    )
+    html = out.read_text()
+    assert "data:image/" not in html
+    assert "protected_static" in html
+
+
+@pytest.mark.integration
+def test_live_doc_get_mdx_downloads_images(live_test_doc_id: int, tmp_path) -> None:
+    out = tmp_path / "doc.mdx"
+    summary = invoke_json(
+        ["doc", "get", "--object-id", str(live_test_doc_id), "--format", "mdx", "--out", str(out)]
+    )
+    assert out.exists(), "mdx file not written"
+    mdx = out.read_text()
+
+    images = summary.get("images") or []
+    assert images, summary
+    for fname in images:
+        assert re.match(r"\d+-", fname), f"unexpected filename scheme: {fname}"
+        downloaded = tmp_path / fname
+        assert downloaded.exists() and downloaded.stat().st_size > 0, fname
+        assert f"]({fname})" in mdx
+    assert "protected_static" not in mdx, mdx
+    # MDX keeps monday callouts as GFM blockquotes.
+    assert "> [!NOTE]" in mdx
+
+
+@pytest.mark.integration
+def test_live_doc_get_html_out_rejected_for_json(live_test_doc_id: int, tmp_path) -> None:
+    result = invoke(
+        [
+            "doc", "get", "--object-id", str(live_test_doc_id),
+            "--format", "json", "--out", str(tmp_path / "doc.json"),
+        ],
+        expect_exit=None,
+    )
+    assert result.exit_code == 2, result.stderr
+    assert "markdown, mdx, or html" in result.stderr

--- a/tests/unit/test_doc_images.py
+++ b/tests/unit/test_doc_images.py
@@ -6,7 +6,13 @@ exercised by the live integration suite; here we cover the pure logic.
 
 from __future__ import annotations
 
+import pytest
+from pytest_httpx import HTTPXMock
+
+from mondo.api.errors import NetworkError
+from mondo.cli import _doc_images
 from mondo.cli._doc_images import (
+    _download_bytes,
     extract_asset_ids_from_markdown,
     local_filename,
     rewrite_markdown_images,
@@ -74,3 +80,23 @@ class TestRewriteMarkdownImages:
     def test_external_image_untouched(self) -> None:
         md = "![](https://example.test/img.png)"
         assert rewrite_markdown_images(md, {1: "x.png"}) == md
+
+
+class TestDownloadBytesSizeCap:
+    """`_download_bytes` caps embedded assets so a huge image can't OOM."""
+
+    def test_small_asset_downloads(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://x/a.png", content=b"hello", headers={"content-type": "image/png"}
+        )
+        data, ctype = _download_bytes("https://x/a.png")
+        assert data == b"hello"
+        assert ctype == "image/png"
+
+    def test_rejects_oversized_via_content_length(
+        self, httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_doc_images, "_MAX_EMBED_BYTES", 4)
+        httpx_mock.add_response(url="https://x/big.png", content=b"way too many bytes")
+        with pytest.raises(NetworkError, match="too large to embed"):
+            _download_bytes("https://x/big.png")

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -759,6 +759,18 @@ class TestBlocksToMdx:
         assert "import std" in out
         assert "&#105;mport" not in out
 
+    def test_tilde_line_inside_backtick_fence_does_not_desync(self) -> None:
+        # A ``` block whose content has a ~~~ line must NOT be treated as a
+        # fence close, or `import` after it would be wrongly neutralized.
+        block = {
+            "id": "c",
+            "type": "code",
+            "content": {"deltaFormat": [{"insert": "~~~\nimport os"}]},
+        }
+        out = blocks_to_mdx([block])
+        assert "import os" in out
+        assert "&#105;mport" not in out
+
 
 class TestBlocksToHtml:
     def test_wraps_in_self_contained_document(self) -> None:

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -710,9 +710,7 @@ class TestBlocksToMdx:
         assert r"\<div>" not in out
 
     def test_callouts_stay_gfm_blockquotes(self) -> None:
-        out = blocks_to_mdx(
-            [_b("n", "notice_box"), _b("c", "normal_text", "inside", parent="n")]
-        )
+        out = blocks_to_mdx([_b("n", "notice_box"), _b("c", "normal_text", "inside", parent="n")])
         assert "> [!NOTE]" in out
 
     def test_escapes_table_cell_text(self) -> None:
@@ -723,6 +721,31 @@ class TestBlocksToMdx:
         ]
         out = blocks_to_mdx(blocks)
         assert r"a \<b> c" in out
+
+    def test_neutralizes_leading_import_keyword(self) -> None:
+        # A prose line opening with `import` would be parsed as MDX ESM; the
+        # leading letter is encoded so it renders as text instead.
+        out = blocks_to_mdx([_b("p", "normal_text", "import the data first")])
+        assert "&#105;mport the data first" in out  # 105 == ord('i')
+        assert not out.strip().startswith("import")
+
+    def test_neutralizes_leading_export_keyword(self) -> None:
+        out = blocks_to_mdx([_b("p", "normal_text", "export your results")])
+        assert "&#101;xport your results" in out  # 101 == ord('e')
+
+    def test_import_mid_sentence_left_intact(self) -> None:
+        out = blocks_to_mdx([_b("p", "normal_text", "we import the data")])
+        assert "we import the data" in out
+
+    def test_leading_import_inside_code_fence_left_intact(self) -> None:
+        block = {
+            "id": "c",
+            "type": "code",
+            "content": {"deltaFormat": [{"insert": "import os"}]},
+        }
+        out = blocks_to_mdx([block])
+        assert "import os" in out
+        assert "&#105;mport" not in out
 
 
 class TestBlocksToHtml:
@@ -786,16 +809,12 @@ class TestBlocksToHtml:
         assert "<blockquote>wise</blockquote>" in out
 
     def test_notice_box_renders_as_aside(self) -> None:
-        out = blocks_to_html(
-            [_b("n", "notice_box"), _b("c", "normal_text", "inside", parent="n")]
-        )
+        out = blocks_to_html([_b("n", "notice_box"), _b("c", "normal_text", "inside", parent="n")])
         assert '<aside class="notice">' in out
         assert "<p>inside</p>" in out
 
     def test_layout_renders_children_in_div(self) -> None:
-        out = blocks_to_html(
-            [_b("l", "layout"), _b("c", "normal_text", "col", parent="l")]
-        )
+        out = blocks_to_html([_b("l", "layout"), _b("c", "normal_text", "col", parent="l")])
         assert '<div class="layout">' in out
         assert "<p>col</p>" in out
 
@@ -806,10 +825,32 @@ class TestBlocksToHtml:
 
     def test_image_with_map_embeds_data_uri(self) -> None:
         block = {"id": "i", "type": "image", "content": {"assetId": 7, "url": "https://x/a.png"}}
-        out = blocks_to_html(
-            [block], images={"7": ("photo.png", "data:image/png;base64,AAA")}
-        )
+        out = blocks_to_html([block], images={"7": ("photo.png", "data:image/png;base64,AAA")})
         assert '<img src="data:image/png;base64,AAA" alt="photo.png">' in out
+
+    def test_escapes_hostile_image_url(self) -> None:
+        block = {
+            "id": "i",
+            "type": "image",
+            "content": {"assetId": 7, "url": 'https://x/a.png"><script>alert(1)</script>'},
+        }
+        out = blocks_to_html([block])
+        assert "<script>alert(1)</script>" not in out
+        assert "&lt;script&gt;" in out
+
+    def test_escapes_hostile_image_alt(self) -> None:
+        block = {"id": "i", "type": "image", "content": {"assetId": 7, "url": "https://x/a.png"}}
+        out = blocks_to_html(
+            [block], images={"7": ('"><script>x</script>', "data:image/png;base64,AAA")}
+        )
+        assert "<script>x</script>" not in out
+
+    def test_escapes_hostile_title(self) -> None:
+        out = blocks_to_html(
+            [_b("p", "normal_text", "hi")], title="</title><script>alert(1)</script>"
+        )
+        assert "<script>alert(1)</script>" not in out
+        assert "&lt;/title&gt;" in out
 
     def test_table_renders_html_table(self) -> None:
         # Matrix references *cell* blocks (parented to the table); each cell's

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -747,6 +747,18 @@ class TestBlocksToMdx:
         assert "import os" in out
         assert "&#105;mport" not in out
 
+    def test_leading_import_inside_unusual_lang_fence_left_intact(self) -> None:
+        # A fence whose info string isn't plain `[\w-]*` (e.g. `c++`/`c#`) must
+        # still be recognized so code content isn't rewritten as prose.
+        block = {
+            "id": "c",
+            "type": "code",
+            "content": {"deltaFormat": [{"insert": "import std"}], "language": "c++"},
+        }
+        out = blocks_to_mdx([block])
+        assert "import std" in out
+        assert "&#105;mport" not in out
+
 
 class TestBlocksToHtml:
     def test_wraps_in_self_contained_document(self) -> None:

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import pytest
 
 from mondo.docs import (
+    blocks_to_html,
     blocks_to_markdown,
+    blocks_to_mdx,
     collect_image_asset_ids,
     extract_doc_ids_from_column_value,
     markdown_to_blocks,
@@ -671,3 +673,173 @@ class TestRoundTrip:
                 content = line.lstrip("# -1234567890.>").strip()
                 if content and content != "---":
                     assert content in back
+
+
+def _b(bid, btype, text="", parent=None):
+    """Block fixture: text becomes deltaFormat content; empty → {}."""
+    return {
+        "id": bid,
+        "type": btype,
+        "content": {"deltaFormat": [{"insert": text}]} if text else {},
+        "parent_block_id": parent,
+    }
+
+
+class TestBlocksToMdx:
+    def test_markdown_passthrough_when_no_special_chars(self) -> None:
+        blocks = [_b("h", "large_title", "Title"), _b("p", "normal_text", "plain prose")]
+        assert blocks_to_mdx(blocks) == blocks_to_markdown(blocks)
+
+    def test_escapes_angle_bracket_in_prose(self) -> None:
+        out = blocks_to_mdx([_b("p", "normal_text", "use <Component> here")])
+        assert r"use \<Component> here" in out
+
+    def test_escapes_brace_in_prose(self) -> None:
+        out = blocks_to_mdx([_b("p", "normal_text", "value {x}")])
+        assert r"value \{x}" in out
+
+    def test_does_not_escape_inside_code_block(self) -> None:
+        """MDX never parses inside fenced code — escaping there would corrupt it."""
+        block = {
+            "id": "c",
+            "type": "code",
+            "content": {"deltaFormat": [{"insert": "<div>{x}</div>"}]},
+        }
+        out = blocks_to_mdx([block])
+        assert "<div>{x}</div>" in out
+        assert r"\<div>" not in out
+
+    def test_callouts_stay_gfm_blockquotes(self) -> None:
+        out = blocks_to_mdx(
+            [_b("n", "notice_box"), _b("c", "normal_text", "inside", parent="n")]
+        )
+        assert "> [!NOTE]" in out
+
+    def test_escapes_table_cell_text(self) -> None:
+        blocks = [
+            {"id": "t", "type": "table", "content": {"cells": [[{"blockId": "cell"}]]}},
+            _b("cell", "table_cell", parent="t"),
+            _b("txt", "normal_text", "a <b> c", parent="cell"),
+        ]
+        out = blocks_to_mdx(blocks)
+        assert r"a \<b> c" in out
+
+
+class TestBlocksToHtml:
+    def test_wraps_in_self_contained_document(self) -> None:
+        out = blocks_to_html([_b("p", "normal_text", "hi")], title="My Doc")
+        assert out.startswith("<!DOCTYPE html>")
+        assert "<style>" in out
+        assert "<title>My Doc</title>" in out
+        assert '<h1 class="doc-title">My Doc</h1>' in out
+        assert "<p>hi</p>" in out
+
+    def test_headings(self) -> None:
+        out = blocks_to_html(
+            [
+                _b("a", "large_title", "H1"),
+                _b("b", "medium_title", "H2"),
+                _b("c", "small_title", "H3"),
+            ]
+        )
+        assert "<h1>H1</h1>" in out
+        assert "<h2>H2</h2>" in out
+        assert "<h3>H3</h3>" in out
+
+    def test_escapes_html_in_text(self) -> None:
+        out = blocks_to_html([_b("p", "normal_text", "a <b> & c")])
+        assert "<p>a &lt;b&gt; &amp; c</p>" in out
+
+    def test_bulleted_list_groups_into_ul(self) -> None:
+        out = blocks_to_html([_b("1", "bulleted_list", "a"), _b("2", "bulleted_list", "b")])
+        assert "<ul>" in out and "</ul>" in out
+        assert out.count("<li>") == 2
+
+    def test_numbered_list_groups_into_ol(self) -> None:
+        out = blocks_to_html([_b("1", "numbered_list", "a"), _b("2", "numbered_list", "b")])
+        assert "<ol>" in out and "</ol>" in out
+
+    def test_checklist_renders_disabled_checkbox(self) -> None:
+        checked = {
+            "id": "1",
+            "type": "check_list",
+            "content": {"deltaFormat": [{"insert": "done"}], "checked": True},
+        }
+        unchecked = _b("2", "check_list", "todo")
+        out = blocks_to_html([checked, unchecked])
+        assert 'class="checklist"' in out
+        assert '<input type="checkbox" disabled checked>' in out
+        assert '<input type="checkbox" disabled>' in out
+
+    def test_code_block(self) -> None:
+        block = {
+            "id": "c",
+            "type": "code",
+            "content": {"deltaFormat": [{"insert": "x = 1 < 2"}], "language": "python"},
+        }
+        out = blocks_to_html([block])
+        assert '<pre><code class="language-python">x = 1 &lt; 2</code></pre>' in out
+
+    def test_divider_and_quote(self) -> None:
+        out = blocks_to_html([_b("d", "divider"), _b("q", "quote", "wise")])
+        assert "<hr>" in out
+        assert "<blockquote>wise</blockquote>" in out
+
+    def test_notice_box_renders_as_aside(self) -> None:
+        out = blocks_to_html(
+            [_b("n", "notice_box"), _b("c", "normal_text", "inside", parent="n")]
+        )
+        assert '<aside class="notice">' in out
+        assert "<p>inside</p>" in out
+
+    def test_layout_renders_children_in_div(self) -> None:
+        out = blocks_to_html(
+            [_b("l", "layout"), _b("c", "normal_text", "col", parent="l")]
+        )
+        assert '<div class="layout">' in out
+        assert "<p>col</p>" in out
+
+    def test_image_without_map_keeps_url(self) -> None:
+        block = {"id": "i", "type": "image", "content": {"assetId": 7, "url": "https://x/a.png"}}
+        out = blocks_to_html([block])
+        assert '<img src="https://x/a.png" alt="">' in out
+
+    def test_image_with_map_embeds_data_uri(self) -> None:
+        block = {"id": "i", "type": "image", "content": {"assetId": 7, "url": "https://x/a.png"}}
+        out = blocks_to_html(
+            [block], images={"7": ("photo.png", "data:image/png;base64,AAA")}
+        )
+        assert '<img src="data:image/png;base64,AAA" alt="photo.png">' in out
+
+    def test_table_renders_html_table(self) -> None:
+        # Matrix references *cell* blocks (parented to the table); each cell's
+        # visible text lives in a child block parented to the cell.
+        blocks = [
+            {
+                "id": "t",
+                "type": "table",
+                "content": {
+                    "cells": [
+                        [{"blockId": "h1"}, {"blockId": "h2"}],
+                        [{"blockId": "c1"}, {"blockId": "c2"}],
+                    ]
+                },
+            },
+            _b("h1", "table_cell", parent="t"),
+            _b("h2", "table_cell", parent="t"),
+            _b("c1", "table_cell", parent="t"),
+            _b("c2", "table_cell", parent="t"),
+            _b("h1t", "normal_text", "A", parent="h1"),
+            _b("h2t", "normal_text", "B", parent="h2"),
+            _b("c1t", "normal_text", "1", parent="c1"),
+            _b("c2t", "normal_text", "2", parent="c2"),
+        ]
+        out = blocks_to_html(blocks)
+        assert "<table>" in out
+        assert "<th>A</th>" in out and "<th>B</th>" in out
+        assert "<td>1</td>" in out and "<td>2</td>" in out
+
+    def test_empty_blocks(self) -> None:
+        out = blocks_to_html([], title="Empty")
+        assert out.startswith("<!DOCTYPE html>")
+        assert "<title>Empty</title>" in out


### PR DESCRIPTION
## What

Adds `html` and `mdx` to `doc get --format` (previously `json`/`markdown`).

monday's API exports **only** markdown server-side (`export_markdown_from_doc`); there is no API path for HTML/PDF/MDX. So both new formats render **client-side**, next to the existing `doc get --format markdown` block renderer — **no new dependencies** (the binaries ship via PyInstaller `--onedir` and can't bundle native renderers).

### `--format html`
Single **self-contained** document — inline `<style>` (light/dark), images **base64-embedded** as `data:` URIs (no sidecar files; self-contained even on stdout). New `blocks_to_html()` mirrors the markdown block dispatch: headings, lists (grouped into `<ul>`/`<ol>`), checklists (`<input type=checkbox disabled>`), code, quotes, dividers, notice boxes (`<aside class="notice">`), tables, layout containers, nesting. Embedding handled by new `embed_doc_images()`.

### `--format mdx`
The markdown rendering with JSX-significant `<`/`{` escaped **in prose only** (never inside code fences), via a new optional `text_filter` hook on the markdown renderer. monday notice/callout boxes stay as GFM `> [!NOTE]` blockquotes (no assumption about the consumer's component set). Images use the existing local-file pipeline like markdown.

### CLI
- `--out` now valid for `markdown`/`mdx`/`html` (still exit 2 for `json`).
- `--no-images` keeps the browser-only monday URLs for all formats.

`text_filter` defaults to `None`, so existing markdown output is byte-identical (confirmed by the unchanged markdown tests).

## Tests
- 28 new unit tests in `test_docs.py` (renderers, escaping, list grouping, tables, images, containers).
- New live suite `test_live_doc_export_formats.py` (4 tests) — passing against the playground doc.
- Full unit suite green (1707); ruff + mypy clean.

## Docs
Skill reference, README, command examples (`--help` epilog), and the generated output-contract-matrix updated.

## Out of scope
PDF export — tracked in #68. The clean path there is "styled HTML → print to PDF" (zero deps), since the PyInstaller binaries can't bundle WeasyPrint/Chromium.