### PR TITLE
fix(cli): dedupe did-you-mean; tombstone for removed doc export-markdown

### DIFF
--- a/src/mondo/cli/_errors.py
+++ b/src/mondo/cli/_errors.py
@@ -99,8 +99,13 @@ def suggest_for_no_such_option(exc: click.exceptions.UsageError) -> str | None:
 
     Pulls Click's own `possibilities` (its difflib matches against
     registered options) first, then falls back to `FLAG_ALIAS_HINTS`
-    for cross-command aliases Click can't suggest.
+    for cross-command aliases Click can't suggest. A removed-command
+    tombstone attached by `MondoGroup.resolve_command` (as
+    `mondo_suggestion`) wins outright.
     """
+    tombstone = getattr(exc, "mondo_suggestion", None)
+    if tombstone:
+        return str(tombstone)
     if not isinstance(exc, click.exceptions.NoSuchOption):
         return None
     possibilities = getattr(exc, "possibilities", None) or []

--- a/src/mondo/cli/_help_format.py
+++ b/src/mondo/cli/_help_format.py
@@ -38,6 +38,41 @@ _OUTPUT_PARAM_NAMES: frozenset[str] = frozenset({"output", "query", "fields"})
 # Mirror the carve-outs in `mondo.cli.argv`.
 _ROOT_PARAM_SKIP: frozenset[str] = frozenset({"help", "install_completion", "show_completion"})
 
+# Tombstones for commands removed in past releases, keyed by
+# (command path below the prog name, attempted subcommand). Matched in
+# `MondoGroup.resolve_command`: the hint replaces the fuzzy did-you-mean
+# (which would steer e.g. a `doc export-markdown` read intent at the
+# `add-markdown` write command) and also feeds the JSON envelope's
+# `suggestion` field via `mondo.cli._errors.suggest_for_no_such_option`.
+# Keying on the command path (rather than the bare group name) keeps
+# nested groups that share a name distinct (`mondo column doc` never had
+# `export-markdown`); plural aliases render their own path (`docs`), so
+# each removed command lists both spellings. The path excludes the prog
+# name (see `_group_path`) so a differently-named entry point still
+# matches.
+_DOC_EXPORT_MARKDOWN_TOMBSTONE = (
+    "removed in 0.11 — use: mondo doc get --doc <id> --format markdown [--engine server]"
+)
+_REMOVED_COMMANDS: dict[tuple[str, str], str] = {
+    ("doc", "export-markdown"): _DOC_EXPORT_MARKDOWN_TOMBSTONE,
+    ("docs", "export-markdown"): _DOC_EXPORT_MARKDOWN_TOMBSTONE,
+}
+
+
+def _group_path(ctx: click.Context) -> str:
+    """Command path of `ctx` without the prog name, e.g. "column doc".
+
+    Built from the context chain rather than `ctx.command_path` because the
+    prog name may itself contain spaces (click reports `python -m pytest`
+    when invoked as a module).
+    """
+    names: list[str] = []
+    node: click.Context | None = ctx
+    while node is not None and node.parent is not None:
+        names.append(node.info_name or "")
+        node = node.parent
+    return " ".join(reversed(names))
+
 
 def is_global_param(param: click.Parameter) -> bool:
     """True if `param` (from the root command) is a true global option."""
@@ -116,7 +151,19 @@ class MondoGroup(typer.core.TyperGroup):
         a sibling under `item` when the user actually wanted `update create`.
         Listing every sibling subcommand lets the agent recover regardless
         of how close their typo was.
+
+        Typer's `TyperGroup.resolve_command` appends its own single-candidate
+        `Did you mean ...?` (`suggest_commands`, on by default since Typer
+        0.16 — guard with getattr, the declared floor 0.15 predates it),
+        which doubled our multi-candidate hint (#76) — disable it for the
+        duration of the call. Commands removed in past releases
+        (`_REMOVED_COMMANDS`) get a tombstone pointing at the replacement
+        invocation instead of a fuzzy match, and the tombstone rides along
+        on `exc.mondo_suggestion` for the JSON error envelope.
         """
+        suggest_commands = getattr(self, "suggest_commands", None)
+        if suggest_commands is not None:
+            self.suggest_commands = False
         try:
             return super().resolve_command(ctx, args)
         except click.UsageError as exc:
@@ -125,13 +172,21 @@ class MondoGroup(typer.core.TyperGroup):
 
                 siblings = sorted(self.list_commands(ctx))
                 if siblings:
-                    close = get_close_matches(args[0], siblings)
-                    parts = [exc.message.rstrip(".")]
-                    if close:
-                        parts.append("Did you mean " + ", ".join(repr(m) for m in close) + "?")
+                    parts = [exc.message.rstrip(".") + "."]
+                    tombstone = _REMOVED_COMMANDS.get((_group_path(ctx), args[0]))
+                    if tombstone:
+                        parts.append(f"'{args[0]}' was {tombstone}.")
+                        exc.mondo_suggestion = tombstone  # type: ignore[attr-defined]
+                    else:
+                        close = get_close_matches(args[0], siblings)
+                        if close:
+                            parts.append("Did you mean " + ", ".join(repr(m) for m in close) + "?")
                     parts.append("Available subcommands: " + ", ".join(siblings) + ".")
                     exc.message = " ".join(parts)
             raise
+        finally:
+            if suggest_commands is not None:
+                self.suggest_commands = suggest_commands
 
 
 class MondoCommand(typer.core.TyperCommand):

--- a/tests/unit/test_cli_no_such_command.py
+++ b/tests/unit/test_cli_no_such_command.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import click
 import pytest
 from typer.testing import CliRunner
 
+from mondo.cli._errors import error_envelope, suggest_for_no_such_option
 from mondo.cli.main import app
 
 runner = CliRunner()
@@ -66,3 +68,89 @@ def test_unknown_subcommand_keeps_fuzzy_hint_when_close() -> None:
     assert "list" in combined
     # The error should still flag it as a "did you mean" hint.
     assert "Did you mean" in combined or "did you mean" in combined.lower()
+
+
+def _flatten(text: str) -> str:
+    """Collapse rich's Error panel (borders + line wrapping) back into one
+    plain line so multi-word assertions survive the rendering."""
+    return " ".join(text.replace("│", " ").split())
+
+
+def test_fuzzy_hint_appears_exactly_once() -> None:
+    """Typer's built-in `suggest_commands` hint used to stack on top of ours,
+    printing 'Did you mean ...?' twice (#76)."""
+    result = runner.invoke(app, ["item", "liist"])
+    assert result.exit_code != 0
+    # `result.output` already includes stderr under click's CliRunner.
+    assert result.output.lower().count("did you mean") == 1
+
+
+def test_removed_doc_export_markdown_gets_tombstone() -> None:
+    """`doc export-markdown` (removed in 0.11) must point at the replacement
+    read command, not fuzzy-match to the `add-markdown` write command (#76)."""
+    result = runner.invoke(app, ["doc", "export-markdown"])
+    assert result.exit_code != 0
+    flat = _flatten(result.output)
+    assert "removed in 0.11" in flat
+    assert "mondo doc get --doc <id> --format markdown" in flat
+    # The fuzzy did-you-mean is suppressed in favor of the tombstone.
+    assert "did you mean" not in flat.lower()
+    # The sibling listing survives.
+    assert "Available subcommands:" in flat
+    assert "add-markdown" in flat
+
+
+def test_removed_doc_export_markdown_tombstone_covers_plural_alias() -> None:
+    """`mondo docs export-markdown` (plural alias) must show the same
+    tombstone — lazy loading names the group after the invoked alias, so
+    the tombstone is keyed on both `mondo doc` and `mondo docs` paths."""
+    result = runner.invoke(app, ["docs", "export-markdown"])
+    assert result.exit_code != 0
+    flat = _flatten(result.output)
+    assert "removed in 0.11" in flat
+    assert "mondo doc get --doc <id> --format markdown" in flat
+    assert "did you mean" not in flat.lower()
+
+
+def test_column_doc_export_markdown_gets_no_tombstone() -> None:
+    """`mondo column doc` is a different group that happens to be named
+    'doc' — `export-markdown` never existed there, so no tombstone; the
+    normal siblings listing applies."""
+    result = runner.invoke(app, ["column", "doc", "export-markdown"])
+    assert result.exit_code != 0
+    flat = _flatten(result.output)
+    assert "removed in 0.11" not in flat
+    assert "Available subcommands:" in flat
+    for sibling in ("append", "clear", "get", "set"):
+        assert sibling in flat, f"missing column-doc sibling {sibling!r}: {flat}"
+
+
+def test_resolve_command_survives_missing_suggest_commands_attr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """typer<0.16 (declared floor is 0.15) has no `suggest_commands`
+    attribute and no `resolve_command` override — an unknown subcommand
+    must still raise UsageError, not AttributeError."""
+    import typer.core
+
+    from mondo.cli._help_format import MondoGroup
+
+    monkeypatch.setattr(typer.core.TyperGroup, "resolve_command", click.Group.resolve_command)
+    group = MondoGroup(name="doc")
+    assert "suggest_commands" in vars(group)  # sanity: current typer sets it
+    del group.suggest_commands  # simulate the older typer
+    ctx = click.Context(group)
+    with pytest.raises(click.UsageError):
+        group.resolve_command(ctx, ["bogus"])
+    assert not hasattr(group, "suggest_commands")  # guard didn't re-create it
+
+
+def test_tombstone_feeds_envelope_suggestion() -> None:
+    """The JSON error envelope's `suggestion` field carries the tombstone
+    text, via the same path `main()` uses for UsageErrors."""
+    with pytest.raises(click.exceptions.UsageError) as excinfo:
+        app(args=["doc", "export-markdown"], standalone_mode=False)
+    env = error_envelope(excinfo.value, suggestion=suggest_for_no_such_option(excinfo.value))
+    assert env["suggestion"] == (
+        "removed in 0.11 — use: mondo doc get --doc <id> --format markdown [--engine server]"
+    )


### PR DESCRIPTION
Resolves #76.

## What
- **Doubled did-you-mean fixed at the source**: the first hint came from Typer's `suggest_commands` (not Click); `MondoGroup.resolve_command` now disables it around the `super()` call (guarded with `getattr` so the declared typer≥0.15 floor can't AttributeError; restored in `finally`), leaving exactly one multi-candidate hint — ours.
- **Tombstone for the removed command**: `doc export-markdown` (removed in 0.11, #71) now errors with `removed in 0.11 — use: mondo doc get --doc <id> --format markdown [--engine server]` instead of pointing at `add-markdown` (a write command). The hint also lands in the JSON envelope's `suggestion` field. Keyed on the context-chain group path, so the `docs` plural alias gets the tombstone and the unrelated nested `column doc` group does not.

## Testing
6 unit tests: single did-you-mean for a close typo, tombstone + suppressed fuzzy hint + retained `Available subcommands` tail, envelope `suggestion`, plural-alias coverage, `column doc` non-collision, and a simulated typer-0.15 (no `suggest_commands`) run asserting UsageError not AttributeError. Full non-integration suite: 1811 passed. Pure CLI-parsing change, no live API surface.

## Review gate
Reviewed by a 3-lens subagent workflow (adversarially verified) + Codex gpt-5.5 (high). Fixed from review: `docs` alias missed the tombstone (Codex); `column doc` false-positive tombstone (workflow); unguarded `suggest_commands` vs the typer≥0.15.0 floor (workflow, 3/3 verifiers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)