### PR TITLE
fix(cli): surface stale-skill warning in non-TTY runs, once per day

### DIFF
--- a/src/mondo/cli/_notices.py
+++ b/src/mondo/cli/_notices.py
@@ -1,12 +1,15 @@
 """Gate for benign stderr notices (#25).
 
 A third of observed agent invocations append `2>/dev/null`, partly because
-mondo emits benign noise (cache-hit notices, skill-freshness warnings) on
-stderr in non-interactive runs — training the habit that stderr is junk,
-which then hides real errors. Benign notices now show only when a human is
-plausibly watching (stderr is a TTY) or when explicitly requested
-(`--verbose` / `MONDO_VERBOSE=1`). Errors are unaffected — they always go
-to stderr.
+mondo emits benign noise (cache-hit notices) on stderr in non-interactive
+runs — training the habit that stderr is junk, which then hides real
+errors. Benign notices now show only when a human is plausibly watching
+(stderr is a TTY) or when explicitly requested (`--verbose` /
+`MONDO_VERBOSE=1`). Errors are unaffected — they always go to stderr.
+
+Skill-freshness warnings are exempt from this gate (#75): agent (non-TTY)
+runs are the audience consuming the skill, so `_skill_freshness` warns
+them too, rate-limited instead of gated.
 """
 
 from __future__ import annotations

--- a/src/mondo/cli/_skill_freshness.py
+++ b/src/mondo/cli/_skill_freshness.py
@@ -6,19 +6,35 @@ against any installed copies under `~/.claude/skills/mondo/SKILL.md` and
 `./.claude/skills/mondo/SKILL.md`. Emits one stderr line per outdated
 location, including a copy-pasteable update command.
 
+The warning is exempt from the benign-notices gate (#25): agent (non-TTY)
+runs are exactly the audience consuming the skill, so they must see it
+too. To avoid spamming pipelines, non-TTY runs are instead rate-limited to
+one warning per 24h per install location, tracked in a JSON marker under
+the mondo cache dir (`skill_freshness_warned.json`). A new bundled version
+re-warns immediately, ignoring the window. TTY or `--verbose` /
+`MONDO_VERBOSE=1` runs warn on every invocation.
+
 Hand-customized installs (no `version:` field) are silently ignored.
-Every IO/parse error is swallowed — this must never break the CLI.
+Every IO/parse error is swallowed (including marker read/write) — this
+must never break the CLI. Marker updates are unlocked read-modify-write:
+two concurrent runs may each warn once, which is accepted as best-effort.
 """
 
 from __future__ import annotations
 
+import contextlib
+import json
+import os
 import re
 import sys
+import tempfile
+import time
 from importlib import resources
 from pathlib import Path
 
 _VERSION_RE = re.compile(r'^version:\s*["\']?([^"\'\n]+?)["\']?\s*$', re.MULTILINE)
 _FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+_WARN_INTERVAL_SECONDS = 24 * 60 * 60
 
 
 def _parse_skill_version(text: str) -> str | None:
@@ -80,28 +96,92 @@ def _candidate_locations() -> list[tuple[Path, str, str]]:
     ]
 
 
-def warn_if_skill_outdated() -> None:
+def _marker_path() -> Path:
+    from mondo.cache.paths import cache_dir
+
+    return cache_dir() / "skill_freshness_warned.json"
+
+
+def _read_marker() -> dict[str, object]:
+    try:
+        data = json.loads(_marker_path().read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_marker(marker: dict[str, object]) -> None:
+    """Atomically replace the marker file (temp file + os.replace).
+
+    A plain write could leave torn JSON if the process dies mid-write,
+    costing a parse failure on every subsequent run.
+    """
+    tmp: str | None = None
+    try:
+        path = _marker_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name, suffix=".tmp")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(marker))
+        os.replace(tmp, path)
+    except Exception:
+        if tmp is not None:
+            with contextlib.suppress(OSError):
+                os.remove(tmp)
+
+
+def _rate_limit_allows(entry: object, bundled: str) -> bool:
+    """True when the non-TTY rate limit allows warning for this location."""
+    if not isinstance(entry, dict):
+        return True
+    if entry.get("bundled_version") != bundled:
+        return True  # new release: re-warn once, ignoring the window
+    warned_at = entry.get("warned_at")
+    if not isinstance(warned_at, (int, float)):
+        return True
+    # Default-allow: suppress only inside a sane elapsed window. A future
+    # warned_at (clock skew) or NaN makes the comparison False → warn and
+    # rewrite the marker with a fresh timestamp.
+    return not (0 <= time.time() - warned_at < _WARN_INTERVAL_SECONDS)
+
+
+def warn_if_skill_outdated(*, verbose: bool = False) -> None:
     """Emit one stderr line per outdated install location, if any.
 
     Silent when no install exists, when an install lacks a `version:`
     field (treated as an opt-out via hand-customization), when the
     bundled skill itself has no version, or on any IO/parse error.
+    TTY or verbose runs warn on every invocation; non-TTY runs are
+    rate-limited to once per 24h per location via the cache marker.
     """
     try:
         bundled = _bundled_version()
         if bundled is None:
             return
+        from mondo.cli._notices import benign_notices_enabled
+
+        rate_limited = not benign_notices_enabled(verbose=verbose)
+        marker = _read_marker() if rate_limited else {}
+        marker_dirty = False
         for path, display, fix_cmd in _candidate_locations():
             if not path.is_file():
                 continue
             installed = _installed_version(path)
             if installed is None:
                 continue
-            if _is_older(installed, bundled):
-                print(
-                    f"warning: mondo skill at {display} is v{installed} "
-                    f"(current: v{bundled}). Update: {fix_cmd}",
-                    file=sys.stderr,
-                )
+            if not _is_older(installed, bundled):
+                continue
+            if rate_limited:
+                if not _rate_limit_allows(marker.get(str(path)), bundled):
+                    continue
+                marker[str(path)] = {"bundled_version": bundled, "warned_at": time.time()}
+                marker_dirty = True
+            print(
+                f"warning: mondo skill at {display} is v{installed} "
+                f"(current: v{bundled}). Update: {fix_cmd}",
+                file=sys.stderr,
+            )
+        if marker_dirty:
+            _write_marker(marker)
     except Exception:
         return

--- a/src/mondo/cli/main.py
+++ b/src/mondo/cli/main.py
@@ -384,12 +384,12 @@ def _root(
     # parses stdout as JSON. The freshness-check module itself remains
     # callable from `tests/unit/test_cli_skill_freshness.py` (which exercises
     # `warn_if_skill_outdated()` directly).
-    # `benign_notices_enabled` (#25): the warning is benign noise to a
-    # pipeline — emit it only when a human is plausibly watching stderr.
-    from mondo.cli._notices import benign_notices_enabled
-
-    if not os.environ.get("PYTEST_CURRENT_TEST") and benign_notices_enabled(verbose=verbose):
-        warn_if_skill_outdated()
+    # The warning is exempt from the benign-notices gate (#25): agent
+    # (non-TTY) runs are exactly the audience consuming the skill. Instead,
+    # non-TTY runs are rate-limited to once per 24h per install location
+    # (see `_skill_freshness`); TTY/verbose runs warn every invocation.
+    if not os.environ.get("PYTEST_CURRENT_TEST"):
+        warn_if_skill_outdated(verbose=verbose)
     ctx.obj = GlobalOpts(
         profile_name=profile,
         flag_token=api_token,

--- a/tests/unit/test_cli_skill_freshness.py
+++ b/tests/unit/test_cli_skill_freshness.py
@@ -8,7 +8,11 @@ invocation. It must:
   - stay silent when no install exists, when an install lacks a
     `version:` field (treated as hand-customized opt-out), or when
     the installed version is current/newer;
-  - never raise.
+  - in non-TTY runs, rate-limit to one warning per 24h per install
+    location via a JSON marker under the cache dir, re-warning
+    immediately when the bundled version changes (#75);
+  - warn on every invocation in TTY or verbose runs;
+  - never raise, even on a corrupt or unwritable marker.
 
 These tests call `warn_if_skill_outdated()` directly and capture
 stderr via `capsys`, avoiding the overhead of a full CLI invocation.
@@ -16,6 +20,8 @@ stderr via `capsys`, avoiding the overhead of a full CLI invocation.
 
 from __future__ import annotations
 
+import json
+import time
 from importlib import resources
 from pathlib import Path
 
@@ -49,6 +55,10 @@ def _write_skill(path: Path, version: str | None) -> None:
 def isolated_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
     """Point Path.home() and Path.cwd() at fresh tmp dirs.
 
+    Also isolates the rate-limit marker (fresh `MONDO_CACHE_DIR`) and
+    pins the non-TTY, non-verbose path so rate-limit behavior is
+    deterministic regardless of the surrounding environment.
+
     Returns (home, cwd) so tests can write fake installed SKILL.mds.
     """
     home = tmp_path / "home"
@@ -57,7 +67,14 @@ def isolated_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Pat
     cwd.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
     monkeypatch.chdir(cwd)
+    monkeypatch.setenv("MONDO_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.delenv("MONDO_VERBOSE", raising=False)
+    monkeypatch.setattr("sys.stderr.isatty", lambda: False)
     return home, cwd
+
+
+def _warning_lines(capsys: pytest.CaptureFixture[str]) -> list[str]:
+    return [line for line in capsys.readouterr().err.splitlines() if line.startswith("warning:")]
 
 
 def test_warns_when_global_install_is_outdated(
@@ -160,6 +177,203 @@ def test_does_not_raise_on_malformed_yaml(
     _skill_freshness.warn_if_skill_outdated()
 
     assert capsys.readouterr().err == ""
+
+
+def test_nontty_warns_once_then_suppresses_within_window(
+    isolated_paths: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    home, _ = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert _warning_lines(capsys) == []
+
+
+def test_nontty_rate_limits_locations_independently(
+    isolated_paths: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    home, cwd = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+    # A second outdated location warns even though the first is in-window.
+    _write_skill(cwd / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+    _skill_freshness.warn_if_skill_outdated()
+    lines = _warning_lines(capsys)
+    assert len(lines) == 1
+    assert "./.claude/skills/mondo" in lines[0]
+
+
+def test_nontty_warns_again_after_window_expires(
+    isolated_paths: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    home, _ = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+    # Rewind the recorded timestamp past the 24h window.
+    marker_path = _skill_freshness._marker_path()
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    for entry in marker.values():
+        entry["warned_at"] -= _skill_freshness._WARN_INTERVAL_SECONDS + 1
+    marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+
+def test_nontty_new_bundled_version_rewarns_immediately(
+    isolated_paths: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home, _ = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+    # A new release changes the bundled version: re-warn despite the window.
+    monkeypatch.setattr(_skill_freshness, "_bundled_version", lambda: "999.0.0")
+    _skill_freshness.warn_if_skill_outdated()
+    lines = _warning_lines(capsys)
+    assert len(lines) == 1
+    assert "v999.0.0" in lines[0]
+
+    # ...but only once for that version.
+    _skill_freshness.warn_if_skill_outdated()
+    assert _warning_lines(capsys) == []
+
+
+def test_nontty_future_warned_at_warns_and_rewrites_marker(
+    isolated_paths: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    home, _ = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+    # Clock skew: a marker written under a fast clock, then NTP-corrected
+    # back, must not suppress forever — default-allow outside the window.
+    marker_path = _skill_freshness._marker_path()
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    for entry in marker.values():
+        entry["warned_at"] += 365 * 24 * 60 * 60
+    marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+    before = time.time()
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+    # The marker is rewritten with a sane (current) timestamp.
+    rewritten = json.loads(marker_path.read_text(encoding="utf-8"))
+    for entry in rewritten.values():
+        assert before <= entry["warned_at"] <= time.time()
+
+
+def test_nontty_nan_warned_at_warns_without_raising(
+    isolated_paths: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    home, _ = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+    # json.loads accepts NaN; every comparison against it is False, so a
+    # naive elapsed check would suppress forever.
+    marker_path = _skill_freshness._marker_path()
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    for entry in marker.values():
+        entry["warned_at"] = float("nan")
+    marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+
+def test_nontty_string_warned_at_warns_without_raising(
+    isolated_paths: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    home, _ = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+    marker_path = _skill_freshness._marker_path()
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    for entry in marker.values():
+        entry["warned_at"] = "yesterday"
+    marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+
+def test_nontty_corrupt_marker_warns_and_does_not_raise(
+    isolated_paths: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    home, _ = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+    marker_path = _skill_freshness._marker_path()
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text("{not json", encoding="utf-8")
+
+    _skill_freshness.warn_if_skill_outdated()
+
+    assert len(_warning_lines(capsys)) == 1
+
+
+def test_nontty_unwritable_marker_warns_and_does_not_raise(
+    isolated_paths: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    home, _ = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+    # A directory at the marker path makes both read and write fail.
+    _skill_freshness._marker_path().mkdir(parents=True, exist_ok=True)
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+    # No marker could be recorded, so the next run warns again.
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+
+
+def test_verbose_warns_on_every_invocation(
+    isolated_paths: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    home, _ = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+
+    _skill_freshness.warn_if_skill_outdated(verbose=True)
+    assert len(_warning_lines(capsys)) == 1
+    _skill_freshness.warn_if_skill_outdated(verbose=True)
+    assert len(_warning_lines(capsys)) == 1
+
+
+def test_tty_warns_on_every_invocation(
+    isolated_paths: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home, _ = isolated_paths
+    _write_skill(home / ".claude" / "skills" / "mondo" / "SKILL.md", "0.0.1")
+    monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
+    _skill_freshness.warn_if_skill_outdated()
+    assert len(_warning_lines(capsys)) == 1
 
 
 def test_parse_skill_version_handles_quoted_and_unquoted() -> None:


### PR DESCRIPTION
Resolves #75.

## What
The stale-skill warning is now exempt from the benign-notices TTY gate (#25) — it's actionable, not noise. TTY/`--verbose` behavior is unchanged (warn every invocation). Non-TTY (agent) runs warn at most **once per 24h per install location**, tracked in `<cache_dir>/skill_freshness_warned.json` keyed by absolute SKILL.md path; a new bundled skill version re-warns immediately. The window check is default-allow (`suppress only when 0 ≤ now − warned_at < 24h`), so clock skew or a NaN/corrupt timestamp degrades to warning again, never to indefinite silence. Marker writes are atomic (`mkstemp` + `os.replace`); every IO/parse error in the path is swallowed — the never-crash property holds.

## Accepted limitations (documented in the module docstring / here)
- The marker read-modify-write is unlocked: two concurrent first runs may each warn once. Worst case is one extra stderr line; a lock isn't worth it for a daily nudge.
- `mondo --version` (eager callback) exits before the root callback and doesn't warn.

## Testing
11 new/extended unit tests: warn-once-then-suppress, per-location independence, window expiry, version-bump re-warn, corrupt marker, unwritable marker, future/NaN/string `warned_at`, TTY/verbose paths. Full non-integration suite: 1816 passed.

## Review gate
Reviewed by a 3-lens subagent workflow (adversarially verified) + Codex gpt-5.5 (high). Fixed from review: future-dated `warned_at` suppressed warnings far beyond 24h (both reviewers); non-atomic marker write (workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)