### PR TITLE
feat(doc): unify markdown export into `doc get --engine server`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,9 +158,10 @@ Live integration tests live under `tests/integration/`, split by feature:
 - `test_live_folders.py` — folder tree, parent linking, rename, delete
   archives contained boards.
 - `test_live_doc_column.py` — `column doc set/get/append/clear`.
-- `test_live_doc_images.py` — `doc get --format markdown --out` and
-  `doc export-markdown --out` download embedded images into the markdown's
-  folder and reference them by `<assetId>-<name>` local filename.
+- `test_live_doc_images.py` — `doc get --format markdown --out` (client
+  renderer) and `doc get --format markdown --engine server --out`
+  download embedded images into the markdown's folder and reference them
+  by `<assetId>-<name>` local filename.
 - `test_live_doc_md_roundtrip.py` — standalone-doc markdown round-trip
   (strict subset + rich golden) plus `doc duplicate`/`doc rename`
   (currently `xfail`-pinned for the `Int!` vs `ID!` schema mismatch).

--- a/README.md
+++ b/README.md
@@ -581,9 +581,8 @@ mondo doc get            --id 7 --format markdown --out ./doc.md  # +download im
 mondo doc get            --id 7 --format markdown --out ./doc.md --no-images  # skip download, keep URLs
 mondo doc get            --id 7 --format mdx --out ./doc.mdx      # MDX (JSX-safe markdown)
 mondo doc get            --id 7 --format html --out ./doc.html    # single self-contained HTML, images base64-embedded
-mondo doc export-markdown --doc 7                    # always-live markdown export (--no-cache/--refresh-cache accepted as no-ops)
-mondo doc export-markdown --doc 7 --out ./doc.md     # +download images, rewrite URLs to local files
-mondo doc export-markdown --doc 7 --out ./doc.md --no-images  # skip download, keep URLs
+mondo doc get            --id 7 --format markdown --engine server # monday's server-side exporter (always live)
+mondo doc get            --id 7 --format markdown --engine server --block <b1> --block <b2> --raw  # subset + raw envelope
 mondo doc create         --workspace 42 --name "Spec" --kind public [--folder 3042556]
 
 mondo doc add-content    --doc 7 --from-file spec.md         # bulk markdown → blocks (append, per-block)

--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -531,16 +531,6 @@
     "source": "DOC_HEAD_BY_OBJECT_ID.docs[0]{id,object_id,name,url}"
   },
   {
-    "command": "doc export-markdown",
-    "output_type": "string | object",
-    "fields": [
-      "out?",
-      "images?"
-    ],
-    "notes": "Prints monday's server-rendered markdown to stdout by default. With --out FILE, writes the markdown to FILE and emits {out, images} where images is the list of localized image filenames downloaded beside it (empty with --no-images). Always live (no per-doc cache): --no-cache / --refresh-cache are accepted as no-ops.",
-    "source": "EXPORT_MARKDOWN_FROM_DOC + localize_markdown_images"
-  },
-  {
     "command": "doc get",
     "output_type": "object | string",
     "fields": [
@@ -557,8 +547,8 @@
       "created_by{id,name}",
       "blocks{id,type,content,parent_block_id}"
     ],
-    "notes": "Default format is JSON object above. --format markdown/mdx/html render to stdout instead (mdx is JSX-safe markdown; html is a single self-contained document). With --out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is the list of localized image filenames downloaded beside it; html embeds images as base64 and emits {out, images} where images is the embedded count. --no-images keeps the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise).",
-    "source": "DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]"
+    "notes": "Default format is JSON object above. --format markdown/mdx/html render to stdout instead (mdx is JSX-safe markdown; html is a single self-contained document). With --out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is the list of localized image filenames downloaded beside it; html embeds images as base64 and emits {out, images} where images is the embedded count. --no-images keeps the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise). --format markdown --engine server renders via monday's server-side exporter instead of the local block renderer (markdown only, always live); it adds --block (repeatable subset export) and --raw (emit monday's {success, markdown, error} envelope; mutually exclusive with --out).",
+    "source": "DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0] | EXPORT_MARKDOWN_FROM_DOC (--engine server)"
   },
   {
     "command": "doc import-html",

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -236,16 +236,11 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   fields: `id`, `object_id`, `name`, `url`
   source: `DOC_HEAD_BY_OBJECT_ID.docs[0]{id,object_id,name,url}`
   notes: Emits a slim doc header for the newly created duplicate; fetched via DOC_HEAD_BY_OBJECT_ID.
-- `doc export-markdown`
-  type: `string | object`
-  fields: `out?`, `images?`
-  source: `EXPORT_MARKDOWN_FROM_DOC + localize_markdown_images`
-  notes: Prints monday's server-rendered markdown to stdout by default. With --out FILE, writes the markdown to FILE and emits {out, images} where images is the list of localized image filenames downloaded beside it (empty with --no-images). Always live (no per-doc cache): --no-cache / --refresh-cache are accepted as no-ops.
 - `doc get`
   type: `object | string`
   fields: `id`, `object_id`, `name`, `doc_kind`, `doc_folder_id`, `created_at`, `updated_at`, `url`, `relative_url`, `workspace_id`, `created_by{id,name}`, `blocks{id,type,content,parent_block_id}`
-  source: `DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]`
-  notes: Default format is JSON object above. --format markdown/mdx/html render to stdout instead (mdx is JSX-safe markdown; html is a single self-contained document). With --out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is the list of localized image filenames downloaded beside it; html embeds images as base64 and emits {out, images} where images is the embedded count. --no-images keeps the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise).
+  source: `DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0] | EXPORT_MARKDOWN_FROM_DOC (--engine server)`
+  notes: Default format is JSON object above. --format markdown/mdx/html render to stdout instead (mdx is JSX-safe markdown; html is a single self-contained document). With --out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is the list of localized image filenames downloaded beside it; html embeds images as base64 and emits {out, images} where images is the embedded count. --no-images keeps the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise). --format markdown --engine server renders via monday's server-side exporter instead of the local block renderer (markdown only, always live); it adds --block (repeatable subset export) and --raw (emit monday's {success, markdown, error} envelope; mutually exclusive with --out).
 - `doc import-html`
   type: `object`
   fields: `error`, `success`, `doc_id`

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -432,21 +432,16 @@ MANUAL_ROWS: dict[str, Row] = {
             "--out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is "
             "the list of localized image filenames downloaded beside it; html embeds images as "
             "base64 and emits {out, images} where images is the embedded count. --no-images keeps "
-            "the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise)."
+            "the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise). "
+            "--format markdown --engine server renders via monday's server-side exporter instead "
+            "of the local block renderer (markdown only, always live); it adds --block (repeatable "
+            "subset export) and --raw (emit monday's {success, markdown, error} envelope; mutually "
+            "exclusive with --out)."
         ),
-        source="DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]",
-    ),
-    "doc export-markdown": Row(
-        command="doc export-markdown",
-        output_type="string | object",
-        fields=["out?", "images?"],
-        notes=(
-            "Prints monday's server-rendered markdown to stdout by default. With --out FILE, "
-            "writes the markdown to FILE and emits {out, images} where images is the list of "
-            "localized image filenames downloaded beside it (empty with --no-images). Always "
-            "live (no per-doc cache): --no-cache / --refresh-cache are accepted as no-ops."
+        source=(
+            "DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0] "
+            "| EXPORT_MARKDOWN_FROM_DOC (--engine server)"
         ),
-        source="EXPORT_MARKDOWN_FROM_DOC + localize_markdown_images",
     ),
     "doc list": Row(
         command="doc list",

--- a/src/mondo/cli/_doc_images.py
+++ b/src/mondo/cli/_doc_images.py
@@ -1,7 +1,7 @@
 """Download monday doc images into a local folder for markdown export.
 
 Shared by `doc get --format markdown --out` (block-tree path) and
-`doc export-markdown --out` (server-rendered-string path).
+`doc get --format markdown --engine server --out` (server-rendered-string path).
 
 monday image blocks carry a numeric `assetId` plus a protected_static `url`
 that only resolves in a logged-in browser. We resolve each asset to its

--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -626,6 +626,15 @@ EXAMPLES: dict[str, list[Example]] = {
             "Render as a single self-contained HTML file (images base64-embedded)",
             "mondo doc get --id 7 --format html --out ./doc.html",
         ),
+        Example(
+            "Render markdown via monday's server-side exporter (always live)",
+            "mondo doc get --id 7 --format markdown --engine server",
+        ),
+        Example(
+            "Server-render specific blocks only, as the raw API envelope",
+            "mondo doc get --id 7 --format markdown --engine server "
+            "--block <block-1> --block <block-2> --raw",
+        ),
         Example("Just the doc name", "mondo doc get --id 7 -q name -o none"),
     ],
     "doc create": [
@@ -709,21 +718,6 @@ EXAMPLES: dict[str, list[Example]] = {
     ],
     "doc clear": [
         Example("Remove all blocks but keep the doc", "mondo doc clear --doc 7"),
-    ],
-    "doc export-markdown": [
-        Example("Export the whole doc as markdown", "mondo doc export-markdown --doc 7"),
-        Example(
-            "Export specific blocks only",
-            "mondo doc export-markdown --doc 7 --block <block-1> --block <block-2> --raw",
-        ),
-        Example(
-            "Save to a file + download images beside it (rewrites URLs to local files)",
-            "mondo doc export-markdown --doc 7 --out ./doc.md",
-        ),
-        Example(
-            "Save to a file but keep image URLs (skip download)",
-            "mondo doc export-markdown --doc 7 --out ./doc.md --no-images",
-        ),
     ],
     "doc version-history": [
         Example(

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -587,19 +587,21 @@ def get_cmd(
     no_cache: bool = typer.Option(
         False,
         "--no-cache",
-        help="Bypass the per-doc blocks cache; fetch live.",
+        help="Bypass the per-doc blocks cache; fetch live. (No effect with --engine server.)",
         rich_help_panel="Cache",
     ),
     refresh_cache: bool = typer.Option(
         False,
         "--refresh-cache",
-        help="Force-refresh the per-doc blocks cache before serving.",
+        help="Force-refresh the per-doc blocks cache before serving. "
+        "(No effect with --engine server.)",
         rich_help_panel="Cache",
     ),
     explain_cache: bool = typer.Option(
         False,
         "--explain-cache",
-        help="Emit a verbose cache-hit line (path/ttl/fetched_at) on stderr.",
+        help="Emit a verbose cache-hit line (path/ttl/fetched_at) on stderr. "
+        "(No effect with --engine server.)",
         rich_help_panel="Cache",
     ),
 ) -> None:

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -620,9 +620,6 @@ def get_cmd(
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     reject_mutually_exclusive(no_cache, refresh_cache)
     del with_url  # docs always carry `url` from monday; flag kept for symmetry
-    _RENDER_FORMATS = {DocFormat.markdown, DocFormat.mdx, DocFormat.html}
-    if out is not None and fmt not in _RENDER_FORMATS:
-        usage_error_or_exit("--out is only valid with --format markdown, mdx, or html.")
     sources = sum(x is not None for x in (doc_id, object_id))
     if sources != 1:
         usage_error_or_exit("pass exactly one of --id or --object-id.")
@@ -642,10 +639,14 @@ def get_cmd(
             no_images=no_images,
         )
         return
+    # Client engine from here on: --block/--raw are server-only.
     if block_id:
         usage_error_or_exit("--block requires --engine server.")
     if raw:
         usage_error_or_exit("--raw requires --engine server.")
+    _RENDER_FORMATS = {DocFormat.markdown, DocFormat.mdx, DocFormat.html}
+    if out is not None and fmt not in _RENDER_FORMATS:
+        usage_error_or_exit("--out is only valid with --format markdown, mdx, or html.")
 
     if doc_id is not None:
         query = DOC_GET_BY_ID_BLOCKS_PAGE

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -5,13 +5,14 @@ Distinct from the `doc` **column** type (which is handled by
 workspace with a block-structured body. The CLI covers:
 
 - `list` / `get` — page-based listing with optional workspace / object-id
-  filters; get emits the full block tree (or a markdown rendering).
+  filters; get emits the full block tree, or renders to markdown/mdx/html
+  (markdown also via monday's server exporter with `--engine server`).
 - `create` — bootstrap a doc inside a workspace (`CreateDocInput.workspace`).
 - `add-block` / `add-content` — single / bulk block inserts.
 - `add-markdown` / `import-html` — server-side markdown/html conversion flows.
 - `update-block` / `delete-block` — edit individual blocks.
 - `rename` / `duplicate` / `delete` — document-level mutations.
-- `export-markdown` / `version-history` / `version-diff` — read-side extras.
+- `version-history` / `version-diff` — read-side extras.
 """
 
 from __future__ import annotations
@@ -91,6 +92,11 @@ class DocFormat(StrEnum):
     markdown = "markdown"
     mdx = "mdx"
     html = "html"
+
+
+class DocEngine(StrEnum):
+    client = "client"
+    server = "server"
 
 
 class DuplicateDocType(StrEnum):
@@ -536,6 +542,26 @@ def get_cmd(
         help="Emit raw JSON (blocks as-is) or render blocks to markdown, mdx, or html.",
         case_sensitive=False,
     ),
+    engine: DocEngine = typer.Option(
+        DocEngine.client,
+        "--engine",
+        help=(
+            "Markdown renderer: `client` (local block renderer, default — and the "
+            "only engine for json/mdx/html) or `server` (monday's exporter, markdown "
+            "only; enables --block/--raw and is always live, ignoring the cache flags)."
+        ),
+        case_sensitive=False,
+    ),
+    block_id: list[str] | None = typer.Option(
+        None,
+        "--block",
+        help="With --engine server: block ID to export (repeatable). Default: whole doc.",
+    ),
+    raw: bool = typer.Option(
+        False,
+        "--raw",
+        help="With --engine server: emit monday's API JSON envelope instead of plain markdown.",
+    ),
     out: Path | None = typer.Option(
         None,
         "--out",
@@ -579,10 +605,12 @@ def get_cmd(
 ) -> None:
     """Fetch a single doc by id or object_id, with its full block tree.
 
-    Served from `docs_blocks/<doc_id>.json` (default TTL 5m — set via
-    `MONDO_CACHE_TTL_DOCS_BLOCKS`). `--object-id` callers resolve to
-    `doc_id` via the existing docs directory cache so both paths share
-    one on-disk cache key.
+    Default (`--engine client`) is served from `docs_blocks/<doc_id>.json`
+    (default TTL 5m — set via `MONDO_CACHE_TTL_DOCS_BLOCKS`); `--object-id`
+    callers resolve to `doc_id` via the docs directory cache so both paths
+    share one on-disk cache key. With `--format markdown --engine server`,
+    markdown comes from monday's server-side exporter instead (always live;
+    supports `--block` subset export and `--raw` envelope passthrough).
     """
     from mondo.cli._cache_flags import emit_cache_provenance, reject_mutually_exclusive
     from mondo.cli._normalize import normalize_doc_entry
@@ -596,6 +624,26 @@ def get_cmd(
     sources = sum(x is not None for x in (doc_id, object_id))
     if sources != 1:
         usage_error_or_exit("pass exactly one of --id or --object-id.")
+
+    if engine is DocEngine.server:
+        if fmt is not DocFormat.markdown:
+            usage_error_or_exit("--engine server only supports --format markdown.")
+        if raw and out is not None:
+            usage_error_or_exit("--raw and --out are mutually exclusive.")
+        _emit_server_markdown(
+            opts,
+            doc_id=doc_id,
+            object_id=object_id,
+            block_id=block_id,
+            raw=raw,
+            out=out,
+            no_images=no_images,
+        )
+        return
+    if block_id:
+        usage_error_or_exit("--block requires --engine server.")
+    if raw:
+        usage_error_or_exit("--raw requires --engine server.")
 
     if doc_id is not None:
         query = DOC_GET_BY_ID_BLOCKS_PAGE
@@ -847,6 +895,53 @@ def _execute_doc_command(
             return (result.get("data") or {}), resolved
     except MondoError as e:
         handle_mondo_error_or_exit(e)
+
+
+def _emit_server_markdown(
+    opts: GlobalOpts,
+    *,
+    doc_id: int | None,
+    object_id: int | None,
+    block_id: list[str] | None,
+    raw: bool,
+    out: Path | None,
+    no_images: bool,
+) -> None:
+    """Render a doc to markdown via monday's server-side `export_markdown_from_doc`
+    (`doc get --format markdown --engine server`). Always live; supports `--block`
+    subset export and `--raw` envelope passthrough.
+    """
+    data, _ = _execute_doc_command(
+        opts,
+        EXPORT_MARKDOWN_FROM_DOC,
+        {"blocks": block_id or None},
+        doc_id=doc_id,
+        object_id=object_id,
+    )
+    result = data.get("export_markdown_from_doc") or {}
+    if raw:
+        opts.emit(result)
+        return
+    if not result.get("success"):
+        _fail_with_object_id_hint(
+            opts, result.get("error") or "export_markdown_from_doc failed", doc_id
+        )
+    from mondo.docs import coalesce_markdown_emphasis
+
+    # Monday's exporter fragments contiguous bold runs into adjacent `**…**`
+    # spans; rejoin them so the markdown reads as one span (#62).
+    markdown = coalesce_markdown_emphasis(result.get("markdown") or "")
+    if out is not None:
+        from mondo.cli._doc_images import localize_markdown_images
+
+        images: list[str] = []
+        if not no_images:
+            markdown, images = localize_markdown_images(opts, markdown, out.parent)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(markdown)
+        opts.emit({"out": str(out), "images": images})
+        return
+    typer.echo(markdown)
 
 
 # ----- write commands -----
@@ -1362,93 +1457,6 @@ def clear_cmd(
         handle_mondo_error_or_exit(e)
 
     opts.emit({"id": resolved_doc, "cleared_blocks": len(block_ids)})
-
-
-@app.command("export-markdown", epilog=epilog_for("doc export-markdown"))
-def export_markdown_cmd(
-    ctx: typer.Context,
-    doc_id: DocIdOpt = None,
-    object_id: DocObjectIdOpt = None,
-    block_id: list[str] | None = typer.Option(
-        None,
-        "--block",
-        help="Block ID to export (repeatable). Default: export full doc.",
-    ),
-    raw: bool = typer.Option(
-        False,
-        "--raw",
-        help="Emit API JSON envelope instead of plain markdown text.",
-    ),
-    out: Path | None = typer.Option(
-        None,
-        "--out",
-        help=(
-            "Write the markdown to this file and download embedded images "
-            "into the same folder, rewriting their URLs to local filenames. "
-            "Without it, markdown goes to stdout with monday image URLs."
-        ),
-    ),
-    no_images: bool = typer.Option(
-        False,
-        "--no-images",
-        help="With --out, skip downloading images; keep their monday URLs.",
-    ),
-    no_cache: bool = typer.Option(
-        False,
-        "--no-cache",
-        help="No-op — export is always live (accepted for flag symmetry).",
-        rich_help_panel="Cache",
-    ),
-    refresh_cache: bool = typer.Option(
-        False,
-        "--refresh-cache",
-        help="No-op — export is always live (accepted for flag symmetry).",
-        rich_help_panel="Cache",
-    ),
-) -> None:
-    """Export doc content as markdown.
-
-    Always fetched live (no per-doc cache is involved), so `--no-cache` /
-    `--refresh-cache` are accepted as no-ops purely for symmetry with the
-    other doc commands.
-    """
-    from mondo.cli._cache_flags import reject_mutually_exclusive
-
-    opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
-    reject_mutually_exclusive(no_cache, refresh_cache)
-    if raw and out is not None:
-        usage_error_or_exit("--raw and --out are mutually exclusive.")
-    data, _ = _execute_doc_command(
-        opts,
-        EXPORT_MARKDOWN_FROM_DOC,
-        {"blocks": block_id or None},
-        doc_id=doc_id,
-        object_id=object_id,
-    )
-    result = data.get("export_markdown_from_doc") or {}
-    if raw:
-        opts.emit(result)
-        return
-    if not result.get("success"):
-        _fail_with_object_id_hint(
-            opts, result.get("error") or "export_markdown_from_doc failed", doc_id
-        )
-    from mondo.docs import coalesce_markdown_emphasis
-
-    # Monday's exporter fragments contiguous bold runs into adjacent `**…**`
-    # spans; rejoin them so the markdown reads as one span (#62).
-    markdown = coalesce_markdown_emphasis(result.get("markdown") or "")
-    if out is not None:
-        from mondo.cli._doc_images import localize_markdown_images
-
-        images: list[str] = []
-        if not no_images:
-            markdown, images = localize_markdown_images(opts, markdown, out.parent)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(markdown)
-        opts.emit({"out": str(out), "images": images})
-        return
-    typer.echo(markdown)
 
 
 @app.command("version-history", epilog=epilog_for("doc version-history"))

--- a/src/mondo/help/agent-tips.md
+++ b/src/mondo/help/agent-tips.md
@@ -148,10 +148,9 @@ circuit through the directory cache (`workspace / folder / team get`,
 force a fresh fetch use `--no-cache` or `--refresh-cache` on the same
 command. See `docs/caching.md` for the per-entity TTL table.
 
-`doc export-markdown` has no per-doc cache (it's always live), so it
-accepts `--no-cache` / `--refresh-cache` as no-ops — purely for flag
-symmetry with the other doc commands; they neither error nor change the
-result.
+`doc get --format markdown --engine server` has no per-doc cache (it's
+always live), so `--no-cache` / `--refresh-cache` have no effect there;
+they neither error nor change the result.
 
 ## Structured error envelope (`-o json|jsonc|yaml`)
 

--- a/src/mondo/help/boards-vs-docs.md
+++ b/src/mondo/help/boards-vs-docs.md
@@ -66,7 +66,7 @@ image URLs only resolve in a logged-in browser):
     mondo doc get --object-id <id> --format markdown --out ./doc.md
     mondo doc get --object-id <id> --format mdx --out ./doc.mdx
     mondo doc get --object-id <id> --format html --out ./doc.html
-    mondo doc export-markdown --object-id <id> --out ./doc.md   # server-side render
+    mondo doc get --object-id <id> --format markdown --engine server --out ./doc.md  # server-side render
 
 Pass `--no-images` to skip the download/embed and keep the original URLs.
 `--out` needs a render format — pairing it with `--format json` exits 2. To

--- a/src/mondo/help/output.md
+++ b/src/mondo/help/output.md
@@ -77,8 +77,8 @@ Two behaviors keep failures visible in pipelines:
   instead of empty input. The mirror never corrupts a partial-success
   stream (it only fires when stdout is still empty), `-o none` keeps
   stdout silent, and exit codes are unchanged. Note this applies even to
-  commands whose success output is not JSON (e.g. `doc export-markdown`
-  redirected to a file): if they fail before producing output, the JSON
+  commands whose success output is not JSON (e.g. `doc get --format
+  markdown` redirected to a file): if they fail before producing output, the JSON
   envelope lands on stdout.
 - **Benign notices are suppressed when no human is watching**: the
   `cache: hit (...)` provenance line and the skill-freshness warning only

--- a/src/mondo/skill/references/docs.md
+++ b/src/mondo/skill/references/docs.md
@@ -38,22 +38,27 @@ mondo doc get --id 5095668848 --format json -o json
 # Or address by object_id (the URL form):
 mondo doc get --object-id 5098297247 --format json -o json
 
-# Render to Markdown (--object-id for the URL-visible id, --doc for the internal id):
-mondo doc export-markdown --object-id 5098297247
-mondo doc export-markdown --doc 5095668848
-
-# Client-side render via `doc get` (prints to stdout) — markdown, mdx, or html:
+# Render via `doc get` (prints to stdout) — markdown, mdx, or html:
 mondo doc get --object-id 5098297247 --format markdown
 mondo doc get --object-id 5098297247 --format mdx
 mondo doc get --object-id 5098297247 --format html
+
+# Markdown via monday's server-side exporter instead of the local renderer:
+mondo doc get --object-id 5098297247 --format markdown --engine server
+mondo doc get --doc 5095668848 --format markdown --engine server
 ```
 
-`doc get --format` renders client-side and supports `markdown`, `mdx`, and `html`; `doc export-markdown` is monday's server-side markdown renderer (markdown only — the API offers no server-side HTML/MDX export). All print to stdout by default.
+`doc get --format` renders all four shapes. Markdown has **two engines**, selected with `--engine`:
+
+- `--engine client` (default) — mondo's local block renderer. It also powers `mdx`/`html`, honours the per-doc cache, and downloads images from the block tree.
+- `--engine server` — monday's server-side `export_markdown_from_doc` exporter (markdown only — the API offers no server-side HTML/MDX export). Always live, and it unlocks two extras the client renderer doesn't have: `--block <id>` (repeatable) to export a subset of blocks, and `--raw` to emit monday's `{success, markdown, error}` envelope. `--engine server` is rejected (exit 2) with any `--format` other than `markdown`, and `--block`/`--raw` are rejected with `--engine client`.
+
+All print to stdout by default.
 
 - **mdx** is the markdown rendering with JSX-significant characters (`<`, `{`) escaped in prose (never inside code fences); monday notice/callout boxes stay as GFM `> [!NOTE]` blockquotes.
 - **html** is a single self-contained document (inline `<style>`, base64-embedded images) — see below.
 
-*Note:* `export-markdown` is always live (it has no per-doc cache), so `--no-cache` / `--refresh-cache` are accepted as no-ops purely for symmetry with the other doc commands.
+*Note:* `--engine server` is always live (it never consults the per-doc cache), so `--no-cache` / `--refresh-cache` have no effect there.
 
 ### Write to a file (and handle embedded images)
 
@@ -64,7 +69,7 @@ For **markdown** and **mdx**, embedded monday images are downloaded into the **s
 ```bash
 mondo doc get --object-id 5098297247 --format markdown --out ./spec.md
 mondo doc get --object-id 5098297247 --format mdx --out ./spec.mdx
-mondo doc export-markdown --object-id 5098297247 --out ./spec.md
+mondo doc get --object-id 5098297247 --format markdown --engine server --out ./spec.md
 ```
 
 ```json
@@ -95,7 +100,7 @@ mondo doc get --object-id 5098297247 --format html --out ./spec.html
 }
 ```
 
-*Gotcha:* `--id`/`--doc` is monday's internal id; `--object-id` is the id you see in `/docs/<id>` URLs. The doc-*targeting* subcommands (`get`, `export-markdown`, `add-block`, `add-content`, `add-markdown`, `set`/`replace`, `clear`, `rename`, `duplicate`, `delete`, `version-history`, `version-diff`) accept `--object-id` — when a URL or a human gave you the id, that's the flag to use. Sending an object id through `--doc` fails (historically as an opaque 500); mondo now detects it and tells you to retry with `--object-id`. The two *block*-scoped commands are the exception: `update-block` and `delete-block` operate on a globally-unique block id, so they take `--id`/`--block` (or the positional `BLOCK_ID`) and do **not** accept `--object-id`. Block types use `snake_case` on input (`normal_text`, `medium_title`, `bulleted_list`); read paths sometimes return them with spaces — match either form.
+*Gotcha:* `--id`/`--doc` is monday's internal id; `--object-id` is the id you see in `/docs/<id>` URLs. The doc-*targeting* subcommands (`get`, `add-block`, `add-content`, `add-markdown`, `set`/`replace`, `clear`, `rename`, `duplicate`, `delete`, `version-history`, `version-diff`) accept `--object-id` — when a URL or a human gave you the id, that's the flag to use. Sending an object id through `--doc` fails (historically as an opaque 500); mondo now detects it and tells you to retry with `--object-id`. The two *block*-scoped commands are the exception: `update-block` and `delete-block` operate on a globally-unique block id, so they take `--id`/`--block` (or the positional `BLOCK_ID`) and do **not** accept `--object-id`. Block types use `snake_case` on input (`normal_text`, `medium_title`, `bulleted_list`); read paths sometimes return them with spaces — match either form.
 
 ## Create a doc
 
@@ -146,7 +151,7 @@ The **strict subset** round-trips with content equality after whitespace normali
 ```bash
 # Round-trip pattern:
 mondo doc add-markdown --doc 5095668850 --markdown "$(cat strict_input.md)"
-mondo doc export-markdown --doc 5095668850 > exported.md
+mondo doc get --doc 5095668850 --format markdown --engine server > exported.md
 ```
 
 *Gotcha:* if you need pixel-perfect markdown out, stick to the strict subset on input. For richer formatting, accept that the export will look different and treat monday as the source of truth.
@@ -162,7 +167,7 @@ mondo doc rename --doc 5095668850 --name "Spec — Q3 launch (v2)"
 {"id": 5095668870, "name": "Spec — Q3 launch — Copy"}
 ```
 
-*Gotcha:* `doc duplicate` and `doc rename` may currently `xfail` against monday's API due to an `Int!` vs `ID!` schema mismatch — check the test status if these regress (`tests/integration/test_live_doc_md_roundtrip.py::test_live_doc_duplicate_preserves_content`). If you need a guaranteed copy, export-markdown + create + add-markdown is a safe fallback.
+*Gotcha:* `doc duplicate` and `doc rename` may currently `xfail` against monday's API due to an `Int!` vs `ID!` schema mismatch — check the test status if these regress (`tests/integration/test_live_doc_md_roundtrip.py::test_live_doc_duplicate_preserves_content`). If you need a guaranteed copy, `doc get --format markdown --engine server` + `create` + `add-markdown` is a safe fallback.
 
 ## Delete a doc
 

--- a/tests/integration/test_live_doc_blocks.py
+++ b/tests/integration/test_live_doc_blocks.py
@@ -117,7 +117,12 @@ def test_live_doc_replace(live_workspace_id: int, cleanup_plan: CleanupPlan) -> 
     assert result.get("success") is True, result
 
     def _replaced() -> None:
-        md = invoke(["doc", "export-markdown", "--object-id", str(object_id), "--no-cache"]).stdout
+        md = invoke(
+            [
+                "doc", "get", "--object-id", str(object_id),
+                "--format", "markdown", "--engine", "server", "--no-cache",
+            ]
+        ).stdout
         assert "Replaced" in md and "Original" not in md, md
 
     wait_for("doc replaced", _replaced)

--- a/tests/integration/test_live_doc_blocks.py
+++ b/tests/integration/test_live_doc_blocks.py
@@ -119,8 +119,15 @@ def test_live_doc_replace(live_workspace_id: int, cleanup_plan: CleanupPlan) -> 
     def _replaced() -> None:
         md = invoke(
             [
-                "doc", "get", "--object-id", str(object_id),
-                "--format", "markdown", "--engine", "server", "--no-cache",
+                "doc",
+                "get",
+                "--object-id",
+                str(object_id),
+                "--format",
+                "markdown",
+                "--engine",
+                "server",
+                "--no-cache",
             ]
         ).stdout
         assert "Replaced" in md and "Original" not in md, md

--- a/tests/integration/test_live_doc_images.py
+++ b/tests/integration/test_live_doc_images.py
@@ -5,7 +5,7 @@ folder and reference them by local filename instead of the browser-only
 `protected_static` URL:
 
 - `doc get --format markdown --out` (our client-side block renderer).
-- `doc export-markdown --out` (monday's server-side markdown).
+- `doc get --format markdown --engine server --out` (monday's server-side markdown).
 
 Gated by MONDO_TEST_DOC_ID; the prepared doc carries image blocks (one
 top-level, two inside a table).
@@ -54,14 +54,18 @@ def test_live_doc_get_markdown_downloads_images(live_test_doc_id: int, tmp_path)
 
 
 @pytest.mark.integration
-def test_live_doc_export_markdown_downloads_images(live_test_doc_id: int, tmp_path) -> None:
+def test_live_doc_server_markdown_downloads_images(live_test_doc_id: int, tmp_path) -> None:
     out = tmp_path / "exp.md"
     summary = invoke_json(
         [
             "doc",
-            "export-markdown",
+            "get",
             "--object-id",
             str(live_test_doc_id),
+            "--format",
+            "markdown",
+            "--engine",
+            "server",
             "--out",
             str(out),
         ]
@@ -105,9 +109,13 @@ def test_live_doc_export_no_images_keeps_urls(live_test_doc_id: int, tmp_path) -
     invoke_json(
         [
             "doc",
-            "export-markdown",
+            "get",
             "--object-id",
             str(live_test_doc_id),
+            "--format",
+            "markdown",
+            "--engine",
+            "server",
             "--out",
             str(exp_out),
             "--no-images",

--- a/tests/integration/test_live_doc_md_roundtrip.py
+++ b/tests/integration/test_live_doc_md_roundtrip.py
@@ -109,11 +109,11 @@ def test_live_doc_markdown_strict_roundtrip_equality(
 
     def _exported() -> str:
         result = invoke(
-            ["doc", "export-markdown", "--doc", str(doc_id)],
+            ["doc", "get", "--doc", str(doc_id), "--format", "markdown", "--engine", "server"],
             expect_exit=0,
         )
         text = result.stdout
-        assert text.strip(), "export-markdown empty"
+        assert text.strip(), "server markdown empty"
         return text
 
     exported = wait_for("doc export visible", _exported)
@@ -169,11 +169,11 @@ def test_live_doc_markdown_rich_roundtrip_golden(
 
     def _exported() -> str:
         result = invoke(
-            ["doc", "export-markdown", "--doc", str(doc_id)],
+            ["doc", "get", "--doc", str(doc_id), "--format", "markdown", "--engine", "server"],
             expect_exit=0,
         )
         text = result.stdout
-        assert text.strip(), "export-markdown empty"
+        assert text.strip(), "server markdown empty"
         return text
 
     exported = _normalize_md(wait_for("doc export visible", _exported))

--- a/tests/integration/test_live_writes.py
+++ b/tests/integration/test_live_writes.py
@@ -632,8 +632,8 @@ def test_live_doc_read_with_notice_box(live_test_doc_id: int) -> None:
     """Read-only verification against the user-prepared doc.
 
     Confirms `doc get` returns blocks (one of which is a notice-box-style
-    block), `doc export-markdown` renders to non-empty markdown, and
-    `doc list --no-cache` finds the doc by name.
+    block), `doc get --format markdown --engine server` renders to non-empty
+    markdown, and `doc list --no-cache` finds the doc by name.
     """
     doc = invoke_json(
         [
@@ -662,12 +662,16 @@ def test_live_doc_read_with_notice_box(live_test_doc_id: int) -> None:
     md_result = invoke(
         [
             "doc",
-            "export-markdown",
+            "get",
             "--doc",
             str(int(doc["id"])),
+            "--format",
+            "markdown",
+            "--engine",
+            "server",
         ]
     )
-    assert md_result.stdout.strip(), "export-markdown produced no output"
+    assert md_result.stdout.strip(), "server markdown produced no output"
 
     workspace_id = int(
         os.environ.get(MONDAY_TEST_WORKSPACE_ID_ENV)
@@ -692,28 +696,30 @@ def test_live_doc_read_with_notice_box(live_test_doc_id: int) -> None:
 
 
 @pytest.mark.integration
-def test_live_doc_export_markdown_object_id(live_test_doc_id: int) -> None:
-    """Read-only #24 coverage: `export-markdown --object-id` works directly,
+def test_live_doc_server_markdown_object_id(live_test_doc_id: int) -> None:
+    """Read-only #24 coverage: server markdown via `--object-id` works directly,
     and the same id passed as `--doc` fails with the targeted retry hint
     instead of an opaque server 500."""
-    md_result = invoke(["doc", "export-markdown", "--object-id", str(live_test_doc_id)])
-    assert md_result.stdout.strip(), "export-markdown --object-id produced no output"
+    server_md = ["--format", "markdown", "--engine", "server"]
+    md_result = invoke(["doc", "get", "--object-id", str(live_test_doc_id), *server_md])
+    assert md_result.stdout.strip(), "server markdown --object-id produced no output"
 
     wrong = invoke(
-        ["doc", "export-markdown", "--doc", str(live_test_doc_id)],
+        ["doc", "get", "--doc", str(live_test_doc_id), *server_md],
         expect_exit=None,
     )
-    assert wrong.exit_code != 0, format_failure(["doc", "export-markdown"], wrong)
+    assert wrong.exit_code != 0, format_failure(["doc", "get", *server_md], wrong)
     assert f"--object-id {live_test_doc_id}" in wrong.stderr, wrong.stderr
 
     both = invoke(
         [
             "doc",
-            "export-markdown",
+            "get",
             "--doc",
             str(live_test_doc_id),
             "--object-id",
             str(live_test_doc_id),
+            *server_md,
         ],
         expect_exit=2,
     )

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -1386,7 +1386,7 @@ class TestDocNewOps:
         body = _last_body(httpx_mock)
         assert body["variables"] == {"doc": 10}
 
-    def test_export_markdown_plain(self, httpx_mock: HTTPXMock) -> None:
+    def test_server_markdown_plain(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(
             url=ENDPOINT,
             method="POST",
@@ -1400,13 +1400,15 @@ class TestDocNewOps:
                 }
             ),
         )
-        result = runner.invoke(app, ["doc", "export-markdown", "--doc", "10"])
+        result = runner.invoke(
+            app, ["doc", "get", "--doc", "10", "--format", "markdown", "--engine", "server"]
+        )
         assert result.exit_code == 0, result.stdout
         assert "# Title" in result.stdout
         body = _last_body(httpx_mock)
         assert body["variables"] == {"doc": 10, "blocks": None}
 
-    def test_export_markdown_failure_exits_5(self, httpx_mock: HTTPXMock) -> None:
+    def test_server_markdown_failure_exits_5(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(
             url=ENDPOINT,
             method="POST",
@@ -1422,12 +1424,14 @@ class TestDocNewOps:
         )
         # Object-id probe on the success=False failure (the #24 guardrail).
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
-        result = runner.invoke(app, ["doc", "export-markdown", "--doc", "10"])
+        result = runner.invoke(
+            app, ["doc", "get", "--doc", "10", "--format", "markdown", "--engine", "server"]
+        )
         assert result.exit_code == 5
 
-    def test_export_markdown_accepts_no_cache_noop(self, httpx_mock: HTTPXMock) -> None:
-        """Issue #34: `--no-cache` is accepted as a no-op (export is always
-        live) rather than failing with a usage error (exit 2)."""
+    def test_server_markdown_accepts_no_cache_noop(self, httpx_mock: HTTPXMock) -> None:
+        """Issue #34: `--engine server` is always live, so `--no-cache` is
+        accepted as a no-op rather than failing with a usage error (exit 2)."""
         httpx_mock.add_response(
             url=ENDPOINT,
             method="POST",
@@ -1435,17 +1439,87 @@ class TestDocNewOps:
                 {"export_markdown_from_doc": {"success": True, "error": None, "markdown": "# T"}}
             ),
         )
-        result = runner.invoke(app, ["doc", "export-markdown", "--doc", "10", "--no-cache"])
+        result = runner.invoke(
+            app,
+            [
+                "doc",
+                "get",
+                "--doc",
+                "10",
+                "--format",
+                "markdown",
+                "--engine",
+                "server",
+                "--no-cache",
+            ],
+        )
         assert result.exit_code == 0, result.stderr
         assert "# T" in result.stdout
 
-    def test_export_markdown_no_cache_refresh_cache_mutually_exclusive(self) -> None:
+    def test_server_markdown_no_cache_refresh_cache_mutually_exclusive(self) -> None:
         result = runner.invoke(
             app,
-            ["doc", "export-markdown", "--doc", "10", "--no-cache", "--refresh-cache"],
+            [
+                "doc",
+                "get",
+                "--doc",
+                "10",
+                "--format",
+                "markdown",
+                "--engine",
+                "server",
+                "--no-cache",
+                "--refresh-cache",
+            ],
         )
         assert result.exit_code == 2
         assert "mutually exclusive" in (result.stderr or result.stdout).lower()
+
+    def test_server_engine_requires_markdown_format(self) -> None:
+        result = runner.invoke(app, ["doc", "get", "--doc", "10", "--engine", "server"])
+        assert result.exit_code == 2
+        assert "only supports --format markdown" in (result.stderr or result.stdout)
+
+    def test_block_requires_server_engine(self) -> None:
+        result = runner.invoke(
+            app, ["doc", "get", "--doc", "10", "--format", "markdown", "--block", "b1"]
+        )
+        assert result.exit_code == 2
+        assert "--block requires --engine server" in (result.stderr or result.stdout)
+
+    def test_raw_requires_server_engine(self) -> None:
+        result = runner.invoke(app, ["doc", "get", "--doc", "10", "--raw"])
+        assert result.exit_code == 2
+        assert "--raw requires --engine server" in (result.stderr or result.stdout)
+
+    def test_server_markdown_blocks_subset_passed_through(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {"export_markdown_from_doc": {"success": True, "error": None, "markdown": "# T"}}
+            ),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "doc",
+                "get",
+                "--doc",
+                "10",
+                "--format",
+                "markdown",
+                "--engine",
+                "server",
+                "--block",
+                "b1",
+                "--block",
+                "b2",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        body = _last_body(httpx_mock)
+        assert body["variables"] == {"doc": 10, "blocks": ["b1", "b2"]}
 
     def test_add_markdown(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(
@@ -1824,10 +1898,22 @@ class TestImageExportOutputGuards:
         assert result.exit_code == 2
         assert httpx_mock.get_requests() == []
 
-    def test_export_markdown_raw_and_out_mutually_exclusive(self, httpx_mock: HTTPXMock) -> None:
+    def test_server_markdown_raw_and_out_mutually_exclusive(self, httpx_mock: HTTPXMock) -> None:
         result = runner.invoke(
             app,
-            ["doc", "export-markdown", "--doc", "10", "--raw", "--out", "x.md"],
+            [
+                "doc",
+                "get",
+                "--doc",
+                "10",
+                "--format",
+                "markdown",
+                "--engine",
+                "server",
+                "--raw",
+                "--out",
+                "x.md",
+            ],
         )
         assert result.exit_code == 2
         assert httpx_mock.get_requests() == []
@@ -2274,7 +2360,7 @@ class TestDocClear:
 
 
 class TestExportMarkdownCoalesce:
-    """Issue #62: fragmented bold runs are rejoined in export-markdown output."""
+    """Issue #62: fragmented bold runs are rejoined in server-markdown output."""
 
     def test_fragmented_bold_collapsed(self, httpx_mock: HTTPXMock) -> None:
         fragmented = "**Caching is ****not**** a win**"
@@ -2291,7 +2377,9 @@ class TestExportMarkdownCoalesce:
                 }
             ),
         )
-        result = runner.invoke(app, ["doc", "export-markdown", "--doc", "10"])
+        result = runner.invoke(
+            app, ["doc", "get", "--doc", "10", "--format", "markdown", "--engine", "server"]
+        )
         assert result.exit_code == 0, result.stdout
         assert "**Caching is not a win**" in result.stdout
         assert "****" not in result.stdout
@@ -2313,7 +2401,20 @@ class TestExportMarkdownCoalesce:
         )
         out = tmp_path / "exported.md"
         result = runner.invoke(
-            app, ["doc", "export-markdown", "--doc", "10", "--out", str(out), "--no-images"]
+            app,
+            [
+                "doc",
+                "get",
+                "--doc",
+                "10",
+                "--format",
+                "markdown",
+                "--engine",
+                "server",
+                "--out",
+                str(out),
+                "--no-images",
+            ],
         )
         assert result.exit_code == 0, result.stdout
         assert out.read_text() == "**a b**"

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -1480,6 +1480,16 @@ class TestDocNewOps:
         assert result.exit_code == 2
         assert "only supports --format markdown" in (result.stderr or result.stdout)
 
+    def test_server_engine_format_guard_precedes_out_guard(self) -> None:
+        """A server-engine call that forgot --format markdown reports the
+        engine/format mismatch first, not the generic --out-needs-markdown
+        message (the client-path guard)."""
+        result = runner.invoke(
+            app, ["doc", "get", "--doc", "10", "--engine", "server", "--raw", "--out", "x.md"]
+        )
+        assert result.exit_code == 2
+        assert "only supports --format markdown" in (result.stderr or result.stdout)
+
     def test_block_requires_server_engine(self) -> None:
         result = runner.invoke(
             app, ["doc", "get", "--doc", "10", "--format", "markdown", "--block", "b1"]

--- a/tests/unit/test_cli_doc_object_id.py
+++ b/tests/unit/test_cli_doc_object_id.py
@@ -58,7 +58,7 @@ def _bodies(httpx_mock: HTTPXMock) -> list[dict]:
     return [json.loads(r.content) for r in httpx_mock.get_requests()]
 
 
-class TestExportMarkdownObjectId:
+class TestServerMarkdownObjectId:
     def test_object_id_resolves_then_exports(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=_head_hit())
         httpx_mock.add_response(
@@ -74,7 +74,10 @@ class TestExportMarkdownObjectId:
                 }
             ),
         )
-        result = runner.invoke(app, ["doc", "export-markdown", "--object-id", OBJECT_ID])
+        result = runner.invoke(
+            app,
+            ["doc", "get", "--format", "markdown", "--engine", "server", "--object-id", OBJECT_ID],
+        )
         assert result.exit_code == 0, result.output
         assert result.stdout.strip() == "# Hello"
         head, export = _bodies(httpx_mock)
@@ -84,19 +87,33 @@ class TestExportMarkdownObjectId:
     def test_doc_and_object_id_together_is_usage_error(self, httpx_mock: HTTPXMock) -> None:
         result = runner.invoke(
             app,
-            ["doc", "export-markdown", "--doc", INTERNAL_ID, "--object-id", OBJECT_ID],
+            [
+                "doc",
+                "get",
+                "--format",
+                "markdown",
+                "--engine",
+                "server",
+                "--doc",
+                INTERNAL_ID,
+                "--object-id",
+                OBJECT_ID,
+            ],
         )
         assert result.exit_code == 2
         assert httpx_mock.get_requests() == []
 
     def test_neither_flag_is_usage_error(self, httpx_mock: HTTPXMock) -> None:
-        result = runner.invoke(app, ["doc", "export-markdown"])
+        result = runner.invoke(app, ["doc", "get", "--format", "markdown", "--engine", "server"])
         assert result.exit_code == 2
         assert httpx_mock.get_requests() == []
 
     def test_object_id_miss_exits_6(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
-        result = runner.invoke(app, ["doc", "export-markdown", "--object-id", OBJECT_ID])
+        result = runner.invoke(
+            app,
+            ["doc", "get", "--format", "markdown", "--engine", "server", "--object-id", OBJECT_ID],
+        )
         assert result.exit_code == 6
         assert "not found" in result.stderr
 
@@ -118,7 +135,9 @@ class TestExportMarkdownObjectId:
         )
         # Probe resolves the id as an object_id → targeted hint.
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=_head_hit())
-        result = runner.invoke(app, ["doc", "export-markdown", "--doc", OBJECT_ID])
+        result = runner.invoke(
+            app, ["doc", "get", "--format", "markdown", "--engine", "server", "--doc", OBJECT_ID]
+        )
         assert result.exit_code == 5
         assert "status=500" in result.stderr
         assert f"--object-id {OBJECT_ID}" in result.stderr
@@ -140,7 +159,9 @@ class TestExportMarkdownObjectId:
             },
         )
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=_head_hit())
-        result = runner.invoke(app, ["doc", "export-markdown", "--doc", OBJECT_ID])
+        result = runner.invoke(
+            app, ["doc", "get", "--format", "markdown", "--engine", "server", "--doc", OBJECT_ID]
+        )
         assert result.exit_code != 0
         assert f"--object-id {OBJECT_ID}" in result.stderr
 
@@ -160,7 +181,9 @@ class TestExportMarkdownObjectId:
         )
         # Probe misses — the id is not an object id; no hint.
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"docs": []}))
-        result = runner.invoke(app, ["doc", "export-markdown", "--doc", INTERNAL_ID])
+        result = runner.invoke(
+            app, ["doc", "get", "--format", "markdown", "--engine", "server", "--doc", INTERNAL_ID]
+        )
         assert result.exit_code == 5
         assert "--object-id" not in result.stderr
 
@@ -265,7 +288,7 @@ class TestUniformObjectIdSurface:
     @pytest.mark.parametrize(
         "args",
         [
-            ["doc", "export-markdown"],
+            ["doc", "get"],
             ["doc", "rename", "--name", "n"],
             ["doc", "delete"],
             ["doc", "duplicate"],


### PR DESCRIPTION
## Why

We had **two** ways to get a doc as markdown — `doc get --format markdown` (our client-side block renderer) and `doc export-markdown` (monday's server-side exporter). From a consumer's perspective they looked interchangeable (both took `--out`/`--no-images`/`--object-id`) yet could produce different output and only one honoured the cache. The server-vs-client distinction is really a *parameter*, not a separate verb.

## What

Fold `doc export-markdown` into `doc get` and **remove** the standalone command:

- `doc get` gains `--engine client|server` (default `client`).
  - `client` — the existing local block renderer; the only engine for `json`/`mdx`/`html`; honours the per-doc cache.
  - `server` — monday's `export_markdown_from_doc`; markdown only; always live.
- `--block <id>` (repeatable, subset export) and `--raw` (monday's API envelope) move onto `doc get`, gated on `--engine server`.
- Validation: `--engine server` requires `--format markdown`; `--block`/`--raw` require `--engine server`; `--raw`/`--out` stay mutually exclusive. The engine/format guard is reported before the generic `--out` guard so the most relevant error speaks first.

Old → new:

```
doc export-markdown --doc 7                  →  doc get --doc 7 --format markdown --engine server
doc export-markdown --doc 7 --block b1 --raw →  doc get --doc 7 --format markdown --engine server --block b1 --raw
doc export-markdown --doc 7 --out ./d.md     →  doc get --doc 7 --format markdown --engine server --out ./d.md
```

The server path is a verbatim lift of the old command body into `_emit_server_markdown`, so dry-run, object-id resolution + the #24 retry hint, the #62 bold-coalesce, image localization, and exit codes are all preserved.

> ⚠️ **Breaking change**: `mondo doc export-markdown` is gone. Callers must move to `doc get --format markdown --engine server`.

## Docs

Updated every surface: `doc get --help`/epilog examples, the bundled skill (`references/docs.md`), in-CLI help topics (`boards-vs-docs`, `agent-tips`, `output`), README, project CLAUDE.md, and the regenerated output-contract matrix.

## Tests

- Unit tests for `export-markdown` migrated to the new surface (server markdown, object-id resolution/#24 hint, #62 coalesce, `--raw`/`--out` exclusion, `--no-cache` no-op).
- New guard tests: `--engine server` requires markdown, `--block`/`--raw` require server, subset passthrough, and the validation-ordering regression.
- Integration tests updated to the new invocation.
- Full unit suite: **1765 passed**. ruff + mypy clean.

## Review

Reviewed with `/code-review` (high), `/simplify`, and codex `gpt-5.5` (high). No correctness regressions found; the one codex finding (validation ordering) is fixed in this branch.