### PR TITLE
feat(export): board html/pdf/grouped-md, xlsx styling, filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,14 +411,39 @@ group_column: group      # optional; defaults to 'group'
 mondo export board --board 1234567890 --format csv                        # to stdout
 mondo export board --board 1234567890 --format json --out board.json
 mondo export board --board 1234567890 --format xlsx --out board.xlsx      # required for xlsx
-mondo export board --board 1234567890 --format md   --include-subitems    # markdown pipe table
-mondo export board --board 1234567890 --format tsv  --max-items 1000
+mondo export board --board 1234567890 --format md   --include-subitems    # grouped markdown
+mondo export board --board 1234567890 --format html --out board.html      # self-contained HTML
+mondo export board --board 1234567890 --format pdf  --out board.pdf       # required for pdf
+mondo export board --board 1234567890 --format csv  --filter status=Done --columns status,date4
+mondo export board --board 1234567890 --format md   --group topics        # one group only
 ```
 
-Formats: `csv | tsv | json | xlsx | md`. Column headers are the board's column
-titles (archived columns are dropped). With `--include-subitems`, the CSV /
-TSV emit a second blank-line-separated block, JSON gets a `subitems` array,
-Markdown gets a `### Subitems` section, and XLSX gets a second worksheet.
+Formats: `csv | tsv | json | xlsx | md | html | pdf`. Column headers are the
+board's column titles (archived columns are dropped). monday has no native
+board-export API, so every format is rendered client-side.
+
+The human-readable formats (`md`, `html`, `pdf`) are **grouped by default**: the
+output opens with a board-name title and then one section per group that contains
+items (in the order items appear; empty groups are omitted), each followed by a
+table of that group's items (the `group` column becomes the section heading, so
+it's not a table column). Pass `--flat` to keep the title but render a single
+table with a `group` column instead of per-group sections. `--flat` has no effect
+on `csv/tsv/json/xlsx`.
+
+Filtering and projection apply to all formats: `--filter COL=VAL` (repeatable)
+narrows server-side (status/dropdown labels resolve to indices), `--group <id>`
+is sugar for `--filter group=<id>`, and `--columns a,b,c` projects client-side to
+a subset of columns by id or title (case-insensitive); the meta columns
+(`id/name/state/group`) are always kept.
+
+`--format pdf` always requires `--out` and renders the self-contained HTML
+through [WeasyPrint](https://weasyprint.org/) — install it on first use
+(`brew install weasyprint`), or fall back to `--format html` and print to PDF
+from a browser. `--format html` defaults to stdout; `--out` is optional.
+
+With `--include-subitems`, the CSV / TSV emit a second blank-line-separated
+block, JSON gets a `subitems` array, the human formats append a trailing
+`Subitems` section, and XLSX gets a second worksheet.
 
 ### Users
 

--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -1409,8 +1409,32 @@ EXAMPLES: dict[str, list[Example]] = {
             "--out board.xlsx --include-subitems",
         ),
         Example(
-            "Markdown table (capped at 1000 rows)",
+            "Grouped markdown (board title + one ## section per group — the default)",
             "mondo export board --board 1234567890 --format md --max-items 1000",
+        ),
+        Example(
+            "Self-contained HTML to stdout",
+            "mondo export board --board 1234567890 --format html --out board.html",
+        ),
+        Example(
+            "PDF via WeasyPrint (requires --out)",
+            "mondo export board --board 1234567890 --format pdf --out board.pdf",
+        ),
+        Example(
+            "Single flat table instead of per-group sections",
+            "mondo export board --board 1234567890 --format md --flat",
+        ),
+        Example(
+            "Server-side filter by a status column",
+            "mondo export board --board 1234567890 --format csv --filter status=Done",
+        ),
+        Example(
+            "Just one group (sugar for --filter group=<id>)",
+            "mondo export board --board 1234567890 --format md --group topics",
+        ),
+        Example(
+            "Project to a subset of columns (by id or title)",
+            "mondo export board --board 1234567890 --format csv --columns status,date4",
         ),
     ],
     # --- import ------------------------------------------------------------

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -158,6 +158,7 @@ def _sanitize_pdf_image_srcs(html_text: str) -> str:
         html_text,
     )
 
+
 # The `--doc` XOR `--object-id` pair shared by every doc-targeting subcommand
 # (same shared-option pattern as the Poll*Opt trio in `mondo.cli._exec`).
 DocIdOpt = Annotated[

--- a/src/mondo/cli/export.py
+++ b/src/mondo/cli/export.py
@@ -1,29 +1,34 @@
-"""`mondo export` command group — dump a board to CSV / JSON / XLSX / Markdown.
+"""`mondo export` command group — dump a board to CSV / TSV / JSON / XLSX / MD / HTML / PDF.
 
 Uses cursor pagination (reused from `item list`) plus a one-shot column-title
-fetch for readable headers. Formats:
+fetch for readable headers. monday's API has no native board-export endpoint —
+every format is rendered client-side. Formats:
 
 - csv / tsv: RFC 4180, one row per item, columns = meta + one-per-board-column
 - json: list of objects keyed by column id + metadata
-- xlsx: one sheet for items (+ one for subitems if --include-subitems)
-- md:  GFM-style pipe table
+- xlsx: one styled sheet for items (+ one for subitems if --include-subitems)
+- md / html / pdf: human-readable; grouped per monday group by default
+  (one section per group), or a single flat table with `--flat`. html reuses
+  the doc stylesheet; pdf renders that HTML through WeasyPrint.
 
-Output defaults to stdout for csv/tsv/json/md, and requires `--out` for xlsx
-(binary format).
+Output defaults to stdout for csv/tsv/json/md/html, and requires `--out` for
+xlsx and pdf (binary / file formats).
 """
 
 from __future__ import annotations
 
 import csv
+import html
 import io
 import json
+from collections import Counter
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import typer
 
-from mondo.api.errors import MondoError, NotFoundError
+from mondo.api.errors import MondoError, NotFoundError, UsageError
 from mondo.api.pagination import MAX_PAGE_SIZE, iter_items_page
 from mondo.api.queries import (
     ITEMS_PAGE_INITIAL_WITH_SUBITEMS,
@@ -32,8 +37,11 @@ from mondo.api.queries import (
 from mondo.cli._column_cache import fetch_board_columns
 from mondo.cli._examples import epilog_for
 from mondo.cli._exec import client_or_exit, handle_mondo_error_or_exit, usage_error_or_exit
+from mondo.cli._pdf import render_pdf
 from mondo.cli._resolve import resolve_required_id
 from mondo.cli.context import GlobalOpts
+from mondo.docs import _HTML_STYLE
+from mondo.services.items import build_query_params, split_filter_expr
 
 if TYPE_CHECKING:
     from mondo.api.client import MondayClient
@@ -50,25 +58,103 @@ class ExportFormat(StrEnum):
     json = "json"
     xlsx = "xlsx"
     md = "md"
+    html = "html"
+    pdf = "pdf"
 
 
 META_FIELDS = ("id", "name", "state", "group")
+# Formats that render a board-name title and (by default) per-group sections.
+_GROUPED_FORMATS = (ExportFormat.md, ExportFormat.html, ExportFormat.pdf)
+# Binary / file-only formats that cannot stream to stdout (require --out).
+_BINARY_FORMATS = (ExportFormat.xlsx, ExportFormat.pdf)
+
+BOARD_NAME_QUERY = "query ($board: ID!) { boards(ids: [$board]) { name } }"
 
 
 # ----- helpers -----
 
 
 def _fetch_columns(opts: GlobalOpts, client: MondayClient, board_id: int) -> list[dict[str, Any]]:
-    """Return [{id, title, type}] for the board, in display order."""
+    """Return the board's full (non-archived) column defs, in display order.
+
+    Full defs (with `settings_str`) are kept so `build_query_params` can resolve
+    `--filter` labels; the renderers only read `id`/`title`.
+    """
     try:
         cols = fetch_board_columns(opts, client, board_id)
     except NotFoundError:
         raise typer.Exit(code=6) from None
-    return [
-        {"id": c.get("id"), "title": c.get("title"), "type": c.get("type")}
-        for c in cols
-        if not c.get("archived")
-    ]
+    return [c for c in cols if not c.get("archived")]
+
+
+def _fetch_board_name(client: MondayClient, board_id: int) -> str:
+    """Best-effort board name for the md/html/pdf title.
+
+    Never a hard error: any failure or empty result falls back to `Board <id>`.
+    """
+    try:
+        result = client.execute(BOARD_NAME_QUERY, {"board": board_id})
+    except MondoError:
+        return f"Board {board_id}"
+    boards = (result.get("data") or {}).get("boards") or []
+    first = boards[0] if boards else None
+    name = first.get("name") if isinstance(first, dict) else None
+    return name or f"Board {board_id}"
+
+
+def _resolve_columns(columns: list[dict[str, Any]], spec: str) -> list[dict[str, Any]]:
+    """Project `columns` to the `--columns` subset, preserving requested order.
+
+    Each comma-separated token matches by column id (exact) or by title
+    (case-insensitive). A title shared by several columns selects them all. An
+    unmatched token raises `UsageError` naming it.
+    """
+    by_id = {str(c.get("id")).lower(): c for c in columns}
+    by_title: dict[str, list[dict[str, Any]]] = {}
+    for c in columns:
+        by_title.setdefault(str(c.get("title")).lower(), []).append(c)
+    out: list[dict[str, Any]] = []
+    for raw in spec.split(","):
+        tok = raw.strip()
+        if not tok:
+            continue
+        key = tok.lower()
+        matches = [by_id[key]] if key in by_id else by_title.get(key, [])
+        if not matches:
+            raise UsageError(f"--columns: no column matches {tok!r}.")
+        for col in matches:
+            if col not in out:
+                out.append(col)
+    if not out:
+        raise UsageError("--columns expects a comma-separated list of column ids.")
+    return out
+
+
+def _column_labels(columns: list[dict[str, Any]]) -> list[str]:
+    """Display label per column, made unique so rows can be keyed by it.
+
+    Rows are dicts keyed by these labels, so a label must not collide with
+    another column's or with a meta field (`id`/`name`/`state`/`group`) — else
+    one column's data would silently overwrite another's. monday allows
+    duplicate column titles, so any title that repeats, or that shadows a meta
+    field, is suffixed with its (unique) column id. Unique, non-shadowing titles
+    are kept verbatim, so the common case is unchanged.
+    """
+    titles = [str(c.get("title")) for c in columns]
+    counts = Counter(titles)
+    labels: list[str] = []
+    for col, title in zip(columns, titles, strict=True):
+        if counts[title] > 1 or title in META_FIELDS:
+            labels.append(f"{title} ({col.get('id')})")
+        else:
+            labels.append(title)
+    return labels
+
+
+def _group_key(item: dict[str, Any]) -> tuple[str | None, str]:
+    """(group id, group title) for an item — id buckets sections, title displays."""
+    group = item.get("group") or {}
+    return (group.get("id"), group.get("title") or "")
 
 
 def _column_text(item: dict[str, Any], col_id: str) -> str:
@@ -78,21 +164,26 @@ def _column_text(item: dict[str, Any], col_id: str) -> str:
     return ""
 
 
-def _item_row(item: dict[str, Any], columns: list[dict[str, Any]]) -> dict[str, Any]:
-    """Flat dict: {meta fields + one key per column title}."""
+def _item_row(
+    item: dict[str, Any], columns: list[dict[str, Any]], labels: list[str]
+) -> dict[str, Any]:
+    """Flat dict: meta fields + one key per column (keyed by its display label)."""
     row: dict[str, Any] = {
         "id": item.get("id"),
         "name": item.get("name"),
         "state": item.get("state"),
         "group": (item.get("group") or {}).get("title"),
     }
-    for col in columns:
-        row[col["title"]] = _column_text(item, col["id"])
+    for col, label in zip(columns, labels, strict=True):
+        row[label] = _column_text(item, col["id"])
     return row
 
 
 def _subitem_row(
-    subitem: dict[str, Any], parent: dict[str, Any], columns: list[dict[str, Any]]
+    subitem: dict[str, Any],
+    parent: dict[str, Any],
+    columns: list[dict[str, Any]],
+    labels: list[str],
 ) -> dict[str, Any]:
     row: dict[str, Any] = {
         "parent_item_id": parent.get("id"),
@@ -101,8 +192,8 @@ def _subitem_row(
         "name": subitem.get("name"),
         "state": subitem.get("state"),
     }
-    for col in columns:
-        row[col["title"]] = _column_text(subitem, col["id"])
+    for col, label in zip(columns, labels, strict=True):
+        row[label] = _column_text(subitem, col["id"])
     return row
 
 
@@ -128,14 +219,105 @@ def _write_json(payload: Any, stream: Any) -> None:
     stream.write("\n")
 
 
-def _write_markdown(rows: list[dict[str, Any]], headers: list[str], stream: Any) -> None:
+def _md_table(rows: list[dict[str, Any]], headers: list[str], stream: Any) -> None:
     def esc(v: Any) -> str:
         return str(v if v is not None else "").replace("|", "\\|").replace("\n", " ")
 
-    stream.write("| " + " | ".join(headers) + " |\n")
+    stream.write("| " + " | ".join(esc(h) for h in headers) + " |\n")
     stream.write("|" + "|".join(["---"] * len(headers)) + "|\n")
     for row in rows:
         stream.write("| " + " | ".join(esc(row.get(h, "")) for h in headers) + " |\n")
+
+
+def _write_markdown(
+    item_rows: list[dict[str, Any]],
+    col_labels: list[str],
+    group_keys: list[tuple[str | None, str]],
+    subitem_rows: list[dict[str, Any]] | None,
+    subitem_headers: list[str] | None,
+    board_name: str,
+    flat: bool,
+    stream: Any,
+) -> None:
+    stream.write(f"# {board_name}\n\n")
+    if flat:
+        _md_table(item_rows, [*META_FIELDS, *col_labels], stream)
+    else:
+        headers = ["id", "name", "state", *col_labels]
+        for title, group_rows in _group_rows(item_rows, group_keys):
+            stream.write(f"## {title}\n\n")
+            _md_table(group_rows, headers, stream)
+            stream.write("\n")
+    if subitem_rows is not None and subitem_headers is not None:
+        # Leading blank line: in flat mode the items table ends flush against
+        # this heading, and GFM requires a blank line before a heading.
+        stream.write("\n## Subitems\n\n")
+        _md_table(subitem_rows, subitem_headers, stream)
+
+
+def _html_table(rows: list[dict[str, Any]], headers: list[str], stream: Any) -> None:
+    def esc(v: Any) -> str:
+        return html.escape(str(v if v is not None else ""))
+
+    stream.write("<table>\n<thead>\n<tr>")
+    stream.write("".join(f"<th>{esc(h)}</th>" for h in headers))
+    stream.write("</tr>\n</thead>\n<tbody>\n")
+    for row in rows:
+        stream.write("<tr>")
+        stream.write("".join(f"<td>{esc(row.get(h, ''))}</td>" for h in headers))
+        stream.write("</tr>\n")
+    stream.write("</tbody>\n</table>\n")
+
+
+def _render_board_html(
+    item_rows: list[dict[str, Any]],
+    col_labels: list[str],
+    group_keys: list[tuple[str | None, str]],
+    subitem_rows: list[dict[str, Any]] | None,
+    subitem_headers: list[str] | None,
+    board_name: str,
+    flat: bool,
+) -> str:
+    body = io.StringIO()
+    body.write(f'<h1 class="doc-title">{html.escape(board_name)}</h1>\n')
+    if flat:
+        _html_table(item_rows, [*META_FIELDS, *col_labels], body)
+    else:
+        headers = ["id", "name", "state", *col_labels]
+        for title, group_rows in _group_rows(item_rows, group_keys):
+            body.write(f"<h2>{html.escape(title)}</h2>\n")
+            _html_table(group_rows, headers, body)
+    if subitem_rows is not None and subitem_headers is not None:
+        body.write("<h2>Subitems</h2>\n")
+        _html_table(subitem_rows, subitem_headers, body)
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        f"<title>{html.escape(board_name)}</title>\n"
+        f"<style>\n{_HTML_STYLE}</style>\n</head>\n<body>\n"
+        f"{body.getvalue()}</body>\n</html>\n"
+    )
+
+
+def _group_rows(
+    item_rows: list[dict[str, Any]], group_keys: list[tuple[str | None, str]]
+) -> list[tuple[str, list[dict[str, Any]]]]:
+    """Bucket rows by group id (in first-seen / board order), yielding (title, rows).
+
+    Bucketing on the stable group id keeps two distinct groups that share a
+    title as separate sections; the title is carried only for the heading. Rows
+    with no group id fall back to bucketing by title.
+    """
+    order: list[Any] = []
+    buckets: dict[Any, tuple[str, list[dict[str, Any]]]] = {}
+    for row, (gid, gtitle) in zip(item_rows, group_keys, strict=True):
+        key = gid if gid is not None else ("title", gtitle)
+        if key not in buckets:
+            buckets[key] = (gtitle, [])
+            order.append(key)
+        buckets[key][1].append(row)
+    return [buckets[k] for k in order]
 
 
 def _write_xlsx(
@@ -146,19 +328,32 @@ def _write_xlsx(
     out_path: Path,
 ) -> None:
     from openpyxl import Workbook  # type: ignore[import-untyped]
+    from openpyxl.styles import Font  # type: ignore[import-untyped]
+    from openpyxl.utils import get_column_letter  # type: ignore[import-untyped]
+
+    def fill_sheet(ws: Any, headers: list[str], rows: list[dict[str, Any]]) -> None:
+        ws.append(headers)
+        for row in rows:
+            ws.append([row.get(h, "") for h in headers])
+        for cell in ws[1]:
+            cell.font = Font(bold=True)
+        ws.freeze_panes = "A2"
+        ws.auto_filter.ref = ws.dimensions
+        for idx, header in enumerate(headers, start=1):
+            longest = max(
+                (len(str(row.get(header, ""))) for row in rows),
+                default=0,
+            )
+            width = min(max(len(header), longest) + 2, 60)
+            ws.column_dimensions[get_column_letter(idx)].width = width
 
     wb = Workbook()
     ws = wb.active
     assert ws is not None
     ws.title = "items"
-    ws.append(items_headers)
-    for row in items_rows:
-        ws.append([row.get(h, "") for h in items_headers])
+    fill_sheet(ws, items_headers, items_rows)
     if subitems_rows is not None and subitems_headers is not None:
-        sws = wb.create_sheet("subitems")
-        sws.append(subitems_headers)
-        for row in subitems_rows:
-            sws.append([row.get(h, "") for h in subitems_headers])
+        fill_sheet(wb.create_sheet("subitems"), subitems_headers, subitems_rows)
     wb.save(out_path)
 
 
@@ -176,13 +371,40 @@ def board_cmd(
         ExportFormat.csv,
         "--format",
         "-f",
-        help="Output format.",
+        help="Output format: csv, tsv, json, xlsx, md, html, pdf.",
         case_sensitive=False,
     ),
     out: Path | None = typer.Option(
         None,
         "--out",
-        help="Output file path. Required for xlsx. Omit to write to stdout.",
+        help="Output file path. Required for xlsx and pdf. Omit to write to stdout "
+        "(csv/tsv/json/md/html).",
+    ),
+    flat: bool = typer.Option(
+        False,
+        "--flat",
+        help="md/html/pdf: emit a single flat table (with a `group` column) "
+        "instead of one section per group. No effect on csv/tsv/json/xlsx.",
+    ),
+    group_id: str | None = typer.Option(
+        None,
+        "--group",
+        help="Restrict to one group (alias for --filter group=<id>).",
+        rich_help_panel="Filters",
+    ),
+    filter_expr: list[str] | None = typer.Option(
+        None,
+        "--filter",
+        help="Server-side filter rule like 'status=Done' or 'status!=Stuck' (repeatable).",
+        rich_help_panel="Filters",
+    ),
+    columns_sel: str | None = typer.Option(
+        None,
+        "--columns",
+        metavar="COL1,COL2",
+        help="Project to these columns only (by id or title, case-insensitive). "
+        "Meta columns (id/name/state/group) are always kept.",
+        rich_help_panel="Filters",
     ),
     include_subitems: bool = typer.Option(
         False, "--include-subitems", help="Also export each item's subitems."
@@ -196,13 +418,51 @@ def board_cmd(
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     board_id = resolve_required_id(board_pos, board_flag, flag_name="--board", resource="board")
 
-    if fmt is ExportFormat.xlsx and out is None:
-        usage_error_or_exit("xlsx is a binary format; pass --out PATH.")
+    if fmt in _BINARY_FORMATS and out is None:
+        usage_error_or_exit(f"{fmt.value} is a binary format; pass --out PATH.")
+
+    # --group is sugar over --filter group=<id>; merge it in.
+    if group_id is not None:
+        filter_expr = [*(filter_expr or []), f"group={group_id}"]
+
+    # Fail fast on malformed --filter before opening the client (usage = exit 2).
+    parsed_filters: list[tuple[str, str, str]] = []
+    if filter_expr:
+        try:
+            parsed_filters = [split_filter_expr(f) for f in filter_expr]
+        except UsageError as e:
+            usage_error_or_exit(str(e))
+
+    # Preflight WeasyPrint after local arg validation but before any network
+    # work: a malformed --filter still surfaces first, and a first-time user
+    # without WeasyPrint gets the install hint without paying for a board fetch
+    # (matches the doc-export PDF path).
+    if fmt is ExportFormat.pdf:
+        from mondo.cli._pdf import find_weasyprint, install_hint
+
+        if find_weasyprint() is None:
+            handle_mondo_error_or_exit(MondoError(install_hint()))
 
     client = client_or_exit(opts)
     try:
         with client:
             columns = _fetch_columns(opts, client, board_id)
+
+            # Build --filter params from the FULL column set: label resolution
+            # must work even when --columns projects the filtered column away.
+            column_defs = {c["id"]: c for c in columns}
+            query_params = build_query_params(parsed_filters, None, column_defs, board_id=board_id)
+
+            # --columns narrows only what's rendered, not what's filtered on.
+            render_columns = columns
+            if columns_sel is not None:
+                try:
+                    render_columns = _resolve_columns(columns, columns_sel)
+                except UsageError as e:
+                    usage_error_or_exit(str(e))
+
+            board_name = _fetch_board_name(client, board_id) if fmt in _GROUPED_FORMATS else ""
+
             query_initial = None
             query_next = None
             if include_subitems:
@@ -213,6 +473,8 @@ def board_cmd(
                 "limit": limit,
                 "max_items": max_items,
             }
+            if query_params is not None:
+                iterator_kwargs["query_params"] = query_params
             if query_initial is not None and query_next is not None:
                 iterator_kwargs["query_initial"] = query_initial
                 iterator_kwargs["query_next"] = query_next
@@ -221,58 +483,97 @@ def board_cmd(
     except MondoError as e:
         handle_mondo_error_or_exit(e)
 
-    col_titles = [c["title"] for c in columns]
-    item_headers = [*META_FIELDS, *col_titles]
-    item_rows = [_item_row(it, columns) for it in items]
+    col_labels = _column_labels(render_columns)
+    item_rows = [_item_row(it, render_columns, col_labels) for it in items]
+    group_keys = [_group_key(it) for it in items]
 
     subitem_headers: list[str] | None = None
     subitem_rows: list[dict[str, Any]] | None = None
     if include_subitems:
-        subitem_headers = ["parent_item_id", "parent_item_name", "id", "name", "state", *col_titles]
+        subitem_headers = ["parent_item_id", "parent_item_name", "id", "name", "state", *col_labels]
         subitem_rows = []
         for parent in items:
             for sub in parent.get("subitems") or []:
-                subitem_rows.append(_subitem_row(sub, parent, columns))
+                subitem_rows.append(_subitem_row(sub, parent, render_columns, col_labels))
 
-    _dispatch(fmt, item_rows, item_headers, subitem_rows, subitem_headers, out)
+    _dispatch(
+        fmt,
+        item_rows,
+        col_labels,
+        group_keys,
+        subitem_rows,
+        subitem_headers,
+        board_name,
+        flat,
+        out,
+    )
 
 
 def _dispatch(
     fmt: ExportFormat,
     item_rows: list[dict[str, Any]],
-    item_headers: list[str],
+    col_labels: list[str],
+    group_keys: list[tuple[str | None, str]],
     subitem_rows: list[dict[str, Any]] | None,
     subitem_headers: list[str] | None,
+    board_name: str,
+    flat: bool,
     out: Path | None,
 ) -> None:
+    item_headers = [*META_FIELDS, *col_labels]
     if fmt is ExportFormat.xlsx:
         assert out is not None
         _write_xlsx(item_rows, item_headers, subitem_rows, subitem_headers, out)
         return
 
+    if fmt is ExportFormat.pdf:
+        assert out is not None
+        html_text = _render_board_html(
+            item_rows, col_labels, group_keys, subitem_rows, subitem_headers, board_name, flat
+        )
+        try:
+            render_pdf(html_text, out)
+        except MondoError as e:
+            handle_mondo_error_or_exit(e)
+        return
+
     buf: Any = out.open("w", encoding="utf-8", newline="") if out is not None else io.StringIO()
 
     try:
-        if fmt is ExportFormat.csv:
-            _write_csv(item_rows, item_headers, ",", buf)
+        if fmt in (ExportFormat.csv, ExportFormat.tsv):
+            delim = "," if fmt is ExportFormat.csv else "\t"
+            _write_csv(item_rows, item_headers, delim, buf)
             if subitem_rows is not None and subitem_headers is not None:
                 buf.write("\n")
-                _write_csv(subitem_rows, subitem_headers, ",", buf)
-        elif fmt is ExportFormat.tsv:
-            _write_csv(item_rows, item_headers, "\t", buf)
-            if subitem_rows is not None and subitem_headers is not None:
-                buf.write("\n")
-                _write_csv(subitem_rows, subitem_headers, "\t", buf)
+                _write_csv(subitem_rows, subitem_headers, delim, buf)
         elif fmt is ExportFormat.json:
             payload: dict[str, Any] = {"items": item_rows}
             if subitem_rows is not None:
                 payload["subitems"] = subitem_rows
             _write_json(payload, buf)
         elif fmt is ExportFormat.md:
-            _write_markdown(item_rows, item_headers, buf)
-            if subitem_rows is not None and subitem_headers is not None:
-                buf.write("\n### Subitems\n\n")
-                _write_markdown(subitem_rows, subitem_headers, buf)
+            _write_markdown(
+                item_rows,
+                col_labels,
+                group_keys,
+                subitem_rows,
+                subitem_headers,
+                board_name,
+                flat,
+                buf,
+            )
+        elif fmt is ExportFormat.html:
+            buf.write(
+                _render_board_html(
+                    item_rows,
+                    col_labels,
+                    group_keys,
+                    subitem_rows,
+                    subitem_headers,
+                    board_name,
+                    flat,
+                )
+            )
     finally:
         if out is not None:
             buf.close()

--- a/src/mondo/docs.py
+++ b/src/mondo/docs.py
@@ -1029,9 +1029,7 @@ def _render_html_table(
     if not isinstance(cells_matrix, list) or not cells_matrix:
         return None
 
-    cells_by_id = {
-        str(b.get("id")): b for b in children_of.get(str(block.get("id") or ""), [])
-    }
+    cells_by_id = {str(b.get("id")): b for b in children_of.get(str(block.get("id") or ""), [])}
     # (inner_html, style_attr) per cell.
     grid: list[list[tuple[str, str]]] = []
     for row in cells_matrix:

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -58,7 +58,7 @@ Consult these *before* improvising. Each is a Goal / Command / Output / Gotcha s
 - `references/docs.md` — workspace docs **and** doc-column ops; markdown round-trip; create/append/clear.
 - `references/files.md` — upload to file columns, attach to updates, download assets.
 - `references/workspaces-and-folders.md` — workspace lookup, folder tree, create / move / delete folders.
-- `references/bulk.md` — `--batch` envelopes, `mondo export` / `mondo import` for CSV/XLSX/JSON/Markdown round-trips.
+- `references/bulk.md` — `--batch` envelopes, `mondo export` / `mondo import` for CSV/TSV/XLSX/JSON/Markdown/HTML/PDF (grouped-by-default for md/html/pdf; `--flat`, `--group`, `--filter`, `--columns`).
 - `references/admin.md` — users, teams, webhooks, tags, activity logs, favorites, notify, validation, complexity.
 
 ## Operating norms (every command obeys these)

--- a/src/mondo/skill/references/bulk.md
+++ b/src/mondo/skill/references/bulk.md
@@ -3,7 +3,7 @@
 Two surfaces:
 
 - **`--batch <file.json>`** on per-resource commands (`item create`, `column set`, …): one HTTP round-trip, per-row envelope, partial-failure semantics.
-- **`mondo export board` / `mondo import board`**: full-board CSV / XLSX / JSON / Markdown round-trips.
+- **`mondo export board` / `mondo import board`**: full-board export in CSV / TSV / JSON / XLSX / Markdown / HTML / PDF (all rendered client-side — monday has no native board-export endpoint). CSV/XLSX/JSON round-trip back via `import board`.
 
 See `mondo help batch-operations` for the canonical prose deep-dive.
 
@@ -58,6 +58,8 @@ exit 1
 
 ## Export a board
 
+Formats: `csv | tsv | json | xlsx | md | html | pdf`. Stdout for csv/tsv/json/md/html; `--out` **required** for xlsx and pdf (exit 2 otherwise).
+
 ```bash
 # JSON to stdout:
 mondo export board 5094861043 --format json -o json
@@ -65,18 +67,44 @@ mondo export board 5094861043 --format json -o json
 # CSV to a file:
 mondo export board 5094861043 --format csv --out ./pm_export.csv
 
-# XLSX (Excel):
-mondo export board 5094861043 --format xlsx --out ./pm_export.xlsx
+# XLSX (Excel) — bold/frozen header, autofilter, autosized cols; subitems on a 2nd sheet:
+mondo export board 5094861043 --format xlsx --out ./pm_export.xlsx --include-subitems
 
-# Markdown table:
+# Markdown — grouped by default (board title <h1> + one ## section per group):
 mondo export board 5094861043 --format md --out ./pm_export.md
+
+# Self-contained HTML (defaults to stdout; --out optional):
+mondo export board 5094861043 --format html --out ./pm_export.html
+
+# PDF via WeasyPrint (requires --out):
+mondo export board 5094861043 --format pdf --out ./pm_export.pdf
 ```
 
-```text
-(stdout for --format json; file at --out for csv/xlsx/md)
+### Grouped vs flat (md / html / pdf only)
+
+These three "human" formats are **grouped by default**: a board-name `# Title` (best-effort fetch; falls back to `Board <id>`, never errors) followed by one `## <group title>` / `<h2>` section per group that contains items, each with its own table. Grouped table headers are `id, name, state` + the column titles — `group` becomes the section heading, not a column. Group order = first-seen (board order); empty groups are omitted, and two groups sharing a title render under one heading.
+
+```bash
+# Single flat table instead (headers: id, name, state, group + column titles):
+mondo export board 5094861043 --format md --flat
 ```
 
-*Gotcha:* CSV flattens column values to strings using the **column title** as the header. The `group` field carries the group title (not the id). When parsing CSV, assume the headers match what `column list` reports under `title`.
+`--flat` has **no effect** on csv/tsv/json/xlsx. `--include-subitems` always appends a trailing `## Subitems` / `<h2>Subitems</h2>` section, grouped or flat.
+
+### Narrowing & projection (all formats)
+
+```bash
+# Server-side filter (repeatable, AND'ed; labels resolve to indices/ids):
+mondo export board 5094861043 --format csv --filter status=Done --filter owner!=
+
+# One group (sugar for --filter group=<id>):
+mondo export board 5094861043 --format md --group topics
+
+# Client-side column projection (by id OR title, case-insensitive; meta cols always kept):
+mondo export board 5094861043 --format csv --columns status,date4
+```
+
+*Gotcha:* `--filter`/`--group` narrow **server-side** via the items query (cheap on big boards); malformed `--filter` syntax fails fast with exit 2 before the client opens. `--columns` is **client-side projection only** — it doesn't reduce GraphQL cost; an unmatched token is a usage error (exit 2). `id/name/state` (+ `group` in flat mode) are always emitted regardless of `--columns`. CSV flattens column values to strings using the **column title** as the header; the `group` field carries the group title (not the id), matching `column list`'s `title`.
 
 ## Import a board from CSV
 

--- a/tests/integration/test_live_pm_board.py
+++ b/tests/integration/test_live_pm_board.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import csv
 import json
+import shutil
 import uuid
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,8 @@ from ._helpers import (
     wait_for,
 )
 from .conftest import PmBoard
+
+_HAS_WEASYPRINT = shutil.which("weasyprint") is not None
 
 
 @pytest.mark.integration
@@ -282,6 +285,128 @@ def test_live_pm_board_export_markdown_smoke(pm_board_session: PmBoard) -> None:
     # Group titles also surface (the GFM table includes a `group` column).
     for group_title in ("Backlog", "In Progress", "Done"):
         assert group_title in md, f"group {group_title!r} not in markdown export"
+
+
+@pytest.mark.integration
+def test_live_pm_board_export_html(pm_board_session: PmBoard, tmp_path: Path) -> None:
+    """`export board --format html --out` writes an HTML doc with a title + group sections."""
+    pm = pm_board_session
+    out = tmp_path / "pm_export.html"
+    invoke(
+        ["export", "board", str(pm.board_id), "--format", "html", "--out", str(out)],
+        expect_exit=0,
+    )
+    assert out.exists() and out.stat().st_size > 0, "html export empty"
+
+    text = out.read_text(encoding="utf-8")
+    # Board-name title (h1) and at least one group section (h2) in grouped mode.
+    assert "<h1" in text and "E2E PM Board" in text, (
+        f"board-name <h1> title missing from html export: {text[:500]!r}"
+    )
+    assert "<h2>Backlog</h2>" in text, "group <h2> section missing from html export"
+    for item_name in pm.item_names:
+        assert item_name in text, f"item {item_name!r} not in html export"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _HAS_WEASYPRINT, reason="weasyprint not installed")
+def test_live_pm_board_export_pdf(pm_board_session: PmBoard, tmp_path: Path) -> None:
+    """`export board --format pdf --out` renders a non-empty PDF via WeasyPrint."""
+    pm = pm_board_session
+    out = tmp_path / "pm_export.pdf"
+    invoke(
+        ["export", "board", str(pm.board_id), "--format", "pdf", "--out", str(out)],
+        expect_exit=0,
+    )
+    assert out.exists() and out.stat().st_size > 0, "pdf export empty"
+    # A real PDF starts with the `%PDF-` magic.
+    assert out.read_bytes()[:5] == b"%PDF-"
+
+
+@pytest.mark.integration
+def test_live_pm_board_export_markdown_grouped(pm_board_session: PmBoard) -> None:
+    """Grouped (default) md emits one `## <group>` section per monday group."""
+    pm = pm_board_session
+    result = invoke(["export", "board", str(pm.board_id), "--format", "md"], expect_exit=0)
+    md = result.stdout
+    assert md.strip(), "markdown export empty"
+
+    # Board-name h1 title.
+    assert "# E2E PM Board" in md, f"board-name # title missing: {md[:300]!r}"
+    # One section heading per group (grouped is the default for md).
+    for group_title in ("Backlog", "In Progress", "Done"):
+        assert f"## {group_title}" in md, f"group section '## {group_title}' missing"
+    # In grouped mode `group` is the heading, not a table column.
+    assert "| group |" not in md, "grouped md should not carry a `group` table column"
+
+
+@pytest.mark.integration
+def test_live_pm_board_export_markdown_flat(pm_board_session: PmBoard) -> None:
+    """`--flat` md collapses to a single table carrying a `group` column."""
+    pm = pm_board_session
+    result = invoke(
+        ["export", "board", str(pm.board_id), "--format", "md", "--flat"],
+        expect_exit=0,
+    )
+    md = result.stdout
+    assert md.strip(), "flat markdown export empty"
+
+    # Flat keeps the `group` column and emits NO `## <group>` section headings.
+    assert "| group |" in md, "flat md should carry a `group` table column"
+    for group_title in ("Backlog", "In Progress", "Done"):
+        assert f"## {group_title}" not in md, f"flat md must not emit '## {group_title}' section"
+    # Every item still present in the single table.
+    for item_name in pm.item_names:
+        assert item_name in md, f"item {item_name!r} not in flat markdown export"
+
+
+@pytest.mark.integration
+def test_live_pm_board_export_filter_narrows_rows(pm_board_session: PmBoard) -> None:
+    """`--filter status=Done` (seeded only on item 0) narrows the JSON export to that item."""
+    pm = pm_board_session
+    result = invoke(
+        [
+            "export",
+            "board",
+            str(pm.board_id),
+            "--format",
+            "json",
+            "--filter",
+            f"{pm.column_ids['status']}={pm.status_value}",
+        ],
+        expect_exit=0,
+    )
+    items = _extract_items_from_export(json.loads(result.stdout))
+    names = {it["name"] for it in items}
+    # Only item_ids[0] carries the seeded "Done" status.
+    assert names == {pm.item_names[0]}, f"filter did not narrow rows: {names}"
+
+
+@pytest.mark.integration
+def test_live_pm_board_export_columns_subset(pm_board_session: PmBoard) -> None:
+    """`--columns` restricts emitted board columns to the requested subset (meta kept)."""
+    pm = pm_board_session
+    result = invoke(
+        [
+            "export",
+            "board",
+            str(pm.board_id),
+            "--format",
+            "csv",
+            "--columns",
+            "Story Points",
+        ],
+        expect_exit=0,
+    )
+    rows = list(csv.DictReader(result.stdout.splitlines()))
+    assert rows, "columns-subset export empty"
+    headers = set(rows[0].keys())
+    # Meta columns are always kept.
+    for meta in ("id", "name", "state", "group"):
+        assert meta in headers, f"meta column {meta!r} missing from --columns export"
+    # The requested column survives; an unrelated column is projected out.
+    assert "Story Points" in headers, "requested column missing from --columns export"
+    assert "Owner Email" not in headers, "unrequested column leaked into --columns export"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -2016,6 +2016,7 @@ class TestDocGetPdf:
             out.write_bytes(b"%PDF-1.7\n")
 
         monkeypatch.setattr(_pdf, "render_pdf", fake_render)
+        monkeypatch.setattr(_pdf, "find_weasyprint", lambda: "weasyprint")
         httpx_mock.add_response(
             url=ENDPOINT,
             method="POST",
@@ -2064,6 +2065,7 @@ class TestDocGetPdf:
             out.write_bytes(b"%PDF-1.7\n")
 
         monkeypatch.setattr(_pdf, "render_pdf", fake_render)
+        monkeypatch.setattr(_pdf, "find_weasyprint", lambda: "weasyprint")
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=self._doc_with_image())
         out = tmp_path / "doc.pdf"
         result = runner.invoke(
@@ -2091,6 +2093,7 @@ class TestDocGetPdf:
             out.write_bytes(b"%PDF-1.7\n")
 
         monkeypatch.setattr(_pdf, "render_pdf", fake_render)
+        monkeypatch.setattr(_pdf, "find_weasyprint", lambda: "weasyprint")
         # 1) doc fetch returns an image block; 2) assets(ids) resolves nothing,
         # so embed_doc_images returns {} and the renderer falls back to the URL.
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=self._doc_with_image())
@@ -2118,6 +2121,7 @@ class TestDocGetPdf:
             out.write_bytes(b"%PDF-1.7\n")
 
         monkeypatch.setattr(_pdf, "render_pdf", fake_render)
+        monkeypatch.setattr(_pdf, "find_weasyprint", lambda: "weasyprint")
         svg = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="
         httpx_mock.add_response(
             url=ENDPOINT,

--- a/tests/unit/test_cli_export.py
+++ b/tests/unit/test_cli_export.py
@@ -78,6 +78,10 @@ def _item(id_: str, name: str, cols: dict[str, str], group: str = "topics") -> d
     }
 
 
+def _board_name(name: str = "My Board") -> dict:
+    return _ok({"boards": [{"name": name}]})
+
+
 # --- format tests ---
 
 
@@ -155,17 +159,249 @@ class TestJsonExport:
 
 
 class TestMarkdownExport:
-    def test_pipe_table(self, httpx_mock: HTTPXMock) -> None:
+    def test_flat_pipe_table(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_board_name())
         httpx_mock.add_response(
             url=ENDPOINT,
             method="POST",
             json=_items_page([_item("1", "A", {"status": "Done"})]),
         )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "md", "--flat"])
+        assert result.exit_code == 0, result.stdout
+        # Flat mode: a single table with a `group` column under the board title.
+        # The title is kept; only the per-group `##` sections are dropped.
+        assert result.stdout.startswith("# My Board\n")
+        assert "| id | name | state | group | Status | Due |" in result.stdout
+        assert "|---|" in result.stdout
+        assert "## " not in result.stdout
+
+    def test_grouped_is_default(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_board_name("Roadmap"))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page(
+                [
+                    _item("1", "A", {"status": "Done"}, group="topics"),
+                    _item("2", "B", {"status": "Working"}, group="next"),
+                ]
+            ),
+        )
         result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "md"])
         assert result.exit_code == 0, result.stdout
-        assert result.stdout.startswith("| id |")
-        assert "|---|" in result.stdout
+        out = result.stdout
+        # Board-name title + one section per group; `group` is the heading, not
+        # a table column.
+        assert out.startswith("# Roadmap\n")
+        assert "## Topics" in out
+        assert "## Next" in out
+        assert "| id | name | state | Status | Due |" in out
+        assert "group" not in out.splitlines()[2]
+
+    def test_board_name_fallback(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        # Empty boards result -> fall back to "Board <id>", never a hard error.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"boards": []}))
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_items_page([_item("1", "A", {})])
+        )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "md"])
+        assert result.exit_code == 0, result.stdout
+        assert result.stdout.startswith("# Board 42\n")
+
+    def test_subitems_section_has_blank_line_separator(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_board_name())
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page(
+                [
+                    {
+                        **_item("1", "Parent", {"status": "Done"}),
+                        "subitems": [
+                            {
+                                "id": "10",
+                                "name": "Child A",
+                                "state": "active",
+                                "column_values": [
+                                    {"id": "status", "text": "In progress", "type": "status"}
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            ),
+        )
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "md", "--flat", "--include-subitems"],
+        )
+        assert result.exit_code == 0, result.stdout
+        out = result.stdout
+        # Flat items table ends flush against the heading; GFM needs the blank line.
+        assert "\n\n## Subitems\n" in out
+        assert "Child A" in out
+
+    def test_table_header_escapes_pipe(self, httpx_mock: HTTPXMock) -> None:
+        cols = _ok(
+            {
+                "boards": [
+                    {
+                        "id": "42",
+                        "name": "B",
+                        "columns": [
+                            {"id": "c1", "title": "Cost | EUR", "type": "text", "archived": False}
+                        ],
+                    }
+                ]
+            }
+        )
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=cols)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_board_name())
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_items_page([_item("1", "A", {"c1": "5"})])
+        )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "md", "--flat"])
+        assert result.exit_code == 0, result.stdout
+        # A pipe in a column title must be escaped so the GFM table stays aligned.
+        assert "Cost \\| EUR" in result.stdout
+
+
+class TestHtmlExport:
+    def test_title_groups_and_rows(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_board_name("Roadmap"))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page(
+                [
+                    _item("1", "Alpha", {"status": "Done"}, group="topics"),
+                    _item("2", "Beta", {"status": "Working"}, group="next"),
+                ]
+            ),
+        )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "html"])
+        assert result.exit_code == 0, result.stdout
+        out = result.stdout
+        assert "<!DOCTYPE html>" in out
+        # Reuses the doc stylesheet (it styles <table>, has @page A4).
+        assert "@page" in out
+        assert "<h1" in out and "Roadmap" in out
+        assert "<h2>Topics</h2>" in out
+        assert "<h2>Next</h2>" in out
+        assert "<table>" in out
+        assert "<td>Alpha</td>" in out
+
+    def test_escaping(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_board_name("A & B"))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "<script>", {"status": "x & y"})]),
+        )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "html"])
+        assert result.exit_code == 0, result.stdout
+        out = result.stdout
+        assert "<script>" not in out.replace("<script>", "")  # sanity
+        assert "&lt;script&gt;" in out
+        assert "x &amp; y" in out
+        assert "A &amp; B" in out
+
+    def test_flat_single_table(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_board_name())
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page(
+                [
+                    _item("1", "A", {}, group="topics"),
+                    _item("2", "B", {}, group="next"),
+                ]
+            ),
+        )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "html", "--flat"])
+        assert result.exit_code == 0, result.stdout
+        out = result.stdout
+        assert "<h2>" not in out
+        assert out.count("<table>") == 1
+        assert "<th>group</th>" in out
+
+
+class TestPdfExport:
+    def test_requires_out(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "pdf"])
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
+    def test_calls_render_pdf_with_board_html(
+        self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_board_name("Roadmap"))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "Alpha", {"status": "Done"})]),
+        )
+        captured: dict[str, object] = {}
+
+        def fake_render_pdf(html_text: str, out: Path) -> None:
+            captured["html"] = html_text
+            captured["out"] = out
+            out.write_bytes(b"%PDF-1.4 fake")
+
+        import mondo.cli.export as export_mod
+
+        monkeypatch.setattr(export_mod, "render_pdf", fake_render_pdf)
+        monkeypatch.setattr("mondo.cli._pdf.find_weasyprint", lambda: "/usr/bin/weasyprint")
+        out = tmp_path / "board.pdf"
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "pdf", "--out", str(out)],
+        )
+        assert result.exit_code == 0, result.stdout
+        assert captured["out"] == out
+        html_text = captured["html"]
+        assert isinstance(html_text, str)
+        assert "<!DOCTYPE html>" in html_text
+        assert "Roadmap" in html_text
+        assert "<td>Alpha</td>" in html_text
+
+    def test_missing_weasyprint_fails_before_fetch(
+        self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No WeasyPrint on PATH: fail fast with the install hint before any
+        # board fetch, so the user isn't made to paginate first.
+        monkeypatch.setattr("mondo.cli._pdf.find_weasyprint", lambda: None)
+        out = tmp_path / "board.pdf"
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "pdf", "--out", str(out)],
+        )
+        assert result.exit_code != 0
+        assert httpx_mock.get_requests() == []
+        assert "weasyprint" in (result.stdout + str(result.exception or "")).lower()
+
+    def test_malformed_filter_beats_weasyprint_preflight(
+        self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # With WeasyPrint absent, a malformed --filter is a local usage error and
+        # must surface before the install hint (both are pre-network).
+        monkeypatch.setattr("mondo.cli._pdf.find_weasyprint", lambda: None)
+        out = tmp_path / "board.pdf"
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "pdf", "--out", str(out), "--filter", "bad"],
+        )
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+        assert "weasyprint" not in (result.stdout + str(result.exception or "")).lower()
 
 
 class TestXlsxExport:
@@ -305,3 +541,266 @@ class TestPagination:
         assert result.exit_code == 0, result.stdout
         parsed = json.loads(result.stdout)
         assert [i["id"] for i in parsed["items"]] == ["1", "2"]
+
+
+# --- xlsx polish ---
+
+
+class TestXlsxStyle:
+    def test_freeze_filter_and_bold(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "A", {"status": "Done"})]),
+        )
+        out = tmp_path / "board.xlsx"
+        result = runner.invoke(
+            app, ["export", "board", "--board", "42", "-f", "xlsx", "--out", str(out)]
+        )
+        assert result.exit_code == 0, result.stdout
+        wb = load_workbook(out)
+        ws = wb["items"]
+        assert ws.freeze_panes == "A2"
+        assert ws.auto_filter.ref == ws.dimensions
+        assert ws["A1"].font.bold is True
+
+
+# --- filtering & column subset ---
+
+
+_COLS_WITH_STATUS_LABELS = _ok(
+    {
+        "boards": [
+            {
+                "id": "42",
+                "name": "B",
+                "columns": [
+                    {
+                        "id": "status",
+                        "title": "Status",
+                        "type": "status",
+                        "archived": False,
+                        "settings_str": json.dumps({"labels": {"1": "Done"}}),
+                    },
+                    {"id": "date4", "title": "Due", "type": "date", "archived": False},
+                ],
+            }
+        ]
+    }
+)
+
+
+class TestFilter:
+    def test_filter_carries_query_params(self, httpx_mock: HTTPXMock) -> None:
+        # settings_str labels let the status codec resolve "Done" -> index, proving
+        # the full column defs (not just {id,title,type}) reach build_query_params.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_COLS_WITH_STATUS_LABELS)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "A", {"status": "Done"})]),
+        )
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "csv", "--filter", "status=Done"],
+        )
+        assert result.exit_code == 0, result.stdout
+        items_body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert "query_params" in items_body["query"] or "ItemsQuery" in items_body["query"]
+        rule = items_body["variables"]["qp"]["rules"][0]
+        assert rule["column_id"] == "status"
+        assert rule["compare_value"] == [1]
+
+    def test_group_sugar(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "A", {})]),
+        )
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "csv", "--group", "topics"],
+        )
+        assert result.exit_code == 0, result.stdout
+        items_body = json.loads(httpx_mock.get_requests()[-1].content)
+        rule = items_body["variables"]["qp"]["rules"][0]
+        assert rule["column_id"] == "group"
+        assert rule["compare_value"] == ["topics"]
+
+    def test_filter_label_resolves_when_column_projected_away(self, httpx_mock: HTTPXMock) -> None:
+        # Regression: --columns must not starve --filter of the full column
+        # defs. Filtering on `status` while projecting only `Due` must still
+        # resolve the "Done" label to its index — sending the raw string makes
+        # monday silently return zero matches.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_COLS_WITH_STATUS_LABELS)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "A", {"status": "Done", "date4": "2026-01-01"})]),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                "board",
+                "--board",
+                "42",
+                "-f",
+                "csv",
+                "--columns",
+                "Due",
+                "--filter",
+                "status=Done",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        items_body = json.loads(httpx_mock.get_requests()[-1].content)
+        rule = items_body["variables"]["qp"]["rules"][0]
+        assert rule["column_id"] == "status"
+        assert rule["compare_value"] == [1]  # resolved via full defs, not ["Done"]
+        # Projection still applied: the filtered-on Status column is not rendered.
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[0] == ["id", "name", "state", "group", "Due"]
+
+
+class TestColumnSubset:
+    def test_projection_by_title(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "A", {"status": "Done", "date4": "2026-01-01"})]),
+        )
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "csv", "--columns", "Status"],
+        )
+        assert result.exit_code == 0, result.stdout
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[0] == ["id", "name", "state", "group", "Status"]
+        assert "Due" not in rows[0]
+
+    def test_projection_by_id_preserves_order(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "A", {"status": "Done", "date4": "2026-01-01"})]),
+        )
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "csv", "--columns", "date4,status"],
+        )
+        assert result.exit_code == 0, result.stdout
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[0] == ["id", "name", "state", "group", "Due", "Status"]
+
+    def test_unknown_token_errors(self, httpx_mock: HTTPXMock) -> None:
+        # The columns fetch resolves first; the bad token aborts before any
+        # items page is requested.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "csv", "--columns", "nope"],
+        )
+        assert result.exit_code == 2
+        assert "nope" in (result.stdout + str(result.exception or ""))
+
+
+_COLS_DUP_TITLE = _ok(
+    {
+        "boards": [
+            {
+                "id": "42",
+                "name": "B",
+                "columns": [
+                    {"id": "text", "title": "Notes", "type": "text", "archived": False},
+                    {"id": "text7", "title": "Notes", "type": "text", "archived": False},
+                ],
+            }
+        ]
+    }
+)
+
+
+class TestDuplicateNames:
+    def test_duplicate_column_titles_keep_both_values(self, httpx_mock: HTTPXMock) -> None:
+        # monday allows two columns with the same title; both must survive
+        # (rows are keyed by a disambiguated label, not the raw title).
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_COLS_DUP_TITLE)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "A", {"text": "first", "text7": "second"})]),
+        )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "csv"])
+        assert result.exit_code == 0, result.stdout
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[0] == ["id", "name", "state", "group", "Notes (text)", "Notes (text7)"]
+        assert rows[1][4] == "first"
+        assert rows[1][5] == "second"
+
+    def test_columns_selects_all_same_titled(self, httpx_mock: HTTPXMock) -> None:
+        # `--columns Notes` must reach both same-titled columns, not just one.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_COLS_DUP_TITLE)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "A", {"text": "first", "text7": "second"})]),
+        )
+        result = runner.invoke(
+            app, ["export", "board", "--board", "42", "-f", "csv", "--columns", "Notes"]
+        )
+        assert result.exit_code == 0, result.stdout
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[0] == ["id", "name", "state", "group", "Notes (text)", "Notes (text7)"]
+        assert rows[1][4] == "first"
+        assert rows[1][5] == "second"
+
+    def test_meta_named_column_does_not_shadow_meta(self, httpx_mock: HTTPXMock) -> None:
+        # A column literally titled "state" must not overwrite the item's
+        # lifecycle state; its label is disambiguated to "state (<id>)".
+        cols = _ok(
+            {
+                "boards": [
+                    {
+                        "id": "42",
+                        "name": "B",
+                        "columns": [
+                            {"id": "text", "title": "state", "type": "text", "archived": False}
+                        ],
+                    }
+                ]
+            }
+        )
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=cols)
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_items_page([_item("1", "A", {"text": "custom"})])
+        )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "csv"])
+        assert result.exit_code == 0, result.stdout
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[0] == ["id", "name", "state", "group", "state (text)"]
+        assert rows[1][2] == "active"  # meta state preserved
+        assert rows[1][4] == "custom"  # the column's own value
+
+    def test_duplicate_group_titles_render_separate_sections(self, httpx_mock: HTTPXMock) -> None:
+        # Two distinct groups sharing a title must stay separate sections
+        # (bucketed by group id, not title).
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_board_name("Roadmap"))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page(
+                [
+                    {**_item("1", "A", {}), "group": {"id": "g1", "title": "Sprint"}},
+                    {**_item("2", "B", {}), "group": {"id": "g2", "title": "Sprint"}},
+                ]
+            ),
+        )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "md"])
+        assert result.exit_code == 0, result.stdout
+        assert result.stdout.count("## Sprint") == 2


### PR DESCRIPTION
## What

Extends `mondo export board` to full parity with the recently-polished doc-export surface, plus a fidelity fix. monday exposes **no native board-export endpoint**, so every format is rendered client-side (same as doc PDF).

### New output formats
- **`html`** — self-contained, reuses the doc stylesheet (`_HTML_STYLE`).
- **`pdf`** — renders the board HTML through WeasyPrint, with a **fail-fast preflight** (install hint surfaces before any board fetch). `pdf` and `xlsx` require `--out`.

### Grouped human formats
- `md`/`html`/`pdf` are **grouped by group with a board-name title by default**; one `##`/`<h2>` section per group that has items.
- **`--flat`** keeps a single table (no per-group sections).

### XLSX polish
- Bold + frozen header, autofilter, and capped column widths — on both the items and subitems sheets.

### Filtering & projection
- **`--filter COL=VAL`** (repeatable, server-side) reusing `item list`'s `build_query_params`, plus **`--group`** sugar.
- **`--columns`** client-side projection (by id or title) that composes with `--include-subitems` and grouping.

### Fidelity fix (id-keying)
- Rows and group sections are keyed by **stable id** (column id / group id) with display titles disambiguated, so **duplicate column or group titles no longer silently drop or merge data**, and a column titled like a meta field (`id`/`name`/`state`/`group`) no longer shadows it. The common (unique-title) case output is unchanged.

## Why
`export board` previously did csv/tsv/json/xlsx/md only, as the plainer sibling of `doc get`. This closes the gap (html/pdf/grouped output), makes the Excel export feel finished, adds the natural "export a slice" filtering, and fixes a latent title-keying data-loss bug.

## Testing
- **33 unit tests** (`tests/unit/test_cli_export.py`) covering every format, grouping/`--flat`, filtering, projection, XLSX styling, escaping, the WeasyPrint preflight ordering, and the duplicate-title/group + meta-shadow cases.
- **6 live e2e tests** (`tests/integration/test_live_pm_board.py`) — html, pdf (real WeasyPrint render), grouped/flat md, `--filter`, `--columns` — **all passing against the live playground board** (10/10 in the export file).
- Full non-integration suite green (1811 passed), `ruff` + `mypy` clean.

## Reviewer notes
- Went through `/simplify`, `/code-review`, `/security-review`, and a `codex gpt-5.5 xhigh` pass; findings fixed with regression tests (md header escaping, GFM subitems separator, board-name hardening, `--columns`+`--filter` label resolution, preflight ordering).
- Docs updated: README "Export" section + bundled skill (`SKILL.md`, `references/bulk.md`) + examples.
- **Known pre-existing, out of scope:** CSV/XLSX formula injection in the csv/tsv/xlsx writers (predates this work).