### PR TITLE
feat(item): auto-resolve --board on rename; add --with-url to find/list

### DIFF
--- a/src/mondo/api/queries.py
+++ b/src/mondo/api/queries.py
@@ -44,6 +44,17 @@ query ($id: ID!) {
 """.strip()
 
 
+# Minimal board-id lookup used by `item rename` to auto-resolve --board
+# from an explicit item id.
+ITEM_BOARD_LOOKUP = """
+query ($id: ID!) {
+  items(ids: [$id]) {
+    board { id }
+  }
+}
+""".strip()
+
+
 ITEM_GET_WITH_UPDATES = """
 query ($id: ID!) {
   items(ids: [$id]) {

--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -281,6 +281,10 @@ EXAMPLES: dict[str, list[Example]] = {
             "--refresh-cache / --no-cache: the bare board listing is cached per board (60s TTL)",
             "mondo item list --board 1234567890 --refresh-cache",
         ),
+        Example(
+            "Include each item's clickable URL",
+            "mondo item list --board 1234567890 --with-url",
+        ),
     ],
     "item find": [
         Example(
@@ -300,6 +304,10 @@ EXAMPLES: dict[str, list[Example]] = {
             "Count matches",
             "mondo item find --board 1234567890 --column status --value Done "
             "-q 'length(@)' -o none",
+        ),
+        Example(
+            "Include each match's clickable URL",
+            "mondo item find --board 1234567890 --column status --value Done --with-url",
         ),
     ],
     "item get": [
@@ -360,11 +368,11 @@ EXAMPLES: dict[str, list[Example]] = {
     ],
     "item rename": [
         Example(
-            "Rename an item",
-            'mondo item rename --id 987 --board 1234567890 --name "New title"',
+            "Rename an item (board auto-resolved from the item id)",
+            'mondo item rename 987 --name "New title"',
         ),
         Example(
-            "Rename by current name (case-insensitive substring)",
+            "Rename by current name (case-insensitive substring; needs --board)",
             'mondo item rename --board 1234567890 --name-contains "Old title" --name "New title"',
         ),
         Example(

--- a/src/mondo/cli/_field_sets.py
+++ b/src/mondo/cli/_field_sets.py
@@ -102,8 +102,12 @@ def item_get_fields() -> frozenset[str]:
 
 @lru_cache(maxsize=1)
 def item_list_fields() -> frozenset[str]:
-    return extract_selected_fields(ITEMS_PAGE_INITIAL) | extract_selected_fields(
-        ITEMS_PAGE_INITIAL_WITH_SUBITEMS
+    # `url` is synthesized by `--with-url`; allow it unconditionally to
+    # avoid warnings under that flag (same policy as boards).
+    return (
+        extract_selected_fields(ITEMS_PAGE_INITIAL)
+        | extract_selected_fields(ITEMS_PAGE_INITIAL_WITH_SUBITEMS)
+        | frozenset({"url"})
     )
 
 

--- a/src/mondo/cli/_list_decorate.py
+++ b/src/mondo/cli/_list_decorate.py
@@ -6,6 +6,7 @@ url fields. Live-path and cache-path code funnel through the same helpers.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from mondo.api.errors import MondoError
@@ -27,21 +28,40 @@ def enrich_workspaces_best_effort(entries: list[dict[str, Any]], opts: GlobalOpt
         pass
 
 
-def apply_board_urls(entries: list[dict[str, Any]], opts: GlobalOpts) -> None:
-    """Attach a synthesized monday `url` to each board entry."""
-    from mondo.cli._url import board_url, get_tenant_slug
+def _apply_urls(
+    entries: list[dict[str, Any]],
+    opts: GlobalOpts,
+    make_url: Callable[[str, int], str],
+) -> None:
+    """Resolve the tenant slug once, then set `url` on each entry with a
+    numeric id via `make_url(slug, entry_id)`."""
+    from mondo.cli._url import get_tenant_slug
 
     try:
         with opts.build_client() as client:
             slug = get_tenant_slug(client)
     except MondoError as e:
         handle_mondo_error_or_exit(e)
-    for b in entries:
+    for entry in entries:
         try:
-            bid = int(b.get("id"))  # type: ignore[arg-type]
+            entry_id = int(entry.get("id"))  # type: ignore[arg-type]
         except TypeError, ValueError:
             continue
-        b["url"] = board_url(slug, bid)
+        entry["url"] = make_url(slug, entry_id)
+
+
+def apply_board_urls(entries: list[dict[str, Any]], opts: GlobalOpts) -> None:
+    """Attach a synthesized monday `url` to each board entry."""
+    from mondo.cli._url import board_url
+
+    _apply_urls(entries, opts, board_url)
+
+
+def apply_item_urls(entries: list[dict[str, Any]], opts: GlobalOpts, *, board_id: int) -> None:
+    """Attach a synthesized monday `url` to each item entry."""
+    from mondo.cli._url import item_url
+
+    _apply_urls(entries, opts, lambda slug, item_id: item_url(slug, board_id, item_id))
 
 
 def strip_url_fields(entries: list[dict[str, Any]]) -> None:

--- a/src/mondo/cli/item.py
+++ b/src/mondo/cli/item.py
@@ -19,6 +19,7 @@ from mondo.api.errors import (
 from mondo.api.pagination import MAX_PAGE_SIZE, iter_items_page
 from mondo.api.queries import (
     ITEM_ARCHIVE,
+    ITEM_BOARD_LOOKUP,
     ITEM_CREATE,
     ITEM_DELETE,
     ITEM_DUPLICATE,
@@ -290,6 +291,12 @@ def list_cmd(
         "Unknown/typo'd column ids are silently omitted by the API (no error).",
         rich_help_panel="Filters",
     ),
+    with_url: bool = typer.Option(
+        False,
+        "--with-url",
+        help="Include a synthesized monday.com `url` on every emitted item "
+        "(one extra account-slug query; not supported with --parent).",
+    ),
     limit: int = typer.Option(
         MAX_PAGE_SIZE,
         "--limit",
@@ -343,6 +350,7 @@ def list_cmd(
         filter_expr=filter_expr,
         order_by=order_by,
         columns_sel=columns_sel,
+        with_url=with_url,
         limit=limit,
         max_items=max_items,
         poll_until=poll_until,
@@ -363,6 +371,7 @@ def _list_items_impl(
     filter_expr: list[str] | None = None,
     order_by: str | None = None,
     columns_sel: str | None = None,
+    with_url: bool = False,
     limit: int = MAX_PAGE_SIZE,
     max_items: int | None = None,
     poll_until: str | None = None,
@@ -383,6 +392,10 @@ def _list_items_impl(
     if parent_id is not None:
         if columns_sel is not None:
             usage_error_or_exit("--columns is not supported with --parent (subitem listing).")
+        if with_url:
+            usage_error_or_exit(
+                "--with-url is not supported with --parent (subitems live on a separate board)."
+            )
         data = execute(opts, SUBITEMS_LIST, {"parent": parent_id})
         items = data.get("items") or []
         if not items:
@@ -391,6 +404,17 @@ def _list_items_impl(
         return
 
     board_id = resolve_required_id(board_pos, board_flag, flag_name="--board", resource="board")
+
+    def _decorate_and_emit(items: list[dict[str, Any]]) -> None:
+        """Shared emit tail for the cache-hit and live paths: optional
+        --with-url decoration, then the field-selected emit."""
+        if with_url:
+            from mondo.cli._list_decorate import apply_item_urls
+
+            apply_item_urls(items, opts, board_id=board_id)
+        from mondo.cli._field_sets import item_list_fields
+
+        opts.emit(items, selected_fields=item_list_fields())
 
     # Cache eligibility (#21) keys off the *user's* filters; the --group
     # sugar is served from the cached full-board list by filtering
@@ -458,7 +482,6 @@ def _list_items_impl(
         cached = store.read()
         if cached is not None:
             from mondo.cli._cache_flags import emit_cache_provenance
-            from mondo.cli._field_sets import item_list_fields
 
             emit_cache_provenance(opts, cached, store=store)
             items = cached.entries
@@ -466,7 +489,7 @@ def _list_items_impl(
                 items = [it for it in items if (it.get("group") or {}).get("id") == group_id]
             if max_items is not None:
                 items = items[:max_items]
-            opts.emit(items, selected_fields=item_list_fields())
+            _decorate_and_emit(items)
             return
     # Only the full-board, full-shape result may be written back — a group
     # slice, a max-items prefix, or a slimmed selection would poison the
@@ -536,9 +559,9 @@ def _list_items_impl(
     except UsageError as e:
         usage_error_or_exit(str(e))
 
-    from mondo.cli._field_sets import item_list_fields
-
-    opts.emit(items, selected_fields=item_list_fields())
+    # Decorate after the cache write above so the synthesized `url` never
+    # poisons the cached full-board list.
+    _decorate_and_emit(items)
 
 
 @app.command("find", epilog=epilog_for("item find"))
@@ -551,6 +574,12 @@ def find_cmd(
     column_id: str = typer.Option(..., "--column", help="Column ID to match on (e.g. 'status')."),
     value: str = typer.Option(
         ..., "--value", help="Column value to match (label, index #N, or CSV)."
+    ),
+    with_url: bool = typer.Option(
+        False,
+        "--with-url",
+        help="Include a synthesized monday.com `url` on every emitted item "
+        "(one extra account-slug query).",
     ),
 ) -> None:
     """Find items by column value.
@@ -566,6 +595,7 @@ def find_cmd(
         board_pos=board_pos,
         board_flag=board_flag,
         filter_expr=[f"{column_id}={value}"],
+        with_url=with_url,
     )
 
 
@@ -845,7 +875,12 @@ def rename_cmd(
     ctx: typer.Context,
     id_pos: int | None = typer.Argument(None, metavar="[ID]", help="Item ID (positional)."),
     id_flag: int | None = typer.Option(None, "--id", "--item", help="Item ID (flag form)."),
-    board_id: int = typer.Option(..., "--board", help="Parent board ID."),
+    board_id: int | None = typer.Option(
+        None,
+        "--board",
+        help="Parent board ID (auto-resolved from the item id when omitted; "
+        "required for name-based selection).",
+    ),
     name_contains: str | None = typer.Option(
         None, "--name-contains", help="Pick the item by case-insensitive name substring."
     ),
@@ -869,15 +904,39 @@ def rename_cmd(
     name match (`--name-contains` / `--name-matches` / `--name-fuzzy`). The
     filter path streams the board's items via `items_page` and is unsuitable
     for huge boards — pass an id directly when the target is known.
+
+    With an explicit id, `--board` may be omitted: it is auto-resolved from
+    the item with one cheap lookup query. Name-based selection still needs
+    `--board` to scope the search.
     """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     explicit_id: int | None
     if id_pos is not None and id_flag is not None and id_pos != id_flag:
         raise typer.BadParameter("pass the item ID as a positional argument or via --id, not both.")
     explicit_id = id_pos if id_pos is not None else id_flag
+    # All local selector validation runs before any network call, so usage
+    # conflicts surface as exit 2 rather than a lookup/auth failure. Same
+    # id-vs-filter mutex (and message) that resolve_by_filters enforces.
+    if explicit_id is not None and (name_contains or name_matches_re or name_fuzzy):
+        raise typer.BadParameter(
+            "pass either an item id or one of "
+            "--name-contains / --name-matches / --name-fuzzy, not both."
+        )
+    if board_id is None and explicit_id is None:
+        usage_error_or_exit(
+            "--board is required for name-based selection "
+            "(--name-contains / --name-matches / --name-fuzzy). "
+            "Pass an item id to have the board auto-resolved."
+        )
     client = client_or_exit(opts)
     try:
         with client:
+            if board_id is None:
+                lookup = exec_or_exit(client, ITEM_BOARD_LOOKUP, {"id": explicit_id})
+                found = lookup.get("items") or []
+                if not found or not (found[0].get("board") or {}).get("id"):
+                    raise NotFoundError(f"item {explicit_id} not found.")
+                board_id = int(found[0]["board"]["id"])
             resolved_item = resolve_item_target(
                 client,
                 board_id,

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -255,6 +255,47 @@ class TestItemList:
         result = runner.invoke(app, ["item", "list", "--board", "42", "--no-cache"])
         assert result.exit_code == 0, (result.stdout or "") + (result.stderr or "")
 
+    def test_with_url_attaches_synthesized_urls(
+        self, httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Issue #78: `item list --with-url` synthesizes a pulses URL per item."""
+        from mondo.cli import _url as url_mod
+
+        monkeypatch.setattr(url_mod, "_TENANT_SLUG_CACHE", None)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "boards": [
+                        {
+                            "items_page": {
+                                "cursor": None,
+                                "items": [{"id": "1", "name": "A"}, {"id": "2", "name": "B"}],
+                            }
+                        }
+                    ]
+                }
+            ),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"me": {"account": {"slug": "marktguru"}}}),
+        )
+        result = runner.invoke(app, ["item", "list", "--board", "42", "--with-url"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+        assert [r["url"] for r in parsed] == [
+            "https://marktguru.monday.com/boards/42/pulses/1",
+            "https://marktguru.monday.com/boards/42/pulses/2",
+        ]
+
+    def test_with_url_rejected_with_parent(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(app, ["item", "list", "--parent", "987", "--with-url"])
+        assert result.exit_code == 2
+        assert httpx_mock.get_requests() == []
+
 
 def _columns_response(columns: list[dict[str, object]]) -> dict[str, object]:
     """Build a COLUMNS_ON_BOARD response with the given column defs."""
@@ -696,6 +737,52 @@ class TestItemRename:
         assert "change_simple_column_value" in body["query"]
         assert 'column_id: "name"' in body["query"]
         assert "change_item_name" not in body["query"]
+
+    def test_without_board_resolves_it_from_item_id(self, httpx_mock: HTTPXMock) -> None:
+        """Issue #77: with an explicit id, --board is looked up via one query."""
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"items": [{"board": {"id": "42"}}]}),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"change_simple_column_value": {"id": "1", "name": "New name"}}),
+        )
+        result = runner.invoke(app, ["item", "rename", "1", "--name", "New name"])
+        assert result.exit_code == 0, result.output
+        reqs = [json.loads(r.content) for r in httpx_mock.get_requests()]
+        assert len(reqs) == 2
+        assert "board { id }" in reqs[0]["query"]
+        assert reqs[0]["variables"] == {"id": 1}
+        assert reqs[1]["variables"] == {"board": 42, "id": 1, "name": "New name"}
+
+    def test_without_board_missing_item_exits_6(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"items": []}))
+        result = runner.invoke(app, ["item", "rename", "999", "--name", "New name"])
+        assert result.exit_code == 6
+        assert "item 999 not found" in result.stderr
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_explicit_id_with_name_filter_exits_2_without_network(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """id vs name-filter mutex is validated locally — no board lookup."""
+        result = runner.invoke(
+            app, ["item", "rename", "999", "--name-contains", "old", "--name", "New"]
+        )
+        assert result.exit_code == 2
+        assert "not both" in result.stderr
+        assert httpx_mock.get_requests() == []
+
+    def test_name_contains_without_board_exits_2(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app, ["item", "rename", "--name-contains", "banana", "--name", "Cherry"]
+        )
+        assert result.exit_code == 2
+        assert "--board is required" in result.stderr
+        assert httpx_mock.get_requests() == []
 
 
 class TestItemCreateBatch:

--- a/tests/unit/test_cli_item_find.py
+++ b/tests/unit/test_cli_item_find.py
@@ -146,6 +146,56 @@ def test_item_find_unknown_label_errors_with_pointer(httpx_mock: HTTPXMock) -> N
     assert "mondo column labels" in combined
 
 
+def test_item_find_with_url_attaches_urls(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #78: `item find --with-url` decorates each match with its
+    clickable pulses URL (same semantics as `item list --with-url`)."""
+    from mondo.cli import _url as url_mod
+
+    monkeypatch.setattr(url_mod, "_TENANT_SLUG_CACHE", None)
+    _stub_status_column(httpx_mock)
+    _stub_items(
+        httpx_mock,
+        [
+            {
+                "id": "1",
+                "name": "Alpha",
+                "state": "active",
+                "group": {"id": "g1", "title": "T"},
+                "column_values": [],
+            }
+        ],
+    )
+    httpx_mock.add_response(
+        url=ENDPOINT,
+        method="POST",
+        json={
+            "data": {"me": {"account": {"slug": "marktguru"}}},
+            "extensions": {"request_id": "r"},
+        },
+    )
+    result = runner.invoke(
+        app,
+        [
+            "-o",
+            "json",
+            "item",
+            "find",
+            "--board",
+            "42",
+            "--column",
+            "status",
+            "--value",
+            "Done",
+            "--with-url",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    rows = json.loads(result.stdout)
+    assert rows[0]["url"] == "https://marktguru.monday.com/boards/42/pulses/1"
+
+
 def test_item_find_in_help_index() -> None:
     """`mondo item --help` should list 'find' alongside list/get/create."""
     result = runner.invoke(app, ["item", "--help"])


### PR DESCRIPTION
Resolves #77, resolves #78.

## What
- `item rename <id> --name ...` no longer requires `--board`: the board is resolved with one `items(ids:[...]){board{id}}` query (new `ITEM_BOARD_LOOKUP`). Missing item → exit 6. `--name-contains` selection still requires `--board` (exit 2 without it), and the id-vs-name-filter mutex now fires locally **before** any network call.
- `item find` and `item list` gained `--with-url` (shared `_list_items_impl` made both trivial). URL decoration happens after the cache write so synthesized `url` fields never enter the board_items cache; rejected with `--parent` (subitems live on a separate board).

## Testing
- 6 new unit tests (board auto-resolve request sequence, missing-item exit 6, name-filter-without-board exit 2, id+name-filter mutex with zero HTTP requests, URL decoration, `--parent` guard). Full non-integration suite: 1812 passed.
- Live-verified on the playground board (5094861043): create → rename without `--board` → verify → `find --with-url` returns the pulse URL → hard-delete cleanup confirmed.

## Review gate
Reviewed by a 3-lens subagent workflow (findings adversarially verified) + Codex gpt-5.5 (high). Fixed from review: selector validation ran after the network lookup (Codex P2 — a usage conflict could surface as exit 6 or a network failure); `apply_item_urls`/`apply_board_urls` duplication factored into a shared helper; decorate+emit tail deduplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)