### PR TITLE
docs: sync doc surfaces with graphql-unwrap + doc html/mdx/clear features

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,9 +586,11 @@ mondo doc export-markdown --doc 7 --out ./doc.md     # +download images, rewrite
 mondo doc export-markdown --doc 7 --out ./doc.md --no-images  # skip download, keep URLs
 mondo doc create         --workspace 42 --name "Spec" --kind public [--folder 3042556]
 
-mondo doc add-content    --doc 7 --from-file spec.md         # bulk markdown → blocks (append)
+mondo doc add-content    --doc 7 --from-file spec.md         # bulk markdown → blocks (append, per-block)
+mondo doc add-markdown   --doc 7 --from-file spec.md         # append via monday's server-side parser → blocks_added
 mondo doc set            --doc 7 --from-file spec.md         # replace full content in place
 mondo doc replace        --object-id 77 --markdown "# Fresh" # alias of `doc set`
+mondo doc clear          --doc 7                             # empty the body, keep the doc (id/url preserved)
 mondo doc add-block      --doc 7 --type normal_text \
                          --content '{"deltaFormat":[{"insert":"hi"}]}' \
                          [--after <block-id>] [--parent-block <block-id>]
@@ -599,10 +601,17 @@ mondo doc delete         --doc 7                             # delete the whole 
 
 `add-content` reuses the Phase-1f markdown converter (headings h1-h3,
 paragraphs, bullet / numbered lists, blockquotes, fenced code, horizontal
-rules). `doc set` (alias `doc replace`) overwrites the whole doc in place
-(preserving its id / object_id / URL) by writing the new content first, then
-deleting the prior blocks. `doc create --folder <id>` places the new doc
-directly inside a folder.
+rules), looping per block; `add-markdown` instead uses monday's server-side
+parser, reports `blocks_added`, rejects empty input, and auto-chunks large
+markdown on block boundaries so big docs no longer 500. Both append. `doc set`
+(alias `doc replace`) overwrites the whole doc in place (preserving its id /
+object_id / URL) by writing the new content first (also chunked; a failed
+multi-chunk write rolls back its partial blocks), then deleting the prior
+blocks. `doc clear` empties the body while keeping the doc itself (vs `doc
+delete`, which removes it). `doc create --folder <id>` places the new doc
+directly inside a folder; if creation is blocked by workspace policy it fails
+with `USER_UNAUTHORIZED` and an actionable license `suggestion`. `--out` needs
+a render format — `--format json` with `--out` exits 2.
 
 ### Updates (item comments)
 

--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -470,10 +470,25 @@
   },
   {
     "command": "doc add-markdown",
-    "output_type": "manual-review",
-    "fields": [],
-    "notes": "Could not auto-infer. Final emit expression: result",
-    "source": "doc.py"
+    "output_type": "object",
+    "fields": [
+      "success",
+      "block_ids",
+      "error",
+      "blocks_added"
+    ],
+    "notes": "Server-side markdown-parser append. blocks_added = len(block_ids). Large input is auto-chunked on top-level block boundaries; empty/whitespace input is refused before any API call.",
+    "source": "ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + blocks_added"
+  },
+  {
+    "command": "doc clear",
+    "output_type": "object",
+    "fields": [
+      "id",
+      "cleared_blocks"
+    ],
+    "notes": "Empties a doc body but keeps the doc (id/object_id/URL preserved). cleared_blocks counts deleted top-level blocks; 0 when already empty.",
+    "source": "DELETE_DOC_BLOCK (per top-level block) → {id, cleared_blocks}"
   },
   {
     "command": "doc create",
@@ -484,8 +499,8 @@
       "name",
       "url"
     ],
-    "notes": "",
-    "source": "CREATE_DOC_IN_WORKSPACE.create_doc"
+    "notes": "Slim header for the new (empty) doc; url always present (--with-url is a no-op). On USER_UNAUTHORIZED the error envelope (not this success row) carries a license/policy suggestion.",
+    "source": "CREATE_DOC_IN_WORKSPACE.create_doc → normalize_doc_entry{id,object_id,name,url}"
   },
   {
     "command": "doc delete",
@@ -605,7 +620,7 @@
       "error",
       "replaced_blocks"
     ],
-    "notes": "In-place full content replace. Adds the new markdown first, then deletes the prior blocks; replaced_blocks counts the deleted originals. Alias: `doc replace`.",
+    "notes": "In-place full content replace. Adds the new markdown first (auto-chunked for large input; a failed multi-chunk write rolls back its partial blocks), then deletes the prior blocks; replaced_blocks counts the deleted originals. Alias: `doc replace`.",
     "source": "ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + replaced_blocks"
   },
   {

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -208,14 +208,20 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   source: `CREATE_DOC_BLOCK.create_doc_block[]`
   notes: One emitted row per created block.
 - `doc add-markdown`
-  type: `manual-review`
-  fields: none
-  source: `doc.py`
-  notes: Could not auto-infer. Final emit expression: result
+  type: `object`
+  fields: `success`, `block_ids`, `error`, `blocks_added`
+  source: `ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + blocks_added`
+  notes: Server-side markdown-parser append. blocks_added = len(block_ids). Large input is auto-chunked on top-level block boundaries; empty/whitespace input is refused before any API call.
+- `doc clear`
+  type: `object`
+  fields: `id`, `cleared_blocks`
+  source: `DELETE_DOC_BLOCK (per top-level block) → {id, cleared_blocks}`
+  notes: Empties a doc body but keeps the doc (id/object_id/URL preserved). cleared_blocks counts deleted top-level blocks; 0 when already empty.
 - `doc create`
   type: `object`
   fields: `id`, `object_id`, `name`, `url`
-  source: `CREATE_DOC_IN_WORKSPACE.create_doc`
+  source: `CREATE_DOC_IN_WORKSPACE.create_doc → normalize_doc_entry{id,object_id,name,url}`
+  notes: Slim header for the new (empty) doc; url always present (--with-url is a no-op). On USER_UNAUTHORIZED the error envelope (not this success row) carries a license/policy suggestion.
 - `doc delete`
   type: `manual-review`
   fields: none
@@ -263,7 +269,7 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   type: `object`
   fields: `success`, `block_ids`, `error`, `replaced_blocks`
   source: `ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + replaced_blocks`
-  notes: In-place full content replace. Adds the new markdown first, then deletes the prior blocks; replaced_blocks counts the deleted originals. Alias: `doc replace`.
+  notes: In-place full content replace. Adds the new markdown first (auto-chunked for large input; a failed multi-chunk write rolls back its partial blocks), then deletes the prior blocks; replaced_blocks counts the deleted originals. Alias: `doc replace`.
 - `doc update-block`
   type: `object`
   fields: `id`, `type`

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -342,6 +342,43 @@ MANUAL_ROWS: dict[str, Row] = {
         notes="Single created block payload.",
         source="CREATE_DOC_BLOCK.create_doc_block",
     ),
+    # `add-markdown` emit is `{**result, "blocks_added": ...}` where result is
+    # the chunked add envelope — AST can't infer the spread, so it's manual.
+    "doc add-markdown": Row(
+        command="doc add-markdown",
+        output_type="object",
+        fields=["success", "block_ids", "error", "blocks_added"],
+        notes=(
+            "Server-side markdown-parser append. blocks_added = len(block_ids). Large input is "
+            "auto-chunked on top-level block boundaries; empty/whitespace input is refused before "
+            "any API call."
+        ),
+        source="ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + blocks_added",
+    ),
+    # `create` emit is `normalize_doc_entry(create_doc)` — AST can't infer it, so
+    # the slim doc header is pinned here.
+    "doc create": Row(
+        command="doc create",
+        output_type="object",
+        fields=["id", "object_id", "name", "url"],
+        notes=(
+            "Slim header for the new (empty) doc; url always present (--with-url is a no-op). On "
+            "USER_UNAUTHORIZED the error envelope (not this success row) carries a license/policy "
+            "suggestion."
+        ),
+        source="CREATE_DOC_IN_WORKSPACE.create_doc → normalize_doc_entry{id,object_id,name,url}",
+    ),
+    # `clear` deletes every top-level block then emits a count — manual.
+    "doc clear": Row(
+        command="doc clear",
+        output_type="object",
+        fields=["id", "cleared_blocks"],
+        notes=(
+            "Empties a doc body but keeps the doc (id/object_id/URL preserved). cleared_blocks "
+            "counts deleted top-level blocks; 0 when already empty."
+        ),
+        source="DELETE_DOC_BLOCK (per top-level block) → {id, cleared_blocks}",
+    ),
     # `doc set` / `doc replace` share one handler (set_cmd), registered via
     # `app.command(...)(set_cmd)` rather than a decorator, so the AST walk
     # below cannot discover them — they live here as manual rows. The emit is
@@ -352,8 +389,9 @@ MANUAL_ROWS: dict[str, Row] = {
         output_type="object",
         fields=["success", "block_ids", "error", "replaced_blocks"],
         notes=(
-            "In-place full content replace. Adds the new markdown first, then deletes the prior "
-            "blocks; replaced_blocks counts the deleted originals. Alias: `doc replace`."
+            "In-place full content replace. Adds the new markdown first (auto-chunked for large "
+            "input; a failed multi-chunk write rolls back its partial blocks), then deletes the "
+            "prior blocks; replaced_blocks counts the deleted originals. Alias: `doc replace`."
         ),
         source="ADD_CONTENT_TO_DOC_FROM_MARKDOWN.add_content_to_doc_from_markdown + replaced_blocks",
     ),

--- a/src/mondo/help/boards-vs-docs.md
+++ b/src/mondo/help/boards-vs-docs.md
@@ -57,17 +57,22 @@ Pass `--with-url` on either to get URLs back.
 
 ## Once you've found a workdoc
 
-Render it to a markdown file (embedded images are downloaded alongside it,
-referenced by local filename — the raw monday image URLs only resolve in a
-logged-in browser):
+Render it to a file. `--format` takes `markdown`, `mdx` (JSX-safe markdown),
+or `html` (a single self-contained document). For markdown/mdx the embedded
+images are downloaded alongside the file and referenced by local filename;
+html base64-embeds them so the file is portable on its own (the raw monday
+image URLs only resolve in a logged-in browser):
 
     mondo doc get --object-id <id> --format markdown --out ./doc.md
+    mondo doc get --object-id <id> --format mdx --out ./doc.mdx
+    mondo doc get --object-id <id> --format html --out ./doc.html
     mondo doc export-markdown --object-id <id> --out ./doc.md   # server-side render
 
-Pass `--no-images` to skip the download and keep the original URLs. To write
-content back — replace a doc in place, or create one inside a folder — see
-`mondo help` and the bundled `references/docs.md` (`doc set` / `doc replace`,
-`doc create --folder`).
+Pass `--no-images` to skip the download/embed and keep the original URLs.
+`--out` needs a render format — pairing it with `--format json` exits 2. To
+write content back — replace a doc in place, empty it, or create one inside a
+folder — see `mondo help` and the bundled `references/docs.md` (`doc set` /
+`doc replace`, `doc clear`, `doc create --folder`).
 
 ## Agent workflow
 

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mondo
 description: Use when the user wants to do anything against monday.com via the `mondo` CLI — reading or writing workspaces, folders, boards, groups, items, subitems, columns, updates, docs, files, users, teams, webhooks, or when they paste a monday.com URL.
-version: "1.6.0"
+version: "1.7.0"
 ---
 
 # mondo
@@ -79,7 +79,7 @@ Consult these *before* improvising. Each is a Goal / Command / Output / Gotcha s
 - **Never `2>/dev/null` a mondo call.** Errors, recovery hints, and the JSON error envelope live on stderr; suppressed, a failure is just empty stdout + a nonzero exit. Benign notices (cache hits, skill-freshness) are withheld in non-TTY runs, so stderr is errors-only in pipelines — use `2>&1` or leave it attached and branch on the exit code.
 - **Name search over directories is cached.** `board / doc list --name-contains` serves from an 8h directory cache (folders have no name filter — use `folder tree` or plain `folder list`); the first cold search of the day pays the full directory fetch (parallelized, but still the expensive step). Don't add `--no-cache` to name searches out of caution — the cache IS the fast path; use `--refresh-cache` only when you have a concrete staleness reason.
 - **Cleanup:** delete commands soft-archive by default; pass `--hard` for true delete.
-- **Escape hatch:** `mondo graphql '<query>'` for anything no subcommand wraps. **Pass the query as a positional** — `-q/--query` is the global JMESPath projection, not the GraphQL query. If a GraphQL document lands in `--query` anyway, mondo runs it as the query (stderr note) but disables the projection for that call; pass it positionally to combine with `-q`. Before reaching for `graphql`, check there isn't already a subcommand: a file/asset download link is `mondo file url --asset <id> -q '[0].public_url'`, **not** a hand-written `graphql 'query { assets(ids:[…]) { public_url } }'`.
+- **Escape hatch:** `mondo graphql '<query>'` for anything no subcommand wraps. It emits the **unwrapped `data` object** by default (so `-q`/jq address the payload directly — no `.data` prefix); pass `--raw` for the full `{data, errors, extensions}` envelope. **Pass the query as a positional** — `-q/--query` is the global JMESPath projection, not the GraphQL query. If a GraphQL document lands in `--query` anyway, mondo runs it as the query (stderr note) but disables the projection for that call; pass it positionally to combine with `-q`. Before reaching for `graphql`, check there isn't already a subcommand: a file/asset download link is `mondo file url --asset <id> -q '[0].public_url'`, **not** a hand-written `graphql 'query { assets(ids:[…]) { public_url } }'`.
 - **Cache notice:** read commands may emit `cache: hit (entity=…, age=…)` to stderr. Suppress with `MONDO_NO_CACHE_NOTICE=1`. Force refresh with `--no-cache` or `--refresh-cache` on any cached read (`<entity> list/get` directories plus per-board / per-item / per-doc caches — `item get`, `item list` bare board scope (60s TTL), `subitem list/get`, `update list --item`, `doc get`, `board get`, `webhook list`, `tag list/get`). Filtered `item list` variants, account-wide `update list`, and `mondo graphql` stay live. See `docs/caching.md` for the per-entity TTL table.
 
 ## When references aren't enough

--- a/src/mondo/skill/references/docs.md
+++ b/src/mondo/skill/references/docs.md
@@ -27,7 +27,7 @@ mondo doc list --workspace 592446 --workspace 699169 -o json   # multiple worksp
 ]
 ```
 
-*Gotcha:* `id` is monday's internal numeric doc id; `object_id` is the (also numeric) URL-visible doc id (`/docs/<object_id>`). `--no-cache` is a good idea immediately after a write — the docs directory cache TTL is 8h, and `doc get` has its own short-TTL per-doc cache (`docs_blocks/<id>.json`, 5m) which is invalidated by every doc-write path (`add-block`, `add-content`, `add-markdown`, `import-html`, `rename`, `delete`, `update-block`, `delete-block`, plus `column doc set/append/clear`). Name filters (`--name-contains`, `--name-matches`, `--name-fuzzy`) are client-side and work with or without `--workspace`.
+*Gotcha:* `id` is monday's internal numeric doc id; `object_id` is the (also numeric) URL-visible doc id (`/docs/<object_id>`). `--no-cache` is a good idea immediately after a write — the docs directory cache TTL is 8h, and `doc get` has its own short-TTL per-doc cache (`docs_blocks/<id>.json`, 5m) which is invalidated by every doc-write path (`add-block`, `add-content`, `add-markdown`, `set`/`replace`, `clear`, `import-html`, `rename`, `delete`, `update-block`, `delete-block`, plus `column doc set/append/clear`). Name filters (`--name-contains`, `--name-matches`, `--name-fuzzy`) are client-side and work with or without `--workspace`.
 
 ## Get a doc — JSON, Markdown, MDX, or HTML
 
@@ -95,7 +95,7 @@ mondo doc get --object-id 5098297247 --format html --out ./spec.html
 }
 ```
 
-*Gotcha:* `--id`/`--doc` is monday's internal id; `--object-id` is the id you see in `/docs/<id>` URLs. The doc-*targeting* subcommands (`get`, `export-markdown`, `add-block`, `add-content`, `add-markdown`, `set`/`replace`, `rename`, `duplicate`, `delete`, `version-history`, `version-diff`) accept `--object-id` — when a URL or a human gave you the id, that's the flag to use. Sending an object id through `--doc` fails (historically as an opaque 500); mondo now detects it and tells you to retry with `--object-id`. The two *block*-scoped commands are the exception: `update-block` and `delete-block` operate on a globally-unique block id, so they take `--id`/`--block` (or the positional `BLOCK_ID`) and do **not** accept `--object-id`. Block types use `snake_case` on input (`normal_text`, `medium_title`, `bulleted_list`); read paths sometimes return them with spaces — match either form.
+*Gotcha:* `--id`/`--doc` is monday's internal id; `--object-id` is the id you see in `/docs/<id>` URLs. The doc-*targeting* subcommands (`get`, `export-markdown`, `add-block`, `add-content`, `add-markdown`, `set`/`replace`, `clear`, `rename`, `duplicate`, `delete`, `version-history`, `version-diff`) accept `--object-id` — when a URL or a human gave you the id, that's the flag to use. Sending an object id through `--doc` fails (historically as an opaque 500); mondo now detects it and tells you to retry with `--object-id`. The two *block*-scoped commands are the exception: `update-block` and `delete-block` operate on a globally-unique block id, so they take `--id`/`--block` (or the positional `BLOCK_ID`) and do **not** accept `--object-id`. Block types use `snake_case` on input (`normal_text`, `medium_title`, `bulleted_list`); read paths sometimes return them with spaces — match either form.
 
 ## Create a doc
 
@@ -108,7 +108,7 @@ mondo doc create --workspace 592446 --name "Spec — Q3 launch" --folder 123456 
 {"id": 5095668850, "object_id": "5098297249", "name": "Spec — Q3 launch", "url": "https://acct.monday.com/docs/5098297249"}
 ```
 
-*Gotcha:* the new doc starts empty. Add content with `add-markdown`, `add-content`, or per-block `add-block`. The create payload always carries `url` (`--with-url` is accepted for symmetry with `board create` / `item create` but is a no-op).
+*Gotcha:* the new doc starts empty. Add content with `add-markdown`, `add-content`, or per-block `add-block`. The create payload always carries `url` (`--with-url` is accepted for symmetry with `board create` / `item create` but is a no-op). If create fails with `USER_UNAUTHORIZED` / "not permitted to create", that's a workspace doc-creation license/policy limit, not a bad token — the error envelope carries a `suggestion` saying so, so don't waste a turn re-checking auth.
 
 ## Add markdown to a doc
 
@@ -123,10 +123,12 @@ cat spec.md | mondo doc add-markdown --doc 5095668850 --from-stdin
 ```
 
 ```json
-{"id": 5095668850, "blocks_added": 4}
+{"success": true, "block_ids": ["abc123", "def456", "ghi789"], "error": null, "blocks_added": 3}
 ```
 
-*Gotcha:* `add-markdown` (and the alias `add-content`) appends to the end. To overwrite the whole doc **in place** (preserving its id / object_id / URL), use `doc set` (alias `doc replace`) — it writes the new markdown first, then deletes the prior blocks, so a failed write leaves the original content intact (no half-blanked doc). Empty markdown is refused (use `doc delete` to remove the doc itself):
+`blocks_added` is the reliable count (length of `block_ids`); the rest is monday's raw `{success, block_ids, error}` envelope.
+
+*Gotcha:* `add-markdown` (monday's server-side parser) and `add-content` (which loops `create_doc_block` per block) are **separate commands, not aliases** — both append to the end. `add-markdown` auto-chunks large markdown on top-level block boundaries, so big docs no longer fail with a 500; empty/whitespace-only input is refused before any API call. To overwrite the whole doc **in place** (preserving its id / object_id / URL), use `doc set` (alias `doc replace`) — it writes the new markdown first (also auto-chunked), then deletes the prior blocks, so a failed write leaves the original content intact (no half-blanked doc); if a multi-chunk write fails partway, the blocks it already added are rolled back. Empty markdown is refused (use `doc delete` to remove the doc itself):
 
 ```bash
 mondo doc set --doc 5095668850 --from-file spec.md
@@ -169,6 +171,18 @@ mondo doc delete --doc 5095668850
 ```
 
 *Gotcha:* deleting a doc that's **referenced by a doc-column** breaks that column's pointer — the column will appear empty in the UI. Either clear the doc-column first (`column doc clear`) or accept the break.
+
+## Clear a doc — empty the body, keep the doc
+
+```bash
+mondo doc clear --doc 5095668850
+```
+
+```json
+{"id": 5095668850, "cleared_blocks": 7}
+```
+
+*Gotcha:* `doc clear` removes every block but **keeps the document** — its id / object_id / URL are preserved (unlike `doc delete`, which removes the doc). An already-empty doc is a no-op (`cleared_blocks: 0`). Supports `--dry-run`. This is the standalone-doc analogue of `column doc clear` (which instead unlinks a doc from a *column*).
 
 ---
 


### PR DESCRIPTION
## What

Documentation-sync audit of every doc surface against the CLI after the three PRs merged since v0.10.1 (#67 graphql unwrap, #69 HTML/MDX export, #66 doc fixes). Audited with parallel per-surface review agents **and** `/codex` (gpt-5.5, high), ground-truthed against `--help` and the CLI source.

**Finding:** the high-risk item — graphql `--raw`/default-unwrap — was already documented correctly everywhere (no stale `.data` paths). The real debt was the #66/#69 doc features being silent or mis-stated, plus a stale generated matrix. Codex additionally caught two **actively wrong** lines the first-pass review missed.

## Fixes by surface

**Skill** (`src/mondo/skill`, version `1.6.0` → `1.7.0`):
- `references/docs.md`: corrected the `add-markdown` output example (it showed a fabricated `{id, blocks_added}`; real shape is `{success, block_ids, error, blocks_added}`); stopped calling `add-content` an **alias** of `add-markdown` (separate commands); added a **Clear a doc** section; documented `set`/`replace` + `add-markdown` auto-chunking and empty-input refusal; added the `doc create` `USER_UNAUTHORIZED` license-`suggestion` gotcha; added `clear` to the object-id + cache-invalidation lists.
- `SKILL.md`: documented graphql default-unwrap + `--raw` on the escape-hatch line.

**Contract matrix** (generator + regenerated `.md`/`.json`): added `MANUAL_ROWS` for `doc add-markdown`, `doc create` (had regressed to `manual-review` after #66), and `doc clear` (was missing); noted `set`/`replace` auto-chunk + rollback. The committed matrix was also stale vs the generator — regenerated.

**Help** (`src/mondo/help/boards-vs-docs.md`): documented `--format mdx/html` + html base64-embedding; `--out` needs a render format (`json` exits 2); mentioned `doc clear`.

**README**: added `doc add-markdown` + `doc clear` to the command block; noted auto-chunk, the create license suggestion, and `--out`/`json` exit 2.

## Verification
- Matrix regenerated (in sync with the generator); ruff + mypy clean.
- `matrix or help or skill or contract` tests pass; full non-integration suite green (1760).
- Final `/codex` pass confirmed the surfaces are accurate (after fixing two inaccuracies it caught in the first draft).

## Out of scope
`CLAUDE.md` left unchanged (maintainer notes, no CLI-behaviour staleness). Codex flagged pre-existing `--with-url` wording in `SKILL.md:74` / `boards-vs-docs.md` that lists `doc get`/`doc create` (where the flag is a harmless no-op) — unrelated to this feature window; worth a separate tiny cleanup if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)