### PR TITLE
docs(skill): document the cache command group (skill ref + help topic)

### DIFF
--- a/src/mondo/help/caching.md
+++ b/src/mondo/help/caching.md
@@ -1,0 +1,71 @@
+# Caching
+
+`mondo` caches monday reads on local disk so repeated calls don't re-hit the
+API. It's on by default, per-profile, and safe: an expired entry is never
+served, and a corrupt file self-heals (it's dropped and refetched).
+
+## What gets cached
+
+Two tiers:
+
+- **Directory caches** — account-wide lists, one file each: `boards`,
+  `workspaces`, `users`, `teams`, `docs`, `folders`, `tags`. Longer TTLs
+  (hours). These back name lookups like `board list --name-contains`.
+- **Per-scope detail caches** — one file per id: per-board `columns`,
+  `groups`, `webhooks`, `board_details`; per-board item lists (`board_items`);
+  per-item `items`, `subitems`, `updates`; per-doc `docs_blocks`. Short TTLs
+  (60 s to 15 m) because these change often.
+
+Each type has its own TTL. Freshness uses the CURRENT configured TTL, not the
+value stored when the file was written — lowering a TTL takes effect on
+already-written files. A file is expired once its age reaches the TTL.
+
+Invalidation is **local-process only**: another terminal's write isn't visible
+until the TTL lapses or you force a refresh. This keeps the model simple at the
+cost of cross-process freshness.
+
+## Escape hatches (on any cached read)
+
+    mondo board get 123 --no-cache        # skip cache entirely for this call
+    mondo board get 123 --refresh-cache   # force a live refetch + rewrite
+
+`--no-cache` and `--refresh-cache` together are a usage error. Cached reads may
+print `cache: hit (entity=…, age=…)` to stderr; silence it with
+`MONDO_NO_CACHE_NOTICE=1`. Filtered `item list` variants, account-wide
+`update list`, and raw `mondo graphql` are never cached.
+
+## Managing the cache
+
+    mondo cache status [<type>]              # age / freshness / entry count per file
+    mondo cache refresh [<type>] [--board ID ...]
+    mondo cache clear   [<type>] [--board ID ...] [--stale]
+
+`<type>` is one of: boards, workspaces, users, teams, docs, folders, tags,
+webhooks, columns, groups, board_details, items, board_items, subitems,
+updates, docs_blocks, or `all` (the default).
+
+**status** prints one row per file with `fresh` (servable now) and `stale` (a
+file that exists but has aged past its TTL — reclaimable). A cold type shows
+both false. In table output a footer nudges you to `cache clear --stale` when
+anything is stale. Project the reclaimable set with:
+
+    mondo cache status -q "[?stale].path"
+
+**clear** soft-deletes cache files (idempotent).
+
+    mondo cache clear --stale        # remove ONLY expired files; keep fresh ones
+    mondo cache clear                # remove everything
+    mondo cache clear columns --board 42
+
+`--stale` is endpoint- and schema-aware: files written against a different
+monday endpoint (kept intentionally for when you switch back) and wrong-schema
+files (self-healed on next read) are never reclaimed. Plain `clear` removes
+regardless of age. `--board` applies only to `columns`/`groups`/`webhooks`/
+`board_details`.
+
+**refresh** force-refetches and rewrites. The per-item / per-doc caches
+(`items`, `board_items`, `subitems`, `updates`, `docs_blocks`) can't be
+refreshed here — each needs a specific id — so use the read command's
+`--refresh-cache` instead (e.g. `mondo item get 999 --refresh-cache`).
+
+All three honor `--profile` and preview with `--dry-run`.

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mondo
 description: Use when the user wants to do anything against monday.com via the `mondo` CLI — reading or writing workspaces, folders, boards, groups, items, subitems, columns, updates, docs, files, users, teams, webhooks, or when they paste a monday.com URL.
-version: "1.8.0"
+version: "1.9.0"
 ---
 
 # mondo
@@ -36,6 +36,7 @@ Map your task to files:
 | workspaces or folders | `references/workspaces-and-folders.md` |
 | bulk export / import | `references/bulk.md` |
 | users, teams, webhooks, activity | `references/admin.md` |
+| local cache (status / clear / refresh, `--no-cache`, `--refresh-cache`) | `references/caching.md` |
 | item comments / updates | `references/updates.md` |
 
 If a task spans multiple areas (e.g. listing items and reading column values), read both files. Only after reading should you construct and run commands.
@@ -60,6 +61,7 @@ Consult these *before* improvising. Each is a Goal / Command / Output / Gotcha s
 - `references/workspaces-and-folders.md` — workspace lookup, folder tree, create / move / delete folders.
 - `references/bulk.md` — `--batch` envelopes, `mondo export` / `mondo import` for CSV/TSV/XLSX/JSON/Markdown/HTML/PDF (grouped-by-default for md/html/pdf; `--flat`, `--group`, `--filter`, `--columns`).
 - `references/admin.md` — users, teams, webhooks, tags, activity logs, favorites, notify, validation, complexity.
+- `references/caching.md` — local cache tiers + TTLs; `cache status`/`clear`/`refresh` (incl. `clear --stale`); per-read `--no-cache`/`--refresh-cache` escape hatches.
 
 ## Operating norms (every command obeys these)
 
@@ -81,8 +83,8 @@ Consult these *before* improvising. Each is a Goal / Command / Output / Gotcha s
 - **Name search over directories is cached.** `board / doc list --name-contains` serves from an 8h directory cache (folders have no name filter — use `folder tree` or plain `folder list`); the first cold search of the day pays the full directory fetch (parallelized, but still the expensive step). Don't add `--no-cache` to name searches out of caution — the cache IS the fast path; use `--refresh-cache` only when you have a concrete staleness reason.
 - **Cleanup:** delete commands soft-archive by default; pass `--hard` for true delete.
 - **Escape hatch:** `mondo graphql '<query>'` for anything no subcommand wraps. It emits the **unwrapped `data` object** by default (so `-q`/jq address the payload directly — no `.data` prefix); pass `--raw` for the full `{data, errors, extensions}` envelope. **Pass the query as a positional** — `-q/--query` is the global JMESPath projection, not the GraphQL query. If a GraphQL document lands in `--query` anyway, mondo runs it as the query (stderr note) but disables the projection for that call; pass it positionally to combine with `-q`. Before reaching for `graphql`, check there isn't already a subcommand: a file/asset download link is `mondo file url --asset <id> -q '[0].public_url'`, **not** a hand-written `graphql 'query { assets(ids:[…]) { public_url } }'`.
-- **Cache notice:** read commands may emit `cache: hit (entity=…, age=…)` to stderr. Suppress with `MONDO_NO_CACHE_NOTICE=1`. Force refresh with `--no-cache` or `--refresh-cache` on any cached read (`<entity> list/get` directories plus per-board / per-item / per-doc caches — `item get`, `item list` bare board scope (60s TTL), `subitem list/get`, `update list --item`, `doc get`, `board get`, `webhook list`, `tag list/get`). Filtered `item list` variants, account-wide `update list`, and `mondo graphql` stay live. See `docs/caching.md` for the per-entity TTL table.
+- **Cache notice:** read commands may emit `cache: hit (entity=…, age=…)` to stderr. Suppress with `MONDO_NO_CACHE_NOTICE=1`. Force refresh with `--no-cache` or `--refresh-cache` on any cached read (`<entity> list/get` directories plus per-board / per-item / per-doc caches — `item get`, `item list` bare board scope (60s TTL), `subitem list/get`, `update list --item`, `doc get`, `board get`, `webhook list`, `tag list/get`). Filtered `item list` variants, account-wide `update list`, and `mondo graphql` stay live. See `references/caching.md` for the cache tiers, the `cache status`/`clear`/`refresh` management commands (incl. `clear --stale`), and the per-entity TTL table.
 
 ## When references aren't enough
 
-Fall back to `mondo help <topic>` for prose deep-dives (the bundled topics cover codecs, exit codes, filters, batch operations, complexity, boards-vs-docs, output, auth, profiles, graphql, agent tips, agent workflow, duplicate-and-customize). For the long tail, `mondo help --dump-spec -o json` is the full contract.
+Fall back to `mondo help <topic>` for prose deep-dives (the bundled topics cover codecs, exit codes, filters, batch operations, complexity, boards-vs-docs, output, auth, profiles, graphql, caching, agent tips, agent workflow, duplicate-and-customize). For the long tail, `mondo help --dump-spec -o json` is the full contract.

--- a/src/mondo/skill/references/caching.md
+++ b/src/mondo/skill/references/caching.md
@@ -1,0 +1,68 @@
+# Caching
+
+`mondo` keeps a local on-disk cache so repeated reads don't re-hit the monday API. Two tiers: **directory caches** (account-wide lists — `boards`, `workspaces`, `users`, `teams`, `docs`, `folders`, `tags`) and **per-scope detail caches** (`board_details`, `board_items`, `items`, `subitems`, `updates`, `docs_blocks`, plus per-board `columns`/`groups`/`webhooks`). Each entity has its own TTL; a read is served from disk until it expires. Invalidation is **local-process only** — another terminal's write is not seen until the TTL lapses or you force a refresh. Full TTL table + design notes: `docs/caching.md`.
+
+## Escape hatches on any cached read
+
+Every cached read command (`board get/list`, `item get/list`, `doc get`, `column list`, `group list`, `update list --item`, name searches, …) accepts:
+
+```bash
+mondo board get 123 --no-cache        # skip the cache for this call (don't read or write)
+mondo board get 123 --refresh-cache   # force a live refetch and rewrite the cache
+```
+
+*Gotcha:* `--no-cache` and `--refresh-cache` together are a usage error (exit 2). Don't sprinkle `--no-cache` on name searches "to be safe" — the directory cache **is** the fast path; use `--refresh-cache` only when you have a concrete staleness reason (someone just renamed/created the thing you're looking for).
+
+*Gotcha:* cached reads may print `cache: hit (entity=…, age=…)` to **stderr** (never stdout). Suppress with `MONDO_NO_CACHE_NOTICE=1`. Filtered `item list` variants, account-wide `update list`, and raw `mondo graphql` are always live (never cached).
+
+## Inspect the cache — `cache status`
+
+```bash
+mondo cache status                # every cache type
+mondo cache status items          # one type; scoped types list one row per file on disk
+```
+
+```json
+[{"type": "boards", "path": "…/boards.json", "fetched_at": "2026-07-02T14:12:57Z",
+  "age": "3h57m", "ttl_seconds": 28800, "fresh": true, "stale": false, "entries": 6222}]
+```
+
+`fresh` = servable now. `stale` = a file exists on disk but has aged past its TTL (reclaimable dead weight). A cold type (no file) is both `fresh: false` and `stale: false`. In table output, a footer hint appears when any file is stale. Filter to just the reclaimable ones with a projection:
+
+```bash
+mondo cache status -q "[?stale].path"
+```
+
+## Reclaim stale files — `cache clear`
+
+```bash
+mondo cache clear --stale         # delete ONLY files past their TTL; keep fresh ones
+mondo cache clear items           # delete every per-item cache file
+mondo cache clear                 # delete everything (all types)
+mondo cache clear columns --board 42   # one board's column cache
+mondo --dry-run cache clear --stale    # preview what would be removed; deletes nothing
+```
+
+*Gotcha:* `--stale` is endpoint- and schema-aware: it never removes a file written against a different monday endpoint (those are deliberately kept for when you switch back) or a wrong-schema file (those self-heal on the next read). It only reclaims caches genuinely expired for the current profile. Plain `cache clear` (no `--stale`) removes regardless of age.
+
+*Gotcha:* `--board` is only valid for the board-scoped types (`columns`, `groups`, `webhooks`, `board_details`); passing it with other types is a usage error.
+
+## Force a live refetch — `cache refresh`
+
+```bash
+mondo cache refresh boards             # refetch the boards directory
+mondo cache refresh columns --board 42 # refetch one board's columns
+mondo cache refresh columns            # refetch every board already in the columns cache
+```
+
+*Gotcha:* the per-item / per-doc caches (`items`, `board_items`, `subitems`, `updates`, `docs_blocks`) **can't** be refreshed here — each needs a specific id only the read site knows. Use the read command's `--refresh-cache` instead (e.g. `mondo item get 999 --refresh-cache`). Refreshable scoped types are `columns`, `groups`, `webhooks`, `board_details`.
+
+## Profiles
+
+All cache commands honor `--profile`, operating on that profile's own cache dir:
+
+```bash
+mondo --profile acme cache status
+```
+
+Cache types (for `status` / `refresh` / `clear`): `boards`, `workspaces`, `users`, `teams`, `docs`, `folders`, `tags`, `webhooks`, `columns`, `groups`, `board_details`, `items`, `board_items`, `subitems`, `updates`, `docs_blocks`, `all` (default).


### PR DESCRIPTION
## Why

The `mondo cache` command group (`status`/`refresh`/`clear`) and the per-read `--no-cache`/`--refresh-cache` escape hatches were **absent from the bundled skill references and `mondo help` topics** — the surfaces agents actually read. The whole caching feature (including the new `clear --stale` shipped in v0.12.2) was effectively undiscoverable there. This was the follow-up gap flagged during that work.

## What

- **New `references/caching.md`** — cache tiers + TTLs, `--no-cache`/`--refresh-cache`, and `status`/`clear`/`refresh` (incl. `clear --stale`, endpoint/schema-aware), in the repo's Goal/Command/Output/Gotcha style.
- **New `mondo help caching` topic** (`src/mondo/help/caching.md`) — self-contained prose deep-dive, auto-discovered and shipped inside the binary.
- **SKILL.md** — registered the reference in the task table + drill-down list, added `caching` to the bundled-topics enumeration, repointed the Cache-notice norm from `docs/caching.md` → `references/caching.md` (installed skills ship `references/`, not `docs/`), and **bumped version 1.8.0 → 1.9.0** so installed copies re-pull.

No CLI/behavior changes — docs only.

## Verification

- `mondo help caching` renders and appears in `mondo help`; `references/caching.md` bundles via resource iteration.
- `test_cli_help.py` + `test_cli_skill.py` + `test_cli_skill_freshness.py` pass; full unit suite **1846 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)