### PR TITLE
Proper Windows setup: Scoop bucket, install.ps1, Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,32 @@ jobs:
 
       - name: Repo hygiene (no gitignored tracked files)
         run: test -z "$(git ls-files -i -c --exclude-standard)"
+
+  windows:
+    name: tests (windows)
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install Python 3.14
+        run: uv python install 3.14
+
+      - name: Install deps
+        run: uv sync --frozen --extra dev
+
+      - name: Parse install.ps1
+        shell: pwsh
+        run: |
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path scripts/install.ps1), [ref]$null, [ref]$errors) | Out-Null
+          if ($errors) { $errors | ForEach-Object { $_.Message }; throw "install.ps1 has parse errors" }
+          "install.ps1 parses OK"
+
+      - name: Pytest
+        run: uv run pytest -m "not integration and not eval"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
             --collect-data mondo.help --hidden-import mondo.help `
             --collect-data mondo.skill --hidden-import mondo.skill `
             --collect-submodules mondo.cli --collect-submodules mondo.output `
+            --collect-data tzdata `
             src/mondo/cli/main.py
 
       - name: Smoke test (unix)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,3 +257,82 @@ jobs:
           fi
           git commit -m "mondo ${{ steps.ver.outputs.version }}"
           git push
+
+  update-scoop:
+    needs: release
+    runs-on: ubuntu-24.04
+    # Skip the bucket update on pre-release tags, same reasoning as the
+    # Homebrew tap: `scoop update mondo` should only pull stable versions.
+    if: ${{ !contains(github.ref_name, '-') }}
+    steps:
+      - name: Derive version
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download Windows archive
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir assets
+          cd assets
+          v="${{ steps.ver.outputs.version }}"
+          gh release download "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "mondo-$v-windows-x86_64.zip"
+
+      - name: Compute SHA256
+        id: sha
+        run: |
+          cd assets
+          v="${{ steps.ver.outputs.version }}"
+          echo "windows_x86_64=$(sha256sum "mondo-$v-windows-x86_64.zip" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout bucket repo
+        uses: actions/checkout@v5
+        with:
+          repository: zoltanf/scoop-mondo
+          token: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          path: bucket
+
+      - name: Render manifest
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          WINDOWS_X86_64: ${{ steps.sha.outputs.windows_x86_64 }}
+        run: |
+          mkdir -p bucket/bucket
+          cat > bucket/bucket/mondo.json <<EOF
+          {
+              "version": "$VERSION",
+              "description": "Power-user CLI for the monday.com GraphQL API",
+              "homepage": "https://github.com/zoltanf/mondo",
+              "license": "MIT",
+              "architecture": {
+                  "64bit": {
+                      "url": "https://github.com/zoltanf/mondo/releases/download/v$VERSION/mondo-$VERSION-windows-x86_64.zip",
+                      "hash": "$WINDOWS_X86_64"
+                  }
+              },
+              "bin": "mondo\\\\mondo.exe",
+              "checkver": "github",
+              "autoupdate": {
+                  "architecture": {
+                      "64bit": {
+                          "url": "https://github.com/zoltanf/mondo/releases/download/v\$version/mondo-\$version-windows-x86_64.zip"
+                      }
+                  }
+              }
+          }
+          EOF
+
+      - name: Commit and push
+        working-directory: bucket
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bucket/mondo.json
+          if git diff --cached --quiet; then
+            echo "manifest unchanged"
+            exit 0
+          fi
+          git commit -m "mondo ${{ steps.ver.outputs.version }}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,11 @@ jobs:
           .\dist\mondo\mondo.exe help codecs | Out-Null
           .\dist\mondo\mondo.exe skill install --global | Out-Null
           if (-not (Test-Path "$HOME/.claude/skills/mondo/SKILL.md")) { throw "SKILL.md missing" }
+          # Verify `--collect-data tzdata` bundled the IANA tz database the
+          # world_clock codec needs (Windows has no system zoneinfo source).
+          $tz = Get-ChildItem -Recurse -Path .\dist\mondo -Filter London -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match 'zoneinfo' } | Select-Object -First 1
+          if (-not $tz) { throw "bundled tzdata zoneinfo data missing from onedir (--collect-data tzdata regressed)" }
 
       - name: Archive (unix)
         if: runner.os != 'Windows'
@@ -133,6 +138,12 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Compute checksums
+        run: |
+          cd artifacts
+          sha256sum mondo-*.tar.gz mondo-*.zip > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -153,7 +164,7 @@ jobs:
             --notes "$notes" \
             --verify-tag \
             $prerelease_flag \
-            artifacts/mondo-*.tar.gz artifacts/mondo-*.zip
+            artifacts/mondo-*.tar.gz artifacts/mondo-*.zip artifacts/SHA256SUMS.txt
 
   update-homebrew:
     needs: release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,9 @@ Cut releases with `scripts/release.sh <version>` (e.g.
 suite, commits `chore(release): v<version>`, tags `v<version>`, and
 pushes `main` + the tag. The tag push triggers
 `.github/workflows/release.yml`, which builds the four platform
-binaries, creates the GitHub Release, and updates the Homebrew tap at
-`zoltanf/homebrew-mondo`. Pass `--skip-tests` only in emergencies.
+binaries, creates the GitHub Release, updates the Homebrew tap at
+`zoltanf/homebrew-mondo`, and updates the Scoop bucket at
+`zoltanf/scoop-mondo` (Windows). Pass `--skip-tests` only in emergencies.
 
 Preconditions enforced by the script: clean working tree, on `main`,
 local in sync with `origin/main`, tag not already present.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Uninstall with `scoop uninstall mondo`.
 ### PowerShell install script (Windows)
 
 No Scoop? Install per-user with a single command — it downloads the latest
-release, extracts it to `%LOCALAPPDATA%\Programs\mondo`, and adds that to your
-PATH:
+release, verifies its SHA256 checksum, extracts it to
+`%LOCALAPPDATA%\Programs\mondo`, and adds that to your PATH:
 
 ```powershell
 irm https://raw.githubusercontent.com/zoltanf/mondo/main/scripts/install.ps1 | iex
@@ -1089,7 +1089,7 @@ What this does, in order:
 Pushing the tag triggers [.github/workflows/release.yml](.github/workflows/release.yml), which:
 
 1. **Builds four binaries in parallel** — macOS (arm64), Linux (x86_64 + arm64), Windows (x86_64) — using PyInstaller on matching GitHub runners. Each binary is smoke-tested with `--version` and `--help` before being archived.
-2. **Creates the GitHub Release** — attaches all four archives to a new Release at `https://github.com/zoltanf/mondo/releases/tag/v<ver>` with auto-generated notes from commit history.
+2. **Creates the GitHub Release** — attaches all four archives plus a `SHA256SUMS.txt` to a new Release at `https://github.com/zoltanf/mondo/releases/tag/v<ver>` with auto-generated notes from commit history.
 3. **Updates the Homebrew tap** — regenerates `Formula/mondo.rb` in [zoltanf/homebrew-mondo][tap] with the new version and SHA256s, then pushes. Users get the new binary on their next `brew upgrade mondo`.
 4. **Updates the Scoop bucket** — regenerates `bucket/mondo.json` in [zoltanf/scoop-mondo](https://github.com/zoltanf/scoop-mondo) with the new version and Windows SHA256, then pushes. Windows users get it on their next `scoop update mondo`.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Open a new terminal afterwards so the PATH change takes effect.
 
 ### Direct download (all platforms)
 
+> This is the manual fallback — you extract the archive and wire up your
+> `PATH` by hand. Prefer a package manager if you can: **Homebrew** on
+> macOS/Linux, **Scoop** or the **PowerShell install script** on Windows
+> (all above). They handle `PATH`, updates, and — on Windows — sidestep the
+> SmartScreen prompt.
+
 Grab a pre-built binary for your OS/arch from the [Releases page][releases]:
 
 | Platform           | Asset                                     |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,35 @@ brew untap zoltanf/mondo   # optional
 > on an Apple Silicon Mac (almost always means Homebrew is running under
 > Rosetta), and other common install gotchas.
 
+### Scoop (Windows) — recommended
+
+```powershell
+scoop bucket add mondo https://github.com/zoltanf/scoop-mondo
+scoop install mondo
+```
+
+Scoop downloads the right Windows binary, puts `mondo` on your `PATH`, and
+keeps it current with:
+
+```powershell
+scoop update mondo
+```
+
+Uninstall with `scoop uninstall mondo`.
+
+### PowerShell install script (Windows)
+
+No Scoop? Install per-user with a single command — it downloads the latest
+release, extracts it to `%LOCALAPPDATA%\Programs\mondo`, and adds that to your
+PATH:
+
+```powershell
+irm https://raw.githubusercontent.com/zoltanf/mondo/main/scripts/install.ps1 | iex
+```
+
+Pin a version by setting `$env:MONDO_VERSION` first (e.g. `$env:MONDO_VERSION = "0.11.0"`).
+Open a new terminal afterwards so the PATH change takes effect.
+
 ### Direct download (all platforms)
 
 Grab a pre-built binary for your OS/arch from the [Releases page][releases]:
@@ -1023,9 +1052,10 @@ What this does, in order:
 
 Pushing the tag triggers [.github/workflows/release.yml](.github/workflows/release.yml), which:
 
-1. **Builds five binaries in parallel** — macOS (arm64 + Intel), Linux (x86_64 + arm64), Windows (x86_64) — using PyInstaller on matching GitHub runners. Each binary is smoke-tested with `--version` and `--help` before being archived.
-2. **Creates the GitHub Release** — attaches all five archives to a new Release at `https://github.com/zoltanf/mondo/releases/tag/v<ver>` with auto-generated notes from commit history.
+1. **Builds four binaries in parallel** — macOS (arm64), Linux (x86_64 + arm64), Windows (x86_64) — using PyInstaller on matching GitHub runners. Each binary is smoke-tested with `--version` and `--help` before being archived.
+2. **Creates the GitHub Release** — attaches all four archives to a new Release at `https://github.com/zoltanf/mondo/releases/tag/v<ver>` with auto-generated notes from commit history.
 3. **Updates the Homebrew tap** — regenerates `Formula/mondo.rb` in [zoltanf/homebrew-mondo][tap] with the new version and SHA256s, then pushes. Users get the new binary on their next `brew upgrade mondo`.
+4. **Updates the Scoop bucket** — regenerates `bucket/mondo.json` in [zoltanf/scoop-mondo](https://github.com/zoltanf/scoop-mondo) with the new version and Windows SHA256, then pushes. Windows users get it on their next `scoop update mondo`.
 
 End-to-end latency is roughly 6–10 minutes depending on runner availability.
 
@@ -1042,9 +1072,10 @@ The script accepts any semver-compatible pre-release identifier
 
 - The GitHub Release is created with the "pre-release" flag set, so it
   doesn't show up as the "Latest" release on the repo page.
-- The Homebrew tap is **not** updated. Pre-releases are only discoverable by
-  browsing the Releases page or downloading the assets directly, so
-  `brew upgrade mondo` never silently moves users onto an RC build.
+- The Homebrew tap and Scoop bucket are **not** updated. Pre-releases are only
+  discoverable by browsing the Releases page or downloading the assets
+  directly, so `brew upgrade mondo` / `scoop update mondo` never silently move
+  users onto an RC build.
 
 To hand-test an RC via Homebrew anyway, edit `Formula/mondo.rb` locally in a
 checkout of [zoltanf/homebrew-mondo][tap] and run `brew install --build-from-tap`.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ Expand-Archive mondo-<ver>-windows-x86_64.zip
 mondo --version
 ```
 
+> **Windows install troubles?** See [docs/troubleshooting-installation.md](docs/troubleshooting-installation.md)
+> — covers SmartScreen blocking the unsigned binary and `mondo` "not
+> recognized" when a terminal predates the PATH change. `scoop install` avoids
+> both.
+
 #### macOS: working around Gatekeeper ("unidentified developer")
 
 The macOS binaries are currently **unsigned** and **unnotarized**. This is only

--- a/README.md
+++ b/README.md
@@ -15,104 +15,6 @@ Ships with an agent-facing help system (`mondo help`, `mondo help --dump-spec`) 
 
 ---
 
-## Features
-
-**Complete monday platform API coverage.** Boards, items, subitems, columns
-(read/write + structural CRUD), groups, workspaces, users, teams, workspace
-docs, webhooks, files, activity logs, folders, favorites, tags, notifications,
-aggregations, validation rules, bulk CSV/XLSX import & export, and a raw
-GraphQL escape hatch.
-
-**Smart column-value shorthand.** Write `--column status=Done`,
-`--column due=2026-04-25`, or `--column tags=urgent,blocked` and a codec
-registry (22 writable column types) turns it into the right JSON — no
-hand-written mutations for 90% of the work.
-
-**Built for agents and scripts.** `mondo help --dump-spec -o json` emits the
-entire command tree (flags, types, enums, examples, exit codes) as one JSON
-blob — ingest once, plan many calls. Exit codes are narrow and stable
-(3=auth, 4=rate, 5=validation, 6=not-found, 7=network) so retry logic can
-branch on the code. By default, successful structured output on stdout is
-JSON when stdout isn't a TTY — though explicit `markdown`/`raw` formats and a
-few legacy ad-hoc error paths are exceptions.
-
-**Complexity-aware.** Every query is transparently rewritten to fetch
-monday's [complexity counters](https://developer.monday.com/api-reference/docs/complexity),
-feeding a session-local meter (`mondo complexity status`) so you never blow
-through the per-minute budget mid-script.
-
-**Local on-disk cache.** Boards, workspaces, users, teams, docs, folders,
-columns, groups, tags, webhooks, per-board details, and short-TTL per-item /
-per-doc payloads are cached with per-entity TTLs. Repeat `list`/`get` calls
-and fuzzy name matches (`--name-fuzzy "prodct launc"`) don't re-walk the API;
-every read command exposes `--refresh-cache` and `--no-cache` for explicit
-control.
-
-**Multi-profile, keyring-backed auth.** Token can live in the OS keyring
-(macOS Keychain / Windows Credential Manager / libsecret), an env var, or
-a `config.yaml` profile — switch accounts with `--profile work`.
-
-### At a glance
-
-**Items & columns**
-
-```bash
-# Create an item with typed column values — no JSON hand-writing
-mondo item create --board 1234567890 --name "Fix CI" \
-  --column status=Working --column owner=42 --column due=2026-04-25
-
-# List items with a JMESPath projection + table output
-mondo item list --board 1234567890 -o table \
-  -q '[].{id:id,name:name,state:state}'
-
-# Update a tags column by name — mondo resolves to tag IDs automatically
-mondo column set --item 987 --column tags --value urgent,blocked
-```
-
-**Boards & workspaces**
-
-```bash
-# Find boards by name (client-side — monday's API has no name filter)
-mondo board list --name-contains pager --limit 20 -o table
-
-# Duplicate a board with all items + updates into a different workspace
-mondo board duplicate --id 1234567890 \
-  --type duplicate_board_with_pulses_and_updates --workspace 42
-
-# Add a whole team as workspace owners
-mondo workspace add-team --id 7 --team 11 --kind owner
-```
-
-**Import / export**
-
-```bash
-# Export a board as XLSX, including a subitems worksheet
-mondo export board --board 1234567890 --format xlsx \
-  --include-subitems --out board.xlsx
-
-# Re-import from CSV, skipping rows whose name already exists
-mondo import board --board 1234567890 --from items.csv --idempotency-name
-
-# Dry-run to see the mutations without sending them
-mondo --dry-run import board --board 1234567890 --from items.csv
-```
-
-**Agents & automation**
-
-```bash
-# Full command tree (flags, types, enums, examples, exit codes) as JSON
-mondo help --dump-spec -o json > mondo-spec.json
-
-# Raw GraphQL escape hatch for anything not yet wrapped
-mondo graphql 'query ($ids:[ID!]!){items(ids:$ids){id name}}' \
-  --vars '{"ids":[1,2]}'
-
-# Pipeline-friendly: extract a scalar, branch on stable exit codes
-count=$(mondo item list --board 42 -q "length(@)" -o none)
-```
-
----
-
 ## Installation
 
 ### Homebrew (macOS, Linux) — recommended
@@ -284,6 +186,104 @@ uv run mondo auth status
 ```
 
 [releases]: https://github.com/zoltanf/mondo/releases
+
+---
+
+## Features
+
+**Complete monday platform API coverage.** Boards, items, subitems, columns
+(read/write + structural CRUD), groups, workspaces, users, teams, workspace
+docs, webhooks, files, activity logs, folders, favorites, tags, notifications,
+aggregations, validation rules, bulk CSV/XLSX import & export, and a raw
+GraphQL escape hatch.
+
+**Smart column-value shorthand.** Write `--column status=Done`,
+`--column due=2026-04-25`, or `--column tags=urgent,blocked` and a codec
+registry (22 writable column types) turns it into the right JSON — no
+hand-written mutations for 90% of the work.
+
+**Built for agents and scripts.** `mondo help --dump-spec -o json` emits the
+entire command tree (flags, types, enums, examples, exit codes) as one JSON
+blob — ingest once, plan many calls. Exit codes are narrow and stable
+(3=auth, 4=rate, 5=validation, 6=not-found, 7=network) so retry logic can
+branch on the code. By default, successful structured output on stdout is
+JSON when stdout isn't a TTY — though explicit `markdown`/`raw` formats and a
+few legacy ad-hoc error paths are exceptions.
+
+**Complexity-aware.** Every query is transparently rewritten to fetch
+monday's [complexity counters](https://developer.monday.com/api-reference/docs/complexity),
+feeding a session-local meter (`mondo complexity status`) so you never blow
+through the per-minute budget mid-script.
+
+**Local on-disk cache.** Boards, workspaces, users, teams, docs, folders,
+columns, groups, tags, webhooks, per-board details, and short-TTL per-item /
+per-doc payloads are cached with per-entity TTLs. Repeat `list`/`get` calls
+and fuzzy name matches (`--name-fuzzy "prodct launc"`) don't re-walk the API;
+every read command exposes `--refresh-cache` and `--no-cache` for explicit
+control.
+
+**Multi-profile, keyring-backed auth.** Token can live in the OS keyring
+(macOS Keychain / Windows Credential Manager / libsecret), an env var, or
+a `config.yaml` profile — switch accounts with `--profile work`.
+
+### At a glance
+
+**Items & columns**
+
+```bash
+# Create an item with typed column values — no JSON hand-writing
+mondo item create --board 1234567890 --name "Fix CI" \
+  --column status=Working --column owner=42 --column due=2026-04-25
+
+# List items with a JMESPath projection + table output
+mondo item list --board 1234567890 -o table \
+  -q '[].{id:id,name:name,state:state}'
+
+# Update a tags column by name — mondo resolves to tag IDs automatically
+mondo column set --item 987 --column tags --value urgent,blocked
+```
+
+**Boards & workspaces**
+
+```bash
+# Find boards by name (client-side — monday's API has no name filter)
+mondo board list --name-contains pager --limit 20 -o table
+
+# Duplicate a board with all items + updates into a different workspace
+mondo board duplicate --id 1234567890 \
+  --type duplicate_board_with_pulses_and_updates --workspace 42
+
+# Add a whole team as workspace owners
+mondo workspace add-team --id 7 --team 11 --kind owner
+```
+
+**Import / export**
+
+```bash
+# Export a board as XLSX, including a subitems worksheet
+mondo export board --board 1234567890 --format xlsx \
+  --include-subitems --out board.xlsx
+
+# Re-import from CSV, skipping rows whose name already exists
+mondo import board --board 1234567890 --from items.csv --idempotency-name
+
+# Dry-run to see the mutations without sending them
+mondo --dry-run import board --board 1234567890 --from items.csv
+```
+
+**Agents & automation**
+
+```bash
+# Full command tree (flags, types, enums, examples, exit codes) as JSON
+mondo help --dump-spec -o json > mondo-spec.json
+
+# Raw GraphQL escape hatch for anything not yet wrapped
+mondo graphql 'query ($ids:[ID!]!){items(ids:$ids){id name}}' \
+  --vars '{"ids":[1,2]}'
+
+# Pipeline-friendly: extract a scalar, branch on stable exit codes
+count=$(mondo item list --board 42 -q "length(@)" -o none)
+```
 
 ---
 

--- a/docs/troubleshooting-installation.md
+++ b/docs/troubleshooting-installation.md
@@ -11,6 +11,8 @@ sees), then a quick diagnosis, then the fix.
 
 1. [`brew install` errors with "arm64 architecture is required" on an Apple Silicon Mac](#scenario-1-brew-install-errors-with-arm64-architecture-is-required-on-an-apple-silicon-mac)
 2. [macOS: "`mondo` cannot be opened" / "`mondo` is damaged"](#scenario-2-macos-mondo-cannot-be-opened--mondo-is-damaged) (Gatekeeper)
+3. [Windows: "Windows protected your PC" / SmartScreen blocks the binary](#scenario-3-windows-windows-protected-your-pc--smartscreen-blocks-the-binary)
+4. [Windows: `mondo` not recognized after install (PATH not active yet)](#scenario-4-windows-mondo-not-recognized-after-install-path-not-active-yet)
 
 ---
 
@@ -153,3 +155,99 @@ The fix is covered in detail in the README:
 [macOS: working around Gatekeeper](../README.md#macos-working-around-gatekeeper-unidentified-developer).
 Short version: `xattr -dr com.apple.quarantine ./mondo` (recursive — the
 release archive extracts to a `mondo/` directory).
+
+---
+
+## Scenario 3: Windows "Windows protected your PC" / SmartScreen blocks the binary
+
+### Symptom
+
+After downloading the release `.zip` in a browser and launching `mondo.exe`
+from Explorer, you see a blue dialog:
+
+```
+Windows protected your PC
+Microsoft Defender SmartScreen prevented an unrecognized app from starting.
+Running this app might put your PC at risk.
+```
+
+### Diagnosis
+
+The Windows binaries are **unsigned** (no code-signing certificate — the same
+reason macOS shows the Gatekeeper dialog in Scenario 2). SmartScreen flags
+files that carry the "Mark of the Web" — an alternate data stream Windows adds
+to anything downloaded through a browser — until the app builds reputation.
+
+This mainly trips when you **double-click the `.exe` in Explorer**. Running
+`mondo` from a terminal (PowerShell / cmd) usually isn't blocked, and the
+recommended install paths avoid it entirely.
+
+### Fix
+
+**Best: use Scoop or the install script.** Neither goes through the
+browser-download + Explorer-launch path that trips SmartScreen:
+
+```powershell
+scoop bucket add mondo https://github.com/zoltanf/scoop-mondo
+scoop install mondo
+# or:
+irm https://raw.githubusercontent.com/zoltanf/mondo/main/scripts/install.ps1 | iex
+```
+
+**If you already downloaded the `.zip` and hit the dialog:**
+
+- Click **More info** → **Run anyway** in the SmartScreen dialog, or
+- Strip the Mark of the Web before extracting, so none of the files inherit
+  it:
+
+  ```powershell
+  Unblock-File .\mondo-<ver>-windows-x86_64.zip
+  Expand-Archive .\mondo-<ver>-windows-x86_64.zip
+  # if you already extracted, unblock the whole directory instead:
+  Get-ChildItem -Recurse .\mondo | Unblock-File
+  ```
+
+**Why unsigned?** Code-signing certificates cost money; for now we ship
+unsigned Windows binaries to keep releases free. `scoop install` is the
+low-friction path.
+
+---
+
+## Scenario 4: Windows `mondo` not recognized after install (PATH not active yet)
+
+### Symptom
+
+You just installed `mondo` (via `scripts/install.ps1`, Scoop, or by adding the
+folder to PATH yourself), but the same terminal still says:
+
+```
+mondo : The term 'mondo' is not recognized as the name of a cmdlet, function,
+script file, or operable program.
+```
+
+### Diagnosis
+
+`PATH` changes only take effect for **newly launched** processes. Your current
+terminal read its environment at startup and won't pick up an entry added
+afterwards. The installers persist the change to your **user** PATH correctly —
+the running shell just predates it.
+
+### Fix
+
+Simplest: **open a new terminal** and try again:
+
+```powershell
+mondo --version
+```
+
+To avoid reopening, reload PATH in the current PowerShell session:
+
+```powershell
+$env:Path = [Environment]::GetEnvironmentVariable("Path", "User") + ";" +
+            [Environment]::GetEnvironmentVariable("Path", "Machine")
+mondo --version
+```
+
+(`install.ps1` already updates the *current* session's PATH, so this mostly
+affects Scoop installs and manual PATH edits, or a second terminal that was
+open while you installed.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
     "openpyxl>=3.1.5",
     "rapidfuzz>=3,<4",
     "markdown-it-py>=3",
+    # Windows has no system IANA tz database, so zoneinfo (used by the
+    # world_clock codec) needs the tzdata package as a fallback source.
+    "tzdata; platform_system == 'Windows'",
 ]
 
 [project.optional-dependencies]

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -44,25 +44,31 @@ try {
     Invoke-WebRequest -UseBasicParsing -Uri "$base/$asset" -OutFile $zip
 
     # Verify the SHA256 against the release's SHA256SUMS.txt. Releases predating
-    # the checksum file (older pinned versions) skip verification — HTTPS to
-    # github.com still authenticates the transport.
+    # the checksum file return 404 and skip verification (HTTPS to github.com
+    # still authenticates the transport); any *other* fetch failure is fatal so
+    # a transient network/TLS error can't silently downgrade integrity.
+    $sums = $null
     try {
         $sums = (Invoke-WebRequest -UseBasicParsing -Uri "$base/SHA256SUMS.txt").Content
     } catch {
-        $sums = $null
+        $status = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
+        if ($status -eq 404) {
+            Write-Warning "SHA256SUMS.txt not published for v$Version - skipping integrity check."
+        } else {
+            throw "failed to fetch SHA256SUMS.txt: $($_.Exception.Message)"
+        }
     }
     if ($sums) {
-        $line = ($sums -split "`n") |
-            Where-Object { $_ -match [regex]::Escape($asset) } | Select-Object -First 1
-        if (-not $line) { throw "no checksum for $asset in SHA256SUMS.txt" }
-        $expected = (($line -split '\s+') | Where-Object { $_ })[0].ToLower()
+        # Anchored match: 64 hex digits, optional '*' (binary marker), exact asset.
+        $pattern = '(?m)^([A-Fa-f0-9]{64})\s+\*?' + [regex]::Escape($asset) + '\s*$'
+        $m = [regex]::Match($sums, $pattern)
+        if (-not $m.Success) { throw "no checksum for $asset in SHA256SUMS.txt" }
+        $expected = $m.Groups[1].Value.ToLower()
         $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
         if ($actual -ne $expected) {
             throw "SHA256 mismatch for ${asset}:`n  expected $expected`n  actual   $actual"
         }
         Write-Host "Verified SHA256 checksum."
-    } else {
-        Write-Warning "SHA256SUMS.txt not published for v$Version - skipping integrity check."
     }
 
     Expand-Archive -Path $zip -DestinationPath $tmp -Force

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3,8 +3,9 @@
     Install the mondo CLI on Windows (x86_64).
 
 .DESCRIPTION
-    Downloads the latest mondo release archive from GitHub, extracts it to
-    %LOCALAPPDATA%\Programs\mondo, and adds that directory to the user PATH.
+    Downloads the latest mondo release archive from GitHub, verifies its
+    SHA256 checksum, extracts it to %LOCALAPPDATA%\Programs\mondo, and adds
+    that directory to the user PATH.
 
     Intended for the one-liner:
 
@@ -23,14 +24,15 @@ $InstallDir = Join-Path $env:LOCALAPPDATA "Programs\mondo"
 $Version = $env:MONDO_VERSION
 if (-not $Version) {
     Write-Host "Resolving latest mondo release..."
-    $latest = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" `
+    $latest = Invoke-RestMethod -UseBasicParsing `
+        -Uri "https://api.github.com/repos/$Repo/releases/latest" `
         -Headers @{ "User-Agent" = "mondo-install" }
     $Version = $latest.tag_name -replace '^v', ''
 }
 $Version = $Version -replace '^v', ''
 
 $asset = "mondo-$Version-windows-x86_64.zip"
-$url = "https://github.com/$Repo/releases/download/v$Version/$asset"
+$base = "https://github.com/$Repo/releases/download/v$Version"
 
 Write-Host "Installing mondo $Version -> $InstallDir"
 
@@ -38,8 +40,30 @@ $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("mondo-install-" + [guid]::N
 New-Item -ItemType Directory -Path $tmp -Force | Out-Null
 try {
     $zip = Join-Path $tmp $asset
-    Write-Host "Downloading $url"
-    Invoke-WebRequest -Uri $url -OutFile $zip
+    Write-Host "Downloading $base/$asset"
+    Invoke-WebRequest -UseBasicParsing -Uri "$base/$asset" -OutFile $zip
+
+    # Verify the SHA256 against the release's SHA256SUMS.txt. Releases predating
+    # the checksum file (older pinned versions) skip verification — HTTPS to
+    # github.com still authenticates the transport.
+    try {
+        $sums = (Invoke-WebRequest -UseBasicParsing -Uri "$base/SHA256SUMS.txt").Content
+    } catch {
+        $sums = $null
+    }
+    if ($sums) {
+        $line = ($sums -split "`n") |
+            Where-Object { $_ -match [regex]::Escape($asset) } | Select-Object -First 1
+        if (-not $line) { throw "no checksum for $asset in SHA256SUMS.txt" }
+        $expected = (($line -split '\s+') | Where-Object { $_ })[0].ToLower()
+        $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
+        if ($actual -ne $expected) {
+            throw "SHA256 mismatch for ${asset}:`n  expected $expected`n  actual   $actual"
+        }
+        Write-Host "Verified SHA256 checksum."
+    } else {
+        Write-Warning "SHA256SUMS.txt not published for v$Version - skipping integrity check."
+    }
 
     Expand-Archive -Path $zip -DestinationPath $tmp -Force
 
@@ -60,15 +84,26 @@ finally {
 }
 
 # Add $InstallDir to the user PATH (persisted) and the current session.
+# Normalize entries (expand env vars, drop trailing slash, case-insensitive)
+# so a cosmetically-different existing entry doesn't produce a duplicate.
+function Get-NormalizedPath([string]$p) {
+    if (-not $p) { return "" }
+    return [Environment]::ExpandEnvironmentVariables($p).TrimEnd('\').ToLowerInvariant()
+}
+$targetNorm = Get-NormalizedPath $InstallDir
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
 $entries = ($userPath -split ';') | Where-Object { $_ -ne '' }
-if ($entries -notcontains $InstallDir) {
+$present = $false
+foreach ($e in $entries) { if ((Get-NormalizedPath $e) -eq $targetNorm) { $present = $true; break } }
+if (-not $present) {
     $newPath = (@($entries) + $InstallDir) -join ';'
     [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
     Write-Host "Added $InstallDir to your user PATH."
     Write-Host "Open a new terminal for the PATH change to take effect."
 }
-if (($env:Path -split ';') -notcontains $InstallDir) {
+# Make mondo usable in the current session too.
+$sessionNorm = ($env:Path -split ';') | ForEach-Object { Get-NormalizedPath $_ }
+if ($sessionNorm -notcontains $targetNorm) {
     $env:Path = "$env:Path;$InstallDir"
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+    Install the mondo CLI on Windows (x86_64).
+
+.DESCRIPTION
+    Downloads the latest mondo release archive from GitHub, extracts it to
+    %LOCALAPPDATA%\Programs\mondo, and adds that directory to the user PATH.
+
+    Intended for the one-liner:
+
+        irm https://raw.githubusercontent.com/zoltanf/mondo/main/scripts/install.ps1 | iex
+
+    Pin a specific version by setting $env:MONDO_VERSION (e.g. "0.11.0")
+    before running. No admin rights required — installs per-user.
+#>
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "zoltanf/mondo"
+$InstallDir = Join-Path $env:LOCALAPPDATA "Programs\mondo"
+
+# Resolve the version: explicit override, else the latest GitHub release.
+$Version = $env:MONDO_VERSION
+if (-not $Version) {
+    Write-Host "Resolving latest mondo release..."
+    $latest = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" `
+        -Headers @{ "User-Agent" = "mondo-install" }
+    $Version = $latest.tag_name -replace '^v', ''
+}
+$Version = $Version -replace '^v', ''
+
+$asset = "mondo-$Version-windows-x86_64.zip"
+$url = "https://github.com/$Repo/releases/download/v$Version/$asset"
+
+Write-Host "Installing mondo $Version -> $InstallDir"
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("mondo-install-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+    $zip = Join-Path $tmp $asset
+    Write-Host "Downloading $url"
+    Invoke-WebRequest -Uri $url -OutFile $zip
+
+    Expand-Archive -Path $zip -DestinationPath $tmp -Force
+
+    # The archive contains a single top-level mondo\ directory (PyInstaller
+    # onedir): mondo.exe plus its _internal\ runtime. Move its contents so the
+    # exe lands directly in $InstallDir.
+    $extracted = Join-Path $tmp "mondo"
+    if (-not (Test-Path (Join-Path $extracted "mondo.exe"))) {
+        throw "unexpected archive layout: mondo\mondo.exe not found in $asset"
+    }
+
+    if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir }
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    Move-Item -Path (Join-Path $extracted "*") -Destination $InstallDir -Force
+}
+finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}
+
+# Add $InstallDir to the user PATH (persisted) and the current session.
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$entries = ($userPath -split ';') | Where-Object { $_ -ne '' }
+if ($entries -notcontains $InstallDir) {
+    $newPath = (@($entries) + $InstallDir) -join ';'
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    Write-Host "Added $InstallDir to your user PATH."
+    Write-Host "Open a new terminal for the PATH change to take effect."
+}
+if (($env:Path -split ';') -notcontains $InstallDir) {
+    $env:Path = "$env:Path;$InstallDir"
+}
+
+Write-Host ""
+& (Join-Path $InstallDir "mondo.exe") --version
+Write-Host "mondo installed. Run 'mondo --help' to get started."

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -387,12 +387,16 @@ class TestHelpPanels:
         out = result.output
         if "Global Options" not in out:
             pytest.skip("no Global Options panel rendered (test environment)")
-        # Scope to just the Global Options panel body — slice between its
-        # header and the next panel header (any "╭─ <title> ─").
-        global_start = out.find("Global Options")
-        rest = out[global_start:]
-        next_panel = rest.find("\n╭─", 1)
-        global_body = rest if next_panel == -1 else rest[:next_panel]
+        # Scope to just the Global Options panel body — slice from its header to
+        # the next panel heading. Match by panel *title* rather than the box
+        # border char, which Rich renders as ASCII on legacy Windows consoles.
+        global_body = out.split("Global Options", 1)[1]
+        end_markers = ["Output / Query", "Cache", "Polling", "Pagination", "Filters"]
+        end_idx = min(
+            (global_body.find(m) for m in end_markers if global_body.find(m) != -1),
+            default=len(global_body),
+        )
+        global_body = global_body[:end_idx]
         # --output, --query, --fields must NOT appear inside the Global
         # Options panel (they now live in the Output / Query panel).
         assert "--query" not in global_body, global_body

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -77,7 +77,10 @@ class TestConfigPath:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
-        monkeypatch.setenv("HOME", str(tmp_path))
+        # config_path() resolves the home dir via Path.home(), which reads
+        # USERPROFILE on Windows and HOME on POSIX — patch the call directly
+        # so the test is platform-independent.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
         assert config_path() == tmp_path / ".config" / "mondo" / "config.yaml"
 
     def test_env_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -366,6 +366,7 @@ dependencies = [
     { name = "rich" },
     { name = "ruamel-yaml" },
     { name = "typer" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 
 [package.optional-dependencies]
@@ -399,6 +400,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=4.8.0" },
     { name = "typer", specifier = ">=0.15.0" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 provides-extras = ["dev"]
 
@@ -813,6 +815,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the gap between the Mac/Linux install story (`brew install`) and Windows, which previously only had a manually-extracted zip + hand-edited PATH.

## What's new

**1. Scoop bucket (one-command install)**
- New `update-scoop` job in `release.yml`, mirroring `update-homebrew`: downloads the Windows zip, computes its SHA256, renders `bucket/mondo.json`, pushes to [zoltanf/scoop-mondo](https://github.com/zoltanf/scoop-mondo). Skips pre-release tags.
- Users get `scoop bucket add mondo … && scoop install mondo`, with auto-PATH and `scoop update mondo`.
- Bucket repo created + seeded; `SCOOP_BUCKET_TOKEN` secret added (fine-grained PAT, Contents:write on the bucket).

**2. PowerShell install script** — `scripts/install.ps1`
- Per-user `irm … | iex`: resolves latest release (or `$env:MONDO_VERSION`), downloads, extracts to `%LOCALAPPDATA%\Programs\mondo`, adds to user PATH. No admin, no Scoop required.

**3. Windows CI** — `ci.yml`
- New `windows-2022` job running `uv sync` + the non-integration pytest suite on every PR/push (previously Windows only ran during the release smoke test).
- A `pwsh` step parses `install.ps1` to catch syntax errors — useful since the script can't be exercised on the macOS dev box.

**4. README** — Scoop + PowerShell install sections; release-pipeline description lists the bucket update; fixed stale "five binaries / Intel" → four (arm64).

## Verification notes
- Both workflow YAMLs parse; the scoop heredoc → JSON was simulated locally and validated with `jq` (`bin` = `mondo\mondo.exe`, autoupdate keeps literal `$version`).
- Source scanned for Windows hazards (`fcntl`/`symlink`/POSIX paths/keyring) — clean.
- The Windows pytest job, pwsh parse, and `update-scoop` job execute only on GitHub runners — first real proof is this PR's CI run + the next stable release.