### PR TITLE
feat(doc): PDF export via WeasyPrint (`doc get --format pdf`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ mondo doc get            --id 7 --format markdown --out ./doc.md  # +download im
 mondo doc get            --id 7 --format markdown --out ./doc.md --no-images  # skip download, keep URLs
 mondo doc get            --id 7 --format mdx --out ./doc.mdx      # MDX (JSX-safe markdown)
 mondo doc get            --id 7 --format html --out ./doc.html    # single self-contained HTML, images base64-embedded
+mondo doc get            --id 7 --format pdf  --out ./doc.pdf     # PDF via WeasyPrint (brew install weasyprint on first use)
 mondo doc export-markdown --doc 7                    # always-live markdown export (--no-cache/--refresh-cache accepted as no-ops)
 mondo doc export-markdown --doc 7 --out ./doc.md     # +download images, rewrite URLs to local files
 mondo doc export-markdown --doc 7 --out ./doc.md --no-images  # skip download, keep URLs
@@ -611,7 +612,13 @@ blocks. `doc clear` empties the body while keeping the doc itself (vs `doc
 delete`, which removes it). `doc create --folder <id>` places the new doc
 directly inside a folder; if creation is blocked by workspace policy it fails
 with `USER_UNAUTHORIZED` and an actionable license `suggestion`. `--out` needs
-a render format — `--format json` with `--out` exits 2.
+a render format — `--format json` with `--out` exits 2. `--format pdf` always
+requires `--out` and renders the self-contained HTML through
+[WeasyPrint](https://weasyprint.org/); monday has no PDF export, so it's done
+client-side. WeasyPrint isn't bundled (it needs native pango/cairo libraries) —
+install it on first use (`brew install weasyprint`; on Windows `pipx install
+weasyprint` + the GTK runtime), or fall back to `--format html` and print to PDF
+from a browser.
 
 ### Updates (item comments)
 

--- a/docs/output-contract-matrix.json
+++ b/docs/output-contract-matrix.json
@@ -557,7 +557,7 @@
       "created_by{id,name}",
       "blocks{id,type,content,parent_block_id}"
     ],
-    "notes": "Default format is JSON object above. --format markdown/mdx/html render to stdout instead (mdx is JSX-safe markdown; html is a single self-contained document). With --out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is the list of localized image filenames downloaded beside it; html embeds images as base64 and emits {out, images} where images is the embedded count. --no-images keeps the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise).",
+    "notes": "Default format is JSON object above. --format markdown/mdx/html render to stdout instead (mdx is JSX-safe markdown; html is a single self-contained document). With --out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is the list of localized image filenames downloaded beside it; html embeds images as base64 and emits {out, images} where images is the embedded count. --format pdf renders the self-contained html through WeasyPrint (client-side; monday has no PDF export) and emits {out, engine, images}; it always requires --out and exits non-zero with an install hint when WeasyPrint is absent. --no-images keeps the monday URLs (pdf renders images empty instead, so no network fetch). --out requires --format markdown/mdx/html/pdf (exit 2 otherwise).",
     "source": "DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]"
   },
   {

--- a/docs/output-contract-matrix.md
+++ b/docs/output-contract-matrix.md
@@ -245,7 +245,7 @@ Nested object/list fields are shown inline as `field{sub1,sub2}`.
   type: `object | string`
   fields: `id`, `object_id`, `name`, `doc_kind`, `doc_folder_id`, `created_at`, `updated_at`, `url`, `relative_url`, `workspace_id`, `created_by{id,name}`, `blocks{id,type,content,parent_block_id}`
   source: `DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]`
-  notes: Default format is JSON object above. --format markdown/mdx/html render to stdout instead (mdx is JSX-safe markdown; html is a single self-contained document). With --out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is the list of localized image filenames downloaded beside it; html embeds images as base64 and emits {out, images} where images is the embedded count. --no-images keeps the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise).
+  notes: Default format is JSON object above. --format markdown/mdx/html render to stdout instead (mdx is JSX-safe markdown; html is a single self-contained document). With --out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is the list of localized image filenames downloaded beside it; html embeds images as base64 and emits {out, images} where images is the embedded count. --format pdf renders the self-contained html through WeasyPrint (client-side; monday has no PDF export) and emits {out, engine, images}; it always requires --out and exits non-zero with an install hint when WeasyPrint is absent. --no-images keeps the monday URLs (pdf renders images empty instead, so no network fetch). --out requires --format markdown/mdx/html/pdf (exit 2 otherwise).
 - `doc import-html`
   type: `object`
   fields: `error`, `success`, `doc_id`

--- a/scripts/generate_output_contract_matrix.py
+++ b/scripts/generate_output_contract_matrix.py
@@ -431,8 +431,12 @@ MANUAL_ROWS: dict[str, Row] = {
             "instead (mdx is JSX-safe markdown; html is a single self-contained document). With "
             "--out FILE: markdown/mdx write the text to FILE and emit {out, images} where images is "
             "the list of localized image filenames downloaded beside it; html embeds images as "
-            "base64 and emits {out, images} where images is the embedded count. --no-images keeps "
-            "the monday URLs. --out requires --format markdown/mdx/html (exit 2 otherwise)."
+            "base64 and emits {out, images} where images is the embedded count. --format pdf renders "
+            "the self-contained html through WeasyPrint (client-side; monday has no PDF export) and "
+            "emits {out, engine, images}; it always requires --out and exits non-zero with an install "
+            "hint when WeasyPrint is absent. --no-images keeps the monday URLs (pdf renders images "
+            "empty instead, so no network fetch). --out requires --format markdown/mdx/html/pdf "
+            "(exit 2 otherwise)."
         ),
         source="DOC_GET_BY_ID.docs[0] | DOCS_BY_OBJECT_ID.docs[0]",
     ),

--- a/src/mondo/cli/_pdf.py
+++ b/src/mondo/cli/_pdf.py
@@ -1,0 +1,86 @@
+"""WeasyPrint-backed PDF rendering for `doc get --format pdf` (issue #68).
+
+monday's API exposes no PDF export, so PDF is produced client-side: the doc is
+rendered to a single self-contained HTML document (`blocks_to_html`, with
+base64-embedded images and print CSS) and handed to WeasyPrint.
+
+WeasyPrint is *not* bundled — it pulls native pango/cairo libraries that don't
+fit the pure-Python PyInstaller build — so it's detected on `PATH` and the user
+is prompted to install it on first use. One engine, one flow: no registry, no
+fallback converter.
+"""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from mondo.api.errors import MondoError
+
+# WeasyPrint is fast for ordinary docs; this only guards a pathological hang.
+_TIMEOUT_S = 120
+
+
+def find_weasyprint() -> str | None:
+    """Absolute path to the `weasyprint` CLI on `PATH`, or None if absent."""
+    return shutil.which("weasyprint")
+
+
+def install_hint() -> str:
+    """Per-OS guidance for installing WeasyPrint (brew can't serve Windows)."""
+    if platform.system() == "Windows":
+        return (
+            "WeasyPrint is required for PDF export. Install it with "
+            "`pipx install weasyprint` plus the GTK runtime "
+            "(see https://doc.courtbouillon.org/weasyprint/stable/first_steps.html), "
+            "or use `--format html` and print to PDF from your browser."
+        )
+    return (
+        "WeasyPrint is required for PDF export. Install it with "
+        "`brew install weasyprint`, or use `--format html` and print to PDF "
+        "from your browser."
+    )
+
+
+def render_pdf(html_text: str, out: Path) -> None:
+    """Render `html_text` to a PDF at `out` via WeasyPrint.
+
+    Writes the HTML and the PDF inside a private temp dir, verifies the output
+    is non-empty, then moves it into place — so a failed run never leaves a
+    truncated PDF at `out`. Raises `MondoError` if WeasyPrint is missing, times
+    out, or fails to produce a usable PDF.
+    """
+    exe = find_weasyprint()
+    if exe is None:
+        raise MondoError(install_hint())
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="mondo-pdf-") as tmp:
+        src = Path(tmp) / "input.html"
+        dst = Path(tmp) / "output.pdf"
+        src.write_text(html_text, encoding="utf-8")
+        try:
+            proc = subprocess.run(
+                [exe, str(src), str(dst)],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=_TIMEOUT_S,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise MondoError(f"WeasyPrint timed out after {_TIMEOUT_S}s") from e
+        except OSError as e:
+            raise MondoError(f"failed to run WeasyPrint: {e}") from e
+
+        if proc.returncode != 0 or not dst.exists() or dst.stat().st_size == 0:
+            tail = "\n".join((proc.stderr or "").strip().splitlines()[-5:])
+            detail = tail or f"exit code {proc.returncode}"
+            raise MondoError(f"WeasyPrint failed to render the PDF:\n{detail}")
+
+        if out.exists():
+            out.unlink()
+        shutil.move(str(dst), str(out))

--- a/src/mondo/cli/_pdf.py
+++ b/src/mondo/cli/_pdf.py
@@ -12,6 +12,8 @@ fallback converter.
 
 from __future__ import annotations
 
+import contextlib
+import os
 import platform
 import shutil
 import subprocess
@@ -48,39 +50,53 @@ def install_hint() -> str:
 def render_pdf(html_text: str, out: Path) -> None:
     """Render `html_text` to a PDF at `out` via WeasyPrint.
 
-    Writes the HTML and the PDF inside a private temp dir, verifies the output
-    is non-empty, then moves it into place — so a failed run never leaves a
-    truncated PDF at `out`. Raises `MondoError` if WeasyPrint is missing, times
-    out, or fails to produce a usable PDF.
+    The PDF is written to a temp file on the same filesystem as `out` and moved
+    into place with `os.replace`, so the install is atomic and a failure never
+    truncates or clobbers an existing PDF at `out`. Raises `MondoError` if
+    WeasyPrint is missing, times out, fails to produce a usable PDF, or the
+    output can't be written.
     """
     exe = find_weasyprint()
     if exe is None:
         raise MondoError(install_hint())
 
-    out.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix="mondo-pdf-") as tmp:
-        src = Path(tmp) / "input.html"
-        dst = Path(tmp) / "output.pdf"
-        src.write_text(html_text, encoding="utf-8")
-        try:
-            proc = subprocess.run(
-                [exe, str(src), str(dst)],
-                stdin=subprocess.DEVNULL,
-                capture_output=True,
-                text=True,
-                timeout=_TIMEOUT_S,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as e:
-            raise MondoError(f"WeasyPrint timed out after {_TIMEOUT_S}s") from e
-        except OSError as e:
-            raise MondoError(f"failed to run WeasyPrint: {e}") from e
+    try:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(suffix=".pdf", dir=out.parent)
+        os.close(fd)
+    except OSError as e:
+        raise MondoError(f"failed to prepare PDF output at {out}: {e}") from e
 
-        if proc.returncode != 0 or not dst.exists() or dst.stat().st_size == 0:
-            tail = "\n".join((proc.stderr or "").strip().splitlines()[-5:])
-            detail = tail or f"exit code {proc.returncode}"
-            raise MondoError(f"WeasyPrint failed to render the PDF:\n{detail}")
+    dst = Path(tmp_name)
+    try:
+        with tempfile.TemporaryDirectory(prefix="mondo-pdf-") as tmp:
+            src = Path(tmp) / "input.html"
+            src.write_text(html_text, encoding="utf-8")
+            try:
+                proc = subprocess.run(
+                    [exe, str(src), str(dst)],
+                    stdin=subprocess.DEVNULL,
+                    capture_output=True,
+                    text=True,
+                    timeout=_TIMEOUT_S,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired as e:
+                raise MondoError(f"WeasyPrint timed out after {_TIMEOUT_S}s") from e
+            except OSError as e:
+                raise MondoError(f"failed to run WeasyPrint: {e}") from e
 
-        if out.exists():
-            out.unlink()
-        shutil.move(str(dst), str(out))
+            if proc.returncode != 0 or not dst.exists() or dst.stat().st_size == 0:
+                tail = "\n".join((proc.stderr or "").strip().splitlines()[-5:])
+                detail = tail or f"exit code {proc.returncode}"
+                raise MondoError(f"WeasyPrint failed to render the PDF:\n{detail}")
+
+        os.replace(dst, out)
+    except OSError as e:
+        raise MondoError(f"failed to write PDF to {out}: {e}") from e
+    finally:
+        # Clean up the temp output if it wasn't moved into place (os.replace
+        # consumes it on success, so this is a no-op then).
+        with contextlib.suppress(OSError):
+            if dst.exists():
+                dst.unlink()

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -16,6 +16,7 @@ workspace with a block-structured body. The CLI covers:
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import json
 import re
@@ -104,20 +105,50 @@ class DuplicateDocType(StrEnum):
 _DOC_BLOCKS_PAGE_SIZE = 100
 
 # Image `src` neutralization for PDF export. WeasyPrint dereferences URLs while
-# converting, so before HTML reaches it we keep ONLY raster base64 data URIs
-# produced by the embed path and blank everything else: remote/`file://` URLs
-# from (untrusted) doc content AND `data:image/svg+xml` — an SVG can pull in
-# external resources when WeasyPrint renders it, so a `data:` allowlist alone is
-# not an SSRF boundary. Safe on our own output: image src/alt are HTML-escaped,
-# so no literal `"` appears inside an attribute value.
+# converting, so before HTML reaches it we keep ONLY base64 data URIs whose
+# decoded bytes are a known *raster* image, and blank everything else (remote /
+# `file://` URLs from untrusted doc content, non-data srcs, and SVG).
+#
+# The declared MIME is NOT trusted: WeasyPrint content-sniffs and will parse SVG
+# out of a `data:image/png` URI, then fetch the external resources an SVG can
+# reference (verified — that's an SSRF). So we validate the actual leading
+# bytes against raster magic numbers; SVG/XML and anything non-raster never
+# survive regardless of the declared type. Rasters are inert pixel data and
+# can't fetch. Safe on our own output: image src/alt are HTML-escaped, so no
+# literal `"` appears inside an attribute value.
 _IMG_SRC = re.compile(r'src="([^"]*)"')
-_SAFE_PDF_IMG_SRC = re.compile(r"data:image/(?:png|jpe?g|gif|webp|bmp);base64,", re.IGNORECASE)
+_DATA_URI_B64 = re.compile(r"data:[\w.+/-]*;base64,(.*)", re.IGNORECASE | re.DOTALL)
+_RASTER_MAGIC = (
+    b"\x89PNG\r\n\x1a\n",  # png
+    b"\xff\xd8\xff",  # jpeg
+    b"GIF87a",
+    b"GIF89a",
+    b"BM",  # bmp
+    b"II*\x00",  # tiff, little-endian
+    b"MM\x00*",  # tiff, big-endian
+)
+
+
+def _is_raster_data_uri(src: str) -> bool:
+    """True only for a `data:...;base64,` URI whose decoded bytes start with a
+    known raster image signature (so SVG/XML and non-images are rejected even
+    when they declare an `image/png` MIME)."""
+    m = _DATA_URI_B64.match(src)
+    if m is None:
+        return False
+    prefix = m.group(1)[:64]
+    prefix = prefix[: len(prefix) // 4 * 4]  # whole base64 groups → clean decode
+    try:
+        head = base64.b64decode(prefix)
+    except ValueError:
+        return False
+    return head.startswith(_RASTER_MAGIC) or (head[:4] == b"RIFF" and head[8:12] == b"WEBP")
 
 
 def _sanitize_pdf_image_srcs(html_text: str) -> str:
-    """Blank every `<img>` src that isn't a raster base64 data URI."""
+    """Blank every `<img>` src that isn't a base64 raster image data URI."""
     return _IMG_SRC.sub(
-        lambda m: m.group(0) if _SAFE_PDF_IMG_SRC.match(m.group(1)) else 'src=""',
+        lambda m: m.group(0) if _is_raster_data_uri(m.group(1)) else 'src=""',
         html_text,
     )
 

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -91,6 +91,7 @@ class DocFormat(StrEnum):
     markdown = "markdown"
     mdx = "mdx"
     html = "html"
+    pdf = "pdf"
 
 
 class DuplicateDocType(StrEnum):
@@ -533,7 +534,7 @@ def get_cmd(
     fmt: DocFormat = typer.Option(
         DocFormat.json,
         "--format",
-        help="Emit raw JSON (blocks as-is) or render blocks to markdown, mdx, or html.",
+        help="Emit raw JSON (blocks as-is) or render blocks to markdown, mdx, html, or pdf.",
         case_sensitive=False,
     ),
     out: Path | None = typer.Option(
@@ -541,11 +542,13 @@ def get_cmd(
         "--out",
         help=(
             "Write the rendered doc to this file (requires --format "
-            "markdown/mdx/html). For markdown/mdx, embedded images are "
-            "downloaded into the same folder and referenced by local filename; "
-            "for html they are base64-embedded so the file is self-contained. "
-            "Without --out, output goes to stdout (markdown/mdx keep monday "
-            "image URLs; html still embeds images)."
+            "markdown/mdx/html/pdf; required for pdf). For markdown/mdx, embedded "
+            "images are downloaded into the same folder and referenced by local "
+            "filename; for html they are base64-embedded so the file is "
+            "self-contained. pdf renders the self-contained html via WeasyPrint "
+            "(install on first use: `brew install weasyprint`). Without --out, "
+            "output goes to stdout (markdown/mdx keep monday image URLs; html "
+            "still embeds images)."
         ),
     ),
     no_images: bool = typer.Option(
@@ -590,9 +593,11 @@ def get_cmd(
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     reject_mutually_exclusive(no_cache, refresh_cache)
     del with_url  # docs always carry `url` from monday; flag kept for symmetry
-    _RENDER_FORMATS = {DocFormat.markdown, DocFormat.mdx, DocFormat.html}
+    _RENDER_FORMATS = {DocFormat.markdown, DocFormat.mdx, DocFormat.html, DocFormat.pdf}
     if out is not None and fmt not in _RENDER_FORMATS:
-        usage_error_or_exit("--out is only valid with --format markdown, mdx, or html.")
+        usage_error_or_exit("--out is only valid with --format markdown, mdx, html, or pdf.")
+    if fmt is DocFormat.pdf and out is None:
+        usage_error_or_exit("--format pdf requires --out <file.pdf>.")
     sources = sum(x is not None for x in (doc_id, object_id))
     if sources != 1:
         usage_error_or_exit("pass exactly one of --id or --object-id.")
@@ -674,6 +679,32 @@ def get_cmd(
             opts.emit({"out": str(out), "images": len(images)})
             return
         typer.echo(html_text)
+        return
+
+    if fmt is DocFormat.pdf:
+        # PDF = the same self-contained HTML handed to WeasyPrint (issue #68).
+        # `--out` is guaranteed present by the up-front guard.
+        assert out is not None
+        from mondo.cli._pdf import render_pdf
+        from mondo.docs import blocks_to_html
+
+        blocks = doc.get("blocks") or []
+        if no_images:
+            # Render image blocks with an empty src so WeasyPrint never reaches
+            # out to monday's (browser-only) image URLs during conversion.
+            from mondo.docs import collect_image_asset_ids
+
+            images = {str(aid): ("", "") for aid in collect_image_asset_ids(blocks)}
+        else:
+            from mondo.cli._doc_images import embed_doc_images
+
+            images = embed_doc_images(opts, blocks)
+        html_text = blocks_to_html(blocks, images=images, title=doc.get("name"))
+        try:
+            render_pdf(html_text, out)
+        except MondoError as e:
+            handle_mondo_error_or_exit(e)
+        opts.emit({"out": str(out), "engine": "weasyprint", "images": len(images)})
         return
 
     if fmt in (DocFormat.markdown, DocFormat.mdx):

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -103,6 +103,24 @@ class DuplicateDocType(StrEnum):
 
 _DOC_BLOCKS_PAGE_SIZE = 100
 
+# Image `src` neutralization for PDF export. WeasyPrint dereferences URLs while
+# converting, so before HTML reaches it we keep ONLY raster base64 data URIs
+# produced by the embed path and blank everything else: remote/`file://` URLs
+# from (untrusted) doc content AND `data:image/svg+xml` — an SVG can pull in
+# external resources when WeasyPrint renders it, so a `data:` allowlist alone is
+# not an SSRF boundary. Safe on our own output: image src/alt are HTML-escaped,
+# so no literal `"` appears inside an attribute value.
+_IMG_SRC = re.compile(r'src="([^"]*)"')
+_SAFE_PDF_IMG_SRC = re.compile(r"data:image/(?:png|jpe?g|gif|webp|bmp);base64,", re.IGNORECASE)
+
+
+def _sanitize_pdf_image_srcs(html_text: str) -> str:
+    """Blank every `<img>` src that isn't a raster base64 data URI."""
+    return _IMG_SRC.sub(
+        lambda m: m.group(0) if _SAFE_PDF_IMG_SRC.match(m.group(1)) else 'src=""',
+        html_text,
+    )
+
 # The `--doc` XOR `--object-id` pair shared by every doc-targeting subcommand
 # (same shared-option pattern as the Poll*Opt trio in `mondo.cli._exec`).
 DocIdOpt = Annotated[
@@ -685,21 +703,19 @@ def get_cmd(
         # PDF = the same self-contained HTML handed to WeasyPrint (issue #68).
         # `--out` is guaranteed present by the up-front guard.
         assert out is not None
-        from mondo.cli._pdf import render_pdf
+        from mondo.cli._doc_images import embed_doc_images
+        from mondo.cli._pdf import find_weasyprint, install_hint, render_pdf
         from mondo.docs import blocks_to_html
 
+        # Preflight before the (network) image embed so a first-time user without
+        # WeasyPrint gets the install hint without paying for asset downloads.
+        if find_weasyprint() is None:
+            handle_mondo_error_or_exit(MondoError(install_hint()))
+
         blocks = doc.get("blocks") or []
-        if no_images:
-            # Render image blocks with an empty src so WeasyPrint never reaches
-            # out to monday's (browser-only) image URLs during conversion.
-            from mondo.docs import collect_image_asset_ids
-
-            images = {str(aid): ("", "") for aid in collect_image_asset_ids(blocks)}
-        else:
-            from mondo.cli._doc_images import embed_doc_images
-
-            images = embed_doc_images(opts, blocks)
+        images = {} if no_images else embed_doc_images(opts, blocks)
         html_text = blocks_to_html(blocks, images=images, title=doc.get("name"))
+        html_text = _sanitize_pdf_image_srcs(html_text)
         try:
             render_pdf(html_text, out)
         except MondoError as e:

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -985,16 +985,24 @@ def _render_html_image(block: dict[str, Any], images: dict[str, tuple[str, str]]
 # (the default — left to the stylesheet). The strict match also blocks
 # attribute injection from untrusted cell content.
 _CELL_HEX_COLOR = re.compile(r"#[0-9A-Fa-f]{3,8}\Z")
+# Non-default cell alignments worth emitting (`left` is the CSS default).
+_CELL_ALIGN = {"center", "right", "justify"}
 
 
-def _cell_bg_style(cell_block: dict[str, Any] | None) -> str:
-    """`style="background-color:..."` for a monday cell's explicit hex colour,
-    or `""` for the default (or any non-hex/unresolvable value)."""
+def _cell_style(cell_block: dict[str, Any] | None) -> str:
+    """Inline `style="..."` for a monday cell's explicit `backgroundColor`
+    (hex only) and `alignment`, or `""` when both are defaults. Values are
+    validated against fixed patterns/sets, which also blocks attribute
+    injection from untrusted cell content."""
     content = _as_content_dict((cell_block or {}).get("content")) or {}
+    decls: list[str] = []
     bg = content.get("backgroundColor")
     if isinstance(bg, str) and _CELL_HEX_COLOR.match(bg):
-        return f' style="background-color:{bg}"'
-    return ""
+        decls.append(f"background-color:{bg}")
+    align = content.get("alignment")
+    if isinstance(align, str) and align in _CELL_ALIGN:
+        decls.append(f"text-align:{align}")
+    return f' style="{";".join(decls)}"' if decls else ""
 
 
 def _render_html_table(
@@ -1006,10 +1014,10 @@ def _render_html_table(
 
     Mirrors `_render_table`'s reading of `content.cells` (a row-major matrix of
     `{"blockId": ...}` references). Each referenced `cell` block is itself a
-    child of the table, carrying the cell's text (in its own children) and a
-    `backgroundColor` we surface as an inline style. Returns None when the
-    schema is missing/malformed so the caller can fall back to a generic
-    container.
+    child of the table, carrying the cell's text (in its own children) plus a
+    `backgroundColor`/`alignment` we surface as an inline style. Returns None
+    when the schema is missing/malformed so the caller can fall back to a
+    generic container.
     """
     content = _as_content_dict(block.get("content"))
     if content is None:
@@ -1039,7 +1047,7 @@ def _render_html_table(
                     t = _html_text(child.get("content"))
                     if t:
                         pieces.append(t)
-            row_html.append((" ".join(pieces), _cell_bg_style(cells_by_id.get(cell_id))))
+            row_html.append((" ".join(pieces), _cell_style(cells_by_id.get(cell_id))))
         grid.append(row_html)
 
     if not grid or not grid[0]:

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -980,6 +980,23 @@ def _render_html_image(block: dict[str, Any], images: dict[str, tuple[str, str]]
     return f'<img src="{html.escape(src, quote=True)}" alt="{html.escape(alt, quote=True)}">'
 
 
+# A concrete hex colour (`#rgb`..`#rrggbbaa`). monday stores a cell's
+# `backgroundColor` either as such a hex or as `var(--primary-background-color)`
+# (the default — left to the stylesheet). The strict match also blocks
+# attribute injection from untrusted cell content.
+_CELL_HEX_COLOR = re.compile(r"#[0-9A-Fa-f]{3,8}\Z")
+
+
+def _cell_bg_style(cell_block: dict[str, Any] | None) -> str:
+    """`style="background-color:..."` for a monday cell's explicit hex colour,
+    or `""` for the default (or any non-hex/unresolvable value)."""
+    content = _as_content_dict((cell_block or {}).get("content")) or {}
+    bg = content.get("backgroundColor")
+    if isinstance(bg, str) and _CELL_HEX_COLOR.match(bg):
+        return f' style="background-color:{bg}"'
+    return ""
+
+
 def _render_html_table(
     block: dict[str, Any],
     children_of: dict[str, list[dict[str, Any]]],
@@ -988,8 +1005,11 @@ def _render_html_table(
     """Render a `table` block as an HTML `<table>`.
 
     Mirrors `_render_table`'s reading of `content.cells` (a row-major matrix of
-    `{"blockId": ...}` references). Returns None when the schema is
-    missing/malformed so the caller can fall back to a generic container.
+    `{"blockId": ...}` references). Each referenced `cell` block is itself a
+    child of the table, carrying the cell's text (in its own children) and a
+    `backgroundColor` we surface as an inline style. Returns None when the
+    schema is missing/malformed so the caller can fall back to a generic
+    container.
     """
     content = _as_content_dict(block.get("content"))
     if content is None:
@@ -998,11 +1018,15 @@ def _render_html_table(
     if not isinstance(cells_matrix, list) or not cells_matrix:
         return None
 
-    grid: list[list[str]] = []
+    cells_by_id = {
+        str(b.get("id")): b for b in children_of.get(str(block.get("id") or ""), [])
+    }
+    # (inner_html, style_attr) per cell.
+    grid: list[list[tuple[str, str]]] = []
     for row in cells_matrix:
         if not isinstance(row, list):
             return None
-        row_html: list[str] = []
+        row_html: list[tuple[str, str]] = []
         for cell_ref in row:
             cell_id = ""
             if isinstance(cell_ref, dict) and cell_ref.get("blockId") is not None:
@@ -1015,20 +1039,20 @@ def _render_html_table(
                     t = _html_text(child.get("content"))
                     if t:
                         pieces.append(t)
-            row_html.append(" ".join(pieces))
+            row_html.append((" ".join(pieces), _cell_bg_style(cells_by_id.get(cell_id))))
         grid.append(row_html)
 
     if not grid or not grid[0]:
         return None
     col_count = max(len(row) for row in grid)
-    grid = [row + [""] * (col_count - len(row)) for row in grid]
+    grid = [row + [("", "")] * (col_count - len(row)) for row in grid]
 
     out = ["<table>", "<thead><tr>"]
-    out += [f"<th>{c}</th>" for c in grid[0]]
+    out += [f"<th{style}>{c}</th>" for c, style in grid[0]]
     out.append("</tr></thead>")
     out.append("<tbody>")
     for row in grid[1:]:
-        out.append("<tr>" + "".join(f"<td>{c}</td>" for c in row) + "</tr>")
+        out.append("<tr>" + "".join(f"<td{style}>{c}</td>" for c, style in row) + "</tr>")
     out += ["</tbody>", "</table>"]
     return out
 

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -952,7 +952,8 @@ aside.notice {
    blocks and table rows from splitting across pages. */
 @page { size: A4; margin: 1.6cm; }
 @media print {
-  body { max-width: none; margin: 0; padding: 0; color: #000; background: #fff; }
+  body { max-width: none; margin: 0; padding: 0; color: #000; background: #fff; font-size: 10.5pt; }
+  pre, code { font-size: 8.5pt; }
   pre { white-space: pre-wrap; word-wrap: break-word; }
   pre, blockquote, aside.notice, tr, img { break-inside: avoid; }
   h1, h2, h3 { break-after: avoid; }

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -947,6 +947,16 @@ aside.notice {
   blockquote, hr, th, td { border-color: #444; }
   aside.notice { background: #16283a; }
 }
+/* Print / PDF export (issue #68): WeasyPrint renders print media, so force
+   light colors, drop the on-screen centering, wrap long code, and keep small
+   blocks and table rows from splitting across pages. */
+@page { size: A4; margin: 1.6cm; }
+@media print {
+  body { max-width: none; margin: 0; padding: 0; color: #000; background: #fff; }
+  pre { white-space: pre-wrap; word-wrap: break-word; }
+  pre, blockquote, aside.notice, tr, img { break-inside: avoid; }
+  h1, h2, h3 { break-after: avoid; }
+}
 """
 
 

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -977,14 +977,17 @@ def _render_html_image(block: dict[str, Any], images: dict[str, tuple[str, str]]
         entry = images.get(str(asset_id))
         if entry is not None:
             alt, src = entry
+    # `quote=True` keeps `"` out of the attribute value — this is also what lets
+    # the PDF src-sanitizer (`_sanitize_pdf_image_srcs` in cli/doc.py) match
+    # `src="..."` with a simple regex; don't drop it.
     return f'<img src="{html.escape(src, quote=True)}" alt="{html.escape(alt, quote=True)}">'
 
 
-# A concrete hex colour (`#rgb`..`#rrggbbaa`). monday stores a cell's
-# `backgroundColor` either as such a hex or as `var(--primary-background-color)`
-# (the default — left to the stylesheet). The strict match also blocks
-# attribute injection from untrusted cell content.
-_CELL_HEX_COLOR = re.compile(r"#[0-9A-Fa-f]{3,8}\Z")
+# A concrete CSS hex colour (3/4/6/8 digits — `#rgb`, `#rgba`, `#rrggbb`,
+# `#rrggbbaa`). monday stores a cell's `backgroundColor` either as such a hex or
+# as `var(--primary-background-color)` (the default — left to the stylesheet).
+# The strict match also blocks attribute injection from untrusted cell content.
+_CELL_HEX_COLOR = re.compile(r"#(?:[0-9A-Fa-f]{3,4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})\Z")
 # Non-default cell alignments worth emitting (`left` is the CSS default).
 _CELL_ALIGN = {"center", "right", "justify"}
 

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -1074,8 +1074,13 @@ def _render_html_list_item(
 ) -> str:
     text = _html_text(block.get("content"))
     if btype == "check_list":
-        checked = " checked" if _extract_checked(block.get("content")) else ""
-        text = f'<input type="checkbox" disabled{checked}> {text}'
+        # Inline box glyph (U+2611 ☑ / U+2610 ☐) rather than `<input
+        # type=checkbox>`: WeasyPrint renders a replaced form control as its own
+        # block, pushing the label onto the next line in PDF export. A glyph is
+        # plain inline text that lays out identically in browsers and WeasyPrint
+        # (the control was `disabled`/non-interactive anyway).
+        box = "☑" if _extract_checked(block.get("content")) else "☐"
+        text = f"{box} {text}"
     kids = children_of.get(str(block.get("id") or ""), [])
     inner = "".join(_render_html_blocks(kids, children_of, images)) if kids else ""
     return f"<li>{text}{inner}</li>"

--- a/src/mondo/help/boards-vs-docs.md
+++ b/src/mondo/help/boards-vs-docs.md
@@ -58,17 +58,23 @@ Pass `--with-url` on either to get URLs back.
 ## Once you've found a workdoc
 
 Render it to a file. `--format` takes `markdown`, `mdx` (JSX-safe markdown),
-or `html` (a single self-contained document). For markdown/mdx the embedded
-images are downloaded alongside the file and referenced by local filename;
-html base64-embeds them so the file is portable on its own (the raw monday
-image URLs only resolve in a logged-in browser):
+`html` (a single self-contained document), or `pdf`. For markdown/mdx the
+embedded images are downloaded alongside the file and referenced by local
+filename; html base64-embeds them so the file is portable on its own (the raw
+monday image URLs only resolve in a logged-in browser):
 
     mondo doc get --object-id <id> --format markdown --out ./doc.md
     mondo doc get --object-id <id> --format mdx --out ./doc.mdx
     mondo doc get --object-id <id> --format html --out ./doc.html
+    mondo doc get --object-id <id> --format pdf --out ./doc.pdf
     mondo doc export-markdown --object-id <id> --out ./doc.md   # server-side render
 
-Pass `--no-images` to skip the download/embed and keep the original URLs.
+`--format pdf` always requires `--out` and renders the html through WeasyPrint
+(monday has no PDF export, so it's client-side). WeasyPrint isn't bundled —
+install it on first use (`brew install weasyprint`; Windows: `pipx install
+weasyprint` + GTK), or use `--format html` and print to PDF from a browser.
+Pass `--no-images` to skip the download/embed and keep the original URLs (for
+pdf, images render empty so no network fetch happens).
 `--out` needs a render format — pairing it with `--format json` exits 2. To
 write content back — replace a doc in place, empty it, or create one inside a
 folder — see `mondo help` and the bundled `references/docs.md` (`doc set` /

--- a/src/mondo/skill/references/docs.md
+++ b/src/mondo/skill/references/docs.md
@@ -46,18 +46,22 @@ mondo doc export-markdown --doc 5095668848
 mondo doc get --object-id 5098297247 --format markdown
 mondo doc get --object-id 5098297247 --format mdx
 mondo doc get --object-id 5098297247 --format html
+
+# PDF needs an external renderer + a file target (see below):
+mondo doc get --object-id 5098297247 --format pdf --out ./spec.pdf
 ```
 
-`doc get --format` renders client-side and supports `markdown`, `mdx`, and `html`; `doc export-markdown` is monday's server-side markdown renderer (markdown only — the API offers no server-side HTML/MDX export). All print to stdout by default.
+`doc get --format` renders client-side and supports `markdown`, `mdx`, `html`, and `pdf`; `doc export-markdown` is monday's server-side markdown renderer (markdown only — the API offers no server-side HTML/MDX export). markdown/mdx/html print to stdout by default; **pdf always requires `--out`**.
 
 - **mdx** is the markdown rendering with JSX-significant characters (`<`, `{`) escaped in prose (never inside code fences); monday notice/callout boxes stay as GFM `> [!NOTE]` blockquotes.
 - **html** is a single self-contained document (inline `<style>`, base64-embedded images) — see below.
+- **pdf** renders that same self-contained html through [WeasyPrint](https://weasyprint.org/) (monday has no PDF export, so it's client-side). WeasyPrint is **not bundled** — it needs native pango/cairo libraries. If it isn't on `PATH`, `doc get --format pdf` exits non-zero with an install hint: `brew install weasyprint` (macOS/Linux) or `pipx install weasyprint` + the GTK runtime (Windows). The fallback for an agent that can't install it is `--format html` (then print to PDF from a browser).
 
 *Note:* `export-markdown` is always live (it has no per-doc cache), so `--no-cache` / `--refresh-cache` are accepted as no-ops purely for symmetry with the other doc commands.
 
 ### Write to a file (and handle embedded images)
 
-Add `--out FILE` to write the rendered doc to a file (valid for `markdown`, `mdx`, and `html`; rejected with exit 2 for `json`).
+Add `--out FILE` to write the rendered doc to a file (valid for `markdown`, `mdx`, `html`, and `pdf`; required for `pdf`; rejected with exit 2 for `json`).
 
 For **markdown** and **mdx**, embedded monday images are downloaded into the **same folder** and referenced by a local `<assetId>-<name>` filename — because the raw `protected_static` image URLs only resolve in a logged-in browser, so the bare file is useless off-platform.
 
@@ -81,7 +85,17 @@ mondo doc get --object-id 5098297247 --format html --out ./spec.html
 {"out": "spec.html", "images": 3}
 ```
 
-*Gotchas:* Pass `--no-images` to skip downloading/embedding and leave the original (browser-only) monday URLs in place — for markdown/mdx the `images` field then lists the local filenames actually written (images inside table cells are downloaded too, so references aren't orphaned).
+For **pdf**, the same embedded-image html is handed to WeasyPrint. The summary reports the engine plus the embedded image count:
+
+```bash
+mondo doc get --object-id 5098297247 --format pdf --out ./spec.pdf
+```
+
+```json
+{"out": "spec.pdf", "engine": "weasyprint", "images": 3}
+```
+
+*Gotchas:* Pass `--no-images` to skip downloading/embedding and leave the original (browser-only) monday URLs in place — for markdown/mdx the `images` field then lists the local filenames actually written (images inside table cells are downloaded too, so references aren't orphaned). For **pdf**, `--no-images` renders image blocks empty so WeasyPrint makes no network fetch.
 
 ```json
 {

--- a/tests/integration/test_live_doc_pdf.py
+++ b/tests/integration/test_live_doc_pdf.py
@@ -1,0 +1,39 @@
+"""Live integration test for `doc get --format pdf` (issue #68).
+
+PDF is produced client-side via WeasyPrint (monday has no PDF export). The test
+is doubly gated: it needs the prepared live doc (MONDO_TEST_DOC_ID) *and* a
+real `weasyprint` on PATH — CI has neither, so it skips cleanly there.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from ._helpers import invoke_json
+
+_HAS_WEASYPRINT = shutil.which("weasyprint") is not None
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _HAS_WEASYPRINT, reason="weasyprint not installed")
+def test_live_doc_get_pdf(live_test_doc_id: int, tmp_path) -> None:
+    out = tmp_path / "doc.pdf"
+    summary = invoke_json(
+        [
+            "doc",
+            "get",
+            "--object-id",
+            str(live_test_doc_id),
+            "--format",
+            "pdf",
+            "--out",
+            str(out),
+        ]
+    )
+    assert summary["engine"] == "weasyprint"
+    assert summary["out"] == str(out)
+    assert out.exists() and out.stat().st_size > 0
+    # A real PDF starts with the `%PDF-` magic.
+    assert out.read_bytes()[:5] == b"%PDF-"

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -2048,6 +2048,32 @@ class TestDocGetPdf:
         assert "svg+xml" not in captured["html"]
         assert 'src=""' in captured["html"]
 
+    def test_sanitize_pdf_image_srcs_validates_magic_bytes(self) -> None:
+        import base64
+
+        from mondo.cli.doc import _sanitize_pdf_image_srcs
+
+        def uri(mime: str, data: bytes) -> str:
+            return f"data:{mime};base64,{base64.b64encode(data).decode()}"
+
+        png = uri("image/png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 40)
+        tiff = uri("image/tiff", b"II*\x00" + b"\x00" * 40)  # inert raster — must survive
+        # SVG bytes DECLARED as png: WeasyPrint would sniff + fetch — must blank.
+        svg_as_png = uri("image/png", b'<svg xmlns="http://x"><image href="http://evil/"/></svg>')
+        declared_svg = uri("image/svg+xml", b"<svg/>")
+        html = "".join(
+            f'<img src="{s}" alt="">'
+            for s in [png, tiff, svg_as_png, declared_svg, "https://x/a.png", "file:///etc/passwd"]
+        )
+        out = _sanitize_pdf_image_srcs(html)
+        assert png in out  # real raster magic → kept
+        assert tiff in out
+        assert svg_as_png not in out  # the content-sniff SSRF bypass → blanked
+        assert declared_svg not in out
+        assert "https://x" not in out
+        assert "file://" not in out
+        assert out.count('src=""') == 4
+
     def test_pdf_missing_weasyprint_skips_image_embed(
         self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -1979,6 +1979,92 @@ class TestDocGetPdf:
         assert 'src=""' in captured["html"]
         assert "https://x/img.png" not in captured["html"]
 
+    def test_pdf_unresolved_image_url_is_blanked(
+        self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even on the default (embed) path, an image whose asset doesn't resolve
+        must not leave its (doc-content, untrusted) URL in the HTML — WeasyPrint
+        would dereference it (SSRF / file:// read). The renderer's `content.url`
+        fallback is neutralized before conversion."""
+        from mondo.cli import _pdf
+
+        captured: dict[str, str] = {}
+
+        def fake_render(html_text: str, out: Path) -> None:
+            captured["html"] = html_text
+            out.write_bytes(b"%PDF-1.7\n")
+
+        monkeypatch.setattr(_pdf, "render_pdf", fake_render)
+        # 1) doc fetch returns an image block; 2) assets(ids) resolves nothing,
+        # so embed_doc_images returns {} and the renderer falls back to the URL.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=self._doc_with_image())
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"assets": []}))
+        out = tmp_path / "doc.pdf"
+        result = runner.invoke(
+            app, ["doc", "get", "--id", "7", "--format", "pdf", "--out", str(out)]
+        )
+        assert result.exit_code == 0, result.stdout
+        assert "https://x/img.png" not in captured["html"]
+        assert 'src=""' in captured["html"]
+
+    def test_pdf_svg_data_uri_is_blanked(
+        self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `data:image/svg+xml` src must NOT survive: an SVG can reference
+        external resources that WeasyPrint would fetch, so only raster data
+        URIs are allowed through. The svg here is doc content (untrusted)."""
+        from mondo.cli import _pdf
+
+        captured: dict[str, str] = {}
+
+        def fake_render(html_text: str, out: Path) -> None:
+            captured["html"] = html_text
+            out.write_bytes(b"%PDF-1.7\n")
+
+        monkeypatch.setattr(_pdf, "render_pdf", fake_render)
+        svg = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "docs": [
+                        {
+                            "id": "7",
+                            "name": "D",
+                            "blocks": [
+                                {"id": "b1", "type": "image", "content": json.dumps({"url": svg})}
+                            ],
+                        }
+                    ]
+                }
+            ),
+        )
+        out = tmp_path / "doc.pdf"
+        result = runner.invoke(
+            app, ["doc", "get", "--id", "7", "--format", "pdf", "--out", str(out)]
+        )
+        assert result.exit_code == 0, result.stdout
+        assert "svg+xml" not in captured["html"]
+        assert 'src=""' in captured["html"]
+
+    def test_pdf_missing_weasyprint_skips_image_embed(
+        self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Preflight: with WeasyPrint absent, the command errors before the
+        image-embed network work — only the doc fetch happens, no assets(ids)."""
+        from mondo.cli import _pdf
+
+        monkeypatch.setattr(_pdf, "find_weasyprint", lambda: None)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=self._doc_with_image())
+        out = tmp_path / "doc.pdf"
+        result = runner.invoke(
+            app, ["doc", "get", "--id", "7", "--format", "pdf", "--out", str(out)]
+        )
+        assert result.exit_code != 0
+        assert len(httpx_mock.get_requests()) == 1  # doc fetch only; no assets(ids)
+        assert not out.exists()
+
 
 class TestAddMarkdownChunking:
     """Issues #59 / #63: auto-chunk large markdown and report blocks_added."""

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -1882,6 +1882,104 @@ class TestImageExportOutputGuards:
         assert json.loads(result.stdout)["images"] == []
 
 
+class TestDocGetPdf:
+    """`doc get --format pdf` — issue #68. WeasyPrint is never run for real:
+    the renderer is monkeypatched so only mondo's surface logic is exercised."""
+
+    def _doc_with_image(self) -> dict:
+        return _ok(
+            {
+                "docs": [
+                    {
+                        "id": "7",
+                        "object_id": "77",
+                        "name": "D",
+                        "blocks": [
+                            {
+                                "id": "b1",
+                                "type": "image",
+                                "content": json.dumps({"assetId": 99, "url": "https://x/img.png"}),
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    def test_pdf_requires_out(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(app, ["doc", "get", "--id", "7", "--format", "pdf"])
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_pdf_success_emits_engine(
+        self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from mondo.cli import _pdf
+
+        def fake_render(html_text: str, out: Path) -> None:
+            out.write_bytes(b"%PDF-1.7\n")
+
+        monkeypatch.setattr(_pdf, "render_pdf", fake_render)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "7", "name": "D", "blocks": []}]}),
+        )
+        out = tmp_path / "doc.pdf"
+        result = runner.invoke(
+            app, ["doc", "get", "--id", "7", "--format", "pdf", "--out", str(out)]
+        )
+        assert result.exit_code == 0, result.stdout
+        assert out.read_bytes().startswith(b"%PDF")
+        payload = json.loads(result.stdout)
+        assert payload["engine"] == "weasyprint"
+        assert payload["out"] == str(out)
+
+    def test_pdf_missing_weasyprint_errors(
+        self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from mondo.cli import _pdf
+
+        monkeypatch.setattr(_pdf, "find_weasyprint", lambda: None)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"docs": [{"id": "7", "name": "D", "blocks": []}]}),
+        )
+        out = tmp_path / "doc.pdf"
+        result = runner.invoke(
+            app, ["doc", "get", "--id", "7", "--format", "pdf", "--out", str(out)]
+        )
+        assert result.exit_code != 0
+        assert "WeasyPrint" in (result.stderr or result.stdout)
+        assert not out.exists()
+
+    def test_pdf_no_images_keeps_no_remote_url(
+        self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--no-images` must not leave a live monday URL for WeasyPrint to
+        fetch: no `assets(ids)` call, and the HTML carries an empty `src`."""
+        from mondo.cli import _pdf
+
+        captured: dict[str, str] = {}
+
+        def fake_render(html_text: str, out: Path) -> None:
+            captured["html"] = html_text
+            out.write_bytes(b"%PDF-1.7\n")
+
+        monkeypatch.setattr(_pdf, "render_pdf", fake_render)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=self._doc_with_image())
+        out = tmp_path / "doc.pdf"
+        result = runner.invoke(
+            app,
+            ["doc", "get", "--id", "7", "--format", "pdf", "--out", str(out), "--no-images"],
+        )
+        assert result.exit_code == 0, result.stdout
+        assert len(httpx_mock.get_requests()) == 1  # doc fetch only, no assets(ids)
+        assert 'src=""' in captured["html"]
+        assert "https://x/img.png" not in captured["html"]
+
+
 class TestAddMarkdownChunking:
     """Issues #59 / #63: auto-chunk large markdown and report blocks_added."""
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -981,6 +981,54 @@ class TestBlocksToHtml:
         assert "<li>☑ done</li>" in out
         assert "<li>☐ todo</li>" in out
 
+    def test_table_cell_background_color(self) -> None:
+        """monday cell `backgroundColor` (hex) is surfaced as an inline style;
+        the default CSS-var and any non-hex value are ignored, and a malicious
+        value can't break out of the attribute."""
+
+        def cell(cid: str, bg: str | None) -> dict:
+            content: dict = {}
+            if bg is not None:
+                content["backgroundColor"] = bg
+            return {"id": cid, "type": "cell", "content": content, "parent_block_id": "t"}
+
+        def text(cid: str, s: str) -> dict:
+            return {
+                "id": f"{cid}-t",
+                "type": "normal_text",
+                "content": {"deltaFormat": [{"insert": s}]},
+                "parent_block_id": cid,
+            }
+
+        blocks = [
+            {
+                "id": "t",
+                "type": "table",
+                "content": {
+                    "cells": [
+                        [{"blockId": "h0"}, {"blockId": "h1"}],
+                        [{"blockId": "c0"}, {"blockId": "c1"}],
+                    ]
+                },
+                "parent_block_id": None,
+            },
+            cell("h0", "var(--primary-background-color)"),
+            text("h0", "Day"),
+            cell("h1", '#fff" onmouseover="alert(1)'),  # injection attempt
+            text("h1", "Val"),
+            cell("c0", "#F0A1AD2B"),
+            text("c0", "2026-06-21"),
+            cell("c1", None),
+            text("c1", "ok"),
+        ]
+        out = blocks_to_html(blocks)
+        assert '<td style="background-color:#F0A1AD2B">2026-06-21</td>' in out
+        # default var, missing value, and the injection attempt → no style.
+        assert "<th>Day</th>" in out
+        assert "<td>ok</td>" in out
+        assert "onmouseover" not in out
+        assert "var(--primary-background-color)" not in out
+
     def test_code_block(self) -> None:
         block = {
             "id": "c",

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -966,7 +966,9 @@ class TestBlocksToHtml:
         out = blocks_to_html([_b("1", "numbered_list", "a"), _b("2", "numbered_list", "b")])
         assert "<ol>" in out and "</ol>" in out
 
-    def test_checklist_renders_disabled_checkbox(self) -> None:
+    def test_checklist_renders_box_glyph(self) -> None:
+        # Box glyphs, not `<input type=checkbox>` — the form control renders as
+        # its own block in WeasyPrint (PDF), breaking the label onto a new line.
         checked = {
             "id": "1",
             "type": "check_list",
@@ -975,8 +977,9 @@ class TestBlocksToHtml:
         unchecked = _b("2", "check_list", "todo")
         out = blocks_to_html([checked, unchecked])
         assert 'class="checklist"' in out
-        assert '<input type="checkbox" disabled checked>' in out
-        assert '<input type="checkbox" disabled>' in out
+        assert "<input" not in out
+        assert "<li>☑ done</li>" in out
+        assert "<li>☐ todo</li>" in out
 
     def test_code_block(self) -> None:
         block = {

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -932,6 +932,15 @@ class TestBlocksToHtml:
         assert '<h1 class="doc-title">My Doc</h1>' in out
         assert "<p>hi</p>" in out
 
+    def test_carries_print_css_for_pdf(self) -> None:
+        # PDF export (issue #68) hands this HTML to WeasyPrint, which renders
+        # print media — so the stylesheet must define page geometry and force
+        # light colors / page-break hints under @media print.
+        out = blocks_to_html([_b("p", "normal_text", "hi")])
+        assert "@page" in out
+        assert "@media print" in out
+        assert "break-inside" in out
+
     def test_headings(self) -> None:
         out = blocks_to_html(
             [

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -981,15 +981,17 @@ class TestBlocksToHtml:
         assert "<li>☑ done</li>" in out
         assert "<li>☐ todo</li>" in out
 
-    def test_table_cell_background_color(self) -> None:
-        """monday cell `backgroundColor` (hex) is surfaced as an inline style;
-        the default CSS-var and any non-hex value are ignored, and a malicious
+    def test_table_cell_background_and_alignment(self) -> None:
+        """monday cell `backgroundColor` (hex) and `alignment` are surfaced as
+        an inline style; defaults/non-hex/`left` are ignored, and a malicious
         value can't break out of the attribute."""
 
-        def cell(cid: str, bg: str | None) -> dict:
+        def cell(cid: str, bg: str | None = None, align: str | None = None) -> dict:
             content: dict = {}
             if bg is not None:
                 content["backgroundColor"] = bg
+            if align is not None:
+                content["alignment"] = align
             return {"id": cid, "type": "cell", "content": content, "parent_block_id": "t"}
 
         def text(cid: str, s: str) -> dict:
@@ -1012,22 +1014,23 @@ class TestBlocksToHtml:
                 },
                 "parent_block_id": None,
             },
-            cell("h0", "var(--primary-background-color)"),
+            cell("h0", bg="var(--primary-background-color)", align="left"),
             text("h0", "Day"),
-            cell("h1", '#fff" onmouseover="alert(1)'),  # injection attempt
+            cell("h1", bg='#fff" onmouseover="alert(1)', align="weird"),  # injection / bad value
             text("h1", "Val"),
-            cell("c0", "#F0A1AD2B"),
+            cell("c0", bg="#F0A1AD2B", align="center"),  # both, combined
             text("c0", "2026-06-21"),
-            cell("c1", None),
+            cell("c1", align="right"),  # alignment only
             text("c1", "ok"),
         ]
         out = blocks_to_html(blocks)
-        assert '<td style="background-color:#F0A1AD2B">2026-06-21</td>' in out
-        # default var, missing value, and the injection attempt → no style.
+        assert '<td style="background-color:#F0A1AD2B;text-align:center">2026-06-21</td>' in out
+        assert '<td style="text-align:right">ok</td>' in out
+        # default var + `left` (CSS default), and the injection / bad values → no style.
         assert "<th>Day</th>" in out
-        assert "<td>ok</td>" in out
         assert "onmouseover" not in out
         assert "var(--primary-background-color)" not in out
+        assert "text-align:weird" not in out
 
     def test_code_block(self) -> None:
         block = {

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1020,12 +1020,14 @@ class TestBlocksToHtml:
             text("h1", "Val"),
             cell("c0", bg="#F0A1AD2B", align="center"),  # both, combined
             text("c0", "2026-06-21"),
-            cell("c1", align="right"),  # alignment only
+            cell("c1", bg="#abcde", align="right"),  # invalid 5-digit hex → align only
             text("c1", "ok"),
         ]
         out = blocks_to_html(blocks)
         assert '<td style="background-color:#F0A1AD2B;text-align:center">2026-06-21</td>' in out
+        # 5-digit hex is invalid CSS → dropped; alignment still applied.
         assert '<td style="text-align:right">ok</td>' in out
+        assert "#abcde" not in out
         # default var + `left` (CSS default), and the injection / bad values → no style.
         assert "<th>Day</th>" in out
         assert "onmouseover" not in out

--- a/tests/unit/test_pdf.py
+++ b/tests/unit/test_pdf.py
@@ -61,7 +61,27 @@ def test_render_pdf_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     argv = captured["argv"]
     assert argv[0] == "/usr/bin/weasyprint"
     assert argv[1].endswith("input.html")
-    assert argv[2].endswith("output.pdf")
+    assert argv[2].endswith(".pdf")  # temp output on out's filesystem
+
+
+def test_render_pdf_failure_preserves_existing_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failed render must not clobber a PDF already at `out` (atomic install)."""
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="nope\n")
+
+    monkeypatch.setattr(_pdf, "find_weasyprint", lambda: "/usr/bin/weasyprint")
+    monkeypatch.setattr(_pdf.subprocess, "run", fake_run)
+
+    out = tmp_path / "doc.pdf"
+    out.write_bytes(b"OLD-PDF")
+    with pytest.raises(MondoError):
+        _pdf.render_pdf("<html></html>", out)
+    assert out.read_bytes() == b"OLD-PDF"  # untouched
+    # No temp .pdf left behind in the output dir.
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["doc.pdf"]
 
 
 def test_render_pdf_nonzero_exit_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/test_pdf.py
+++ b/tests/unit/test_pdf.py
@@ -1,0 +1,104 @@
+"""Unit tests for the WeasyPrint-backed PDF renderer (`mondo.cli._pdf`).
+
+WeasyPrint is never invoked for real here: `subprocess.run` is monkeypatched to
+a fake that writes (or refuses to write) the output file, so the temp-file
+handling, argv, output verification, and failure paths are exercised without a
+real converter on CI.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mondo.api.errors import MondoError
+from mondo.cli import _pdf
+
+
+def test_find_weasyprint_uses_which(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_pdf.shutil, "which", lambda name: "/opt/bin/weasyprint")
+    assert _pdf.find_weasyprint() == "/opt/bin/weasyprint"
+    monkeypatch.setattr(_pdf.shutil, "which", lambda name: None)
+    assert _pdf.find_weasyprint() is None
+
+
+def test_install_hint_branches_per_os(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_pdf.platform, "system", lambda: "Darwin")
+    assert "brew install weasyprint" in _pdf.install_hint()
+    monkeypatch.setattr(_pdf.platform, "system", lambda: "Windows")
+    win = _pdf.install_hint()
+    assert "brew" not in win
+    assert "pipx" in win or "pip install" in win
+
+
+def test_render_pdf_missing_weasyprint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(_pdf, "find_weasyprint", lambda: None)
+    with pytest.raises(MondoError) as exc:
+        _pdf.render_pdf("<html></html>", tmp_path / "out.pdf")
+    assert "WeasyPrint" in str(exc.value)
+    assert not (tmp_path / "out.pdf").exists()
+
+
+def test_render_pdf_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        captured["argv"] = argv
+        # argv = [exe, input_html, output_pdf]; emulate WeasyPrint writing a PDF.
+        Path(argv[2]).write_bytes(b"%PDF-1.7\n...")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(_pdf, "find_weasyprint", lambda: "/usr/bin/weasyprint")
+    monkeypatch.setattr(_pdf.subprocess, "run", fake_run)
+
+    out = tmp_path / "nested" / "doc.pdf"
+    _pdf.render_pdf("<html><body>hi</body></html>", out)
+
+    assert out.exists()
+    assert out.read_bytes().startswith(b"%PDF")
+    argv = captured["argv"]
+    assert argv[0] == "/usr/bin/weasyprint"
+    assert argv[1].endswith("input.html")
+    assert argv[2].endswith("output.pdf")
+
+
+def test_render_pdf_nonzero_exit_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="boom: bad css\n")
+
+    monkeypatch.setattr(_pdf, "find_weasyprint", lambda: "/usr/bin/weasyprint")
+    monkeypatch.setattr(_pdf.subprocess, "run", fake_run)
+
+    out = tmp_path / "doc.pdf"
+    with pytest.raises(MondoError) as exc:
+        _pdf.render_pdf("<html></html>", out)
+    assert "boom: bad css" in str(exc.value)
+    assert not out.exists()
+
+
+def test_render_pdf_empty_output_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        Path(argv[2]).write_bytes(b"")  # exit 0 but produced nothing usable
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(_pdf, "find_weasyprint", lambda: "/usr/bin/weasyprint")
+    monkeypatch.setattr(_pdf.subprocess, "run", fake_run)
+
+    out = tmp_path / "doc.pdf"
+    with pytest.raises(MondoError):
+        _pdf.render_pdf("<html></html>", out)
+    assert not out.exists()
+
+
+def test_render_pdf_timeout_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        raise subprocess.TimeoutExpired(argv, 1)
+
+    monkeypatch.setattr(_pdf, "find_weasyprint", lambda: "/usr/bin/weasyprint")
+    monkeypatch.setattr(_pdf.subprocess, "run", fake_run)
+
+    with pytest.raises(MondoError) as exc:
+        _pdf.render_pdf("<html></html>", tmp_path / "doc.pdf")
+    assert "timed out" in str(exc.value).lower()


### PR DESCRIPTION
Closes #68.

## What

Adds `mondo doc get --format pdf --out <file.pdf>`. monday's API has no PDF export, so PDF is produced **client-side**: the doc is rendered to the existing self-contained HTML (`blocks_to_html`, base64-embedded images + print CSS) and handed to [WeasyPrint](https://weasyprint.org/).

## Why WeasyPrint, not a bundled library

WeasyPrint needs native pango/cairo libraries that don't fit the pure-Python PyInstaller `--onedir` build, so it is **not bundled**. It's detected on `PATH` via `shutil.which` and the user is prompted to install it **on first use** (`brew install weasyprint`; `pipx install weasyprint` + GTK on Windows). One engine, one flow — no registry, no fallback converter. If WeasyPrint is absent, the command exits non-zero with an install hint pointing at `--format html` (print-to-PDF from a browser) as the manual route.

> libharu was considered and rejected: it's a low-level PDF *construction* library (no HTML/Markdown input), has no maintained Python binding, can't be bundled, and ships no CLI to shell out to — it would mean writing our own layout engine *and* taking a native dep.

## Details

- new `mondo.cli._pdf`: `find_weasyprint` / `install_hint` / `render_pdf` — subprocess discipline (`shell=False`, `stdin=DEVNULL`, 120s timeout), temp-dir isolation, non-empty-output verification, atomic move into place
- `--format pdf` **requires `--out`**; `--no-images` renders image blocks with empty `src` so WeasyPrint makes **no network fetch**
- print CSS (`@page` + `@media print`: force light colors, drop on-screen centering, wrap code, page-break hints) appended to the shared doc stylesheet — also improves browser printing of `--format html`
- emits `{out, engine: "weasyprint", images}`

## Docs

README, `mondo help` doc topic (`boards-vs-docs`), bundled skill reference (`references/docs.md`), and the generated `docs/output-contract-matrix.{md,json}` all updated.

## Tests

- **Unit** ([test_pdf.py](../blob/feat/doc-pdf-export/tests/unit/test_pdf.py), `TestDocGetPdf` in test_cli_doc.py, print-CSS assertion in test_docs.py) — WeasyPrint monkeypatched: success, missing-engine, non-zero exit, empty output, timeout, `--out` required, `--no-images` no-leak.
- **Live** ([test_live_doc_pdf.py](../blob/feat/doc-pdf-export/tests/integration/test_live_doc_pdf.py)) — gated on a real `weasyprint` on PATH + `MONDO_TEST_DOC_ID`; **verified locally** producing a real `%PDF` from the playground doc.
- Full non-integration suite: **1778 passed**, mypy + ruff clean.

## Reviews

Plan was reviewed by Codex (gpt-5.5, xhigh) before implementation; this PR will additionally get `/security-review`, `/code-review`, `/simplify`, and a second Codex pass.