### PR TITLE
feat(doc): add --folder filter to doc list

### DIFF
--- a/src/mondo/cli/_examples.py
+++ b/src/mondo/cli/_examples.py
@@ -572,6 +572,10 @@ EXAMPLES: dict[str, list[Example]] = {
             "mondo doc list --object-id 77",
         ),
         Example(
+            "Only docs inside one folder (client-side; root docs never match)",
+            "mondo doc list --workspace 42 --folder 987654",
+        ),
+        Example(
             "Filter by name (client-side substring)",
             "mondo doc list --name-contains spec",
         ),

--- a/src/mondo/cli/doc.py
+++ b/src/mondo/cli/doc.py
@@ -283,6 +283,12 @@ def list_cmd(
         help="Filter by doc object_id (repeatable).",
         rich_help_panel="Filters",
     ),
+    folder: int | None = typer.Option(
+        None,
+        "--folder",
+        help="Client-side filter on folder ID (workspace-root docs never match).",
+        rich_help_panel="Filters",
+    ),
     kind: DocKind | None = typer.Option(
         None,
         "--kind",
@@ -366,8 +372,10 @@ def list_cmd(
     """List docs (page-based).
 
     Use --name-contains / --name-matches / --name-fuzzy to narrow by name,
-    --workspace to restrict to workspaces, and --kind to pick public/private/
-    share. Served from the local directory cache when available.
+    --workspace to restrict to workspaces, --folder to keep only docs inside
+    one folder (docs at the workspace root have no folder and never match),
+    and --kind to pick public/private/share. Served from the local directory
+    cache when available.
     """
     from mondo.api.errors import UsageError
     from mondo.cli._cache_flags import reject_mutually_exclusive, resolve_cache_prefs
@@ -387,6 +395,7 @@ def list_cmd(
             opts,
             workspace=workspace,
             object_id=object_id,
+            folder=folder,
             kind=kind,
             order_by=order_by,
             needle_lower=needle_lower,
@@ -416,6 +425,7 @@ def list_cmd(
                     **variables,
                     "limit": limit,
                     "max_items": max_items,
+                    "folder": folder,
                     "kind": kind.value if kind else None,
                     "name_contains": name_contains,
                     "name_matches": name_matches,
@@ -424,11 +434,13 @@ def list_cmd(
             }
         )
         raise typer.Exit(0)
-    # Client-side filters (kind / name_*) require fetching every page before
-    # capping, otherwise we'd drop matches past the first `max_items` pre-filter
-    # rows. When no client-side filter is active, let pagination stop early.
+    # Client-side filters (folder / kind / name_*) require fetching every page
+    # before capping, otherwise we'd drop matches past the first `max_items`
+    # pre-filter rows. When no client-side filter is active, let pagination
+    # stop early.
     client_side_filter_active = (
-        kind is not None
+        folder is not None
+        or kind is not None
         or needle_lower is not None
         or pattern is not None
         or name_fuzzy is not None
@@ -457,7 +469,8 @@ def list_cmd(
                         max_items=fetch_cap,
                     )
                 )
-                if (kind is None or (d.get("kind") or "") == kind.value)
+                if (folder is None or str(d.get("folder_id") or "") == str(folder))
+                and (kind is None or (d.get("kind") or "") == kind.value)
                 and _name_matches(d, needle_lower, pattern)
             ]
     except MondoError as e:
@@ -489,6 +502,7 @@ def _list_via_cache(
     *,
     workspace: list[int] | None,
     object_id: list[int] | None,
+    folder: int | None,
     kind: DocKind | None,
     order_by: DocsOrderBy | None,
     needle_lower: str | None,
@@ -516,6 +530,7 @@ def _list_via_cache(
                 "filters": {
                     "workspace_ids": workspace or None,
                     "object_ids": object_id or None,
+                    "folder": folder,
                     "kind": kind.value if kind else None,
                     "order_by": order_by.value if order_by else None,
                     "name_fuzzy": name_fuzzy,
@@ -545,6 +560,8 @@ def _list_via_cache(
     if object_id:
         wanted_obj = {str(o) for o in object_id}
         entries = [e for e in entries if str(e.get("object_id") or "") in wanted_obj]
+    if folder is not None:
+        entries = [e for e in entries if str(e.get("folder_id") or "") == str(folder)]
     entries = [e for e in entries if _name_matches(e, needle_lower, pattern)]
 
     if order_by is not None:

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -185,6 +185,67 @@ class TestList:
         parsed = json.loads(result.stdout)
         assert [d["id"] for d in parsed] == ["2", "3"]
 
+    def test_folder_filters_client_side(self, httpx_mock: HTTPXMock) -> None:
+        """--folder keeps only docs whose doc_folder_id matches; docs at the
+        workspace root (doc_folder_id null) never match."""
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "docs": [
+                        {"id": "1", "name": "A", "doc_folder_id": "555"},
+                        {"id": "2", "name": "B", "doc_folder_id": None},
+                        {"id": "3", "name": "C", "doc_folder_id": "777"},
+                        {"id": "4", "name": "D", "doc_folder_id": "555"},
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["doc", "list", "--folder", "555"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert [d["id"] for d in parsed] == ["1", "4"]
+
+    def test_folder_composes_with_name_filter(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "docs": [
+                        {"id": "1", "name": "Spec v1", "doc_folder_id": "555"},
+                        {"id": "2", "name": "Roadmap", "doc_folder_id": "555"},
+                        {"id": "3", "name": "spec doc", "doc_folder_id": "777"},
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(
+            app,
+            ["doc", "list", "--folder", "555", "--name-contains", "spec"],
+        )
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert [d["id"] for d in parsed] == ["1"]
+
+    def test_folder_no_match_emits_empty_list(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "docs": [
+                        {"id": "1", "name": "A", "doc_folder_id": "555"},
+                        {"id": "2", "name": "B", "doc_folder_id": None},
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["doc", "list", "--folder", "999"])
+        assert result.exit_code == 0, result.stdout
+        assert json.loads(result.stdout) == []
+
     def test_query_includes_doc_folder_id_and_updated_at(self, httpx_mock: HTTPXMock) -> None:
         """Both are native on Monday's `Doc` type and populate the
         `folder_id` / `updated_at` core shape fields."""
@@ -430,9 +491,9 @@ class TestListCache:
         assert httpx_mock.get_requests() == []
 
     def _queue_prime_for_fuzzy(self, httpx_mock: HTTPXMock) -> None:
-        """Seed the docs cache with a richer mix so fuzzy / kind tests can
-        distinguish matches. One workspace, four docs varying in name and
-        doc_kind."""
+        """Seed the docs cache with a richer mix so fuzzy / kind / folder
+        tests can distinguish matches. One workspace, four docs varying in
+        name, doc_kind and doc_folder_id (docs 2 and 4 sit at the root)."""
         httpx_mock.add_response(
             url=ENDPOINT,
             method="POST",
@@ -450,6 +511,7 @@ class TestListCache:
                             "name": "Product Launch",
                             "workspace_id": "42",
                             "doc_kind": "public",
+                            "doc_folder_id": "555",
                         },
                         {
                             "id": "2",
@@ -457,6 +519,7 @@ class TestListCache:
                             "name": "Marketing Plan",
                             "workspace_id": "42",
                             "doc_kind": "private",
+                            "doc_folder_id": None,
                         },
                         {
                             "id": "3",
@@ -464,6 +527,7 @@ class TestListCache:
                             "name": "Product Roadmap",
                             "workspace_id": "42",
                             "doc_kind": "public",
+                            "doc_folder_id": "555",
                         },
                         {
                             "id": "4",
@@ -471,6 +535,7 @@ class TestListCache:
                             "name": "Unrelated Stuff",
                             "workspace_id": "42",
                             "doc_kind": "private",
+                            "doc_folder_id": None,
                         },
                     ]
                 }
@@ -511,6 +576,15 @@ class TestListCache:
         assert result.exit_code == 0, result.stdout
         parsed = json.loads(result.stdout)
         assert sorted(d["id"] for d in parsed) == ["2", "4"]
+
+    def test_folder_filters_client_side_cache(self, httpx_mock: HTTPXMock) -> None:
+        """--folder served from the cache keeps only in-folder docs; docs at
+        the workspace root (doc_folder_id null) are excluded."""
+        self._queue_prime_for_fuzzy(httpx_mock)
+        result = runner.invoke(app, ["doc", "list", "--folder", "555"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert sorted(d["id"] for d in parsed) == ["1", "3"]
 
     def test_name_filters_mutually_exclusive_cache(self, httpx_mock: HTTPXMock) -> None:
         # No priming required — validation happens before any cache read.


### PR DESCRIPTION
Resolves #79.

## What
`doc list --folder <id>` — client-side filter on the normalized `folder_id` field (from `Document.doc_folder_id`, already fetched by the directory query; `queries.py` untouched). Works on both the live path (participates in `client_side_filter_active` so pagination fetches everything before capping) and the cache path. Root docs (`doc_folder_id: null`) never match. Composes with `--workspace` and the name filters; dry-run payloads echo `folder`.

## Testing
- 4 unit tests: live-path filter, composition with `--name-contains`, no-match, and cache-path filter (added from review — the cache branch was untested). Full non-integration suite: 1809 passed.
- Live-verified on the playground workspace (592446): created a throwaway folder + doc inside it, `doc list --workspace 592446 --folder <id> --no-cache` returned exactly that doc; negative checks (`--folder 999999999` → `[]`); doc + folder deleted, zero leftovers confirmed.

## Review gate
Reviewed by a 3-lens subagent workflow (adversarially verified) + Codex gpt-5.5 (high). Codex: clean. Workflow: flagged the untested cache path — test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)