### PR TITLE
feat(columns): render mirror & board_relation display_value (#88)

### DIFF
--- a/src/mondo/api/queries/_fragments.py
+++ b/src/mondo/api/queries/_fragments.py
@@ -1,0 +1,18 @@
+"""Shared GraphQL fragments interpolated into multiple query modules."""
+
+from __future__ import annotations
+
+# Canonical `column_values` field selection. The polymorphic inline
+# fragments make the computed-column types (mirror, formula, board_relation,
+# dependency) return their computed `display_value` (monday returns a null
+# `text` for these types), so typed reads no longer need to escape to raw
+# GraphQL. Kept as a single-line string so callers can interpolate it into an
+# f-string query template (`column_values {{ {COLUMN_VALUES_SELECTION} }}`)
+# without doubling the fragment's own braces.
+COLUMN_VALUES_SELECTION = (
+    "id type text value "
+    "... on MirrorValue { display_value } "
+    "... on BoardRelationValue { display_value linked_item_ids } "
+    "... on FormulaValue { display_value } "
+    "... on DependencyValue { display_value linked_item_ids }"
+)

--- a/src/mondo/api/queries/columns.py
+++ b/src/mondo/api/queries/columns.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from ._fragments import COLUMN_VALUES_SELECTION
+
 # --- columns: list / get / context ---
 
 COLUMNS_ON_BOARD = """
@@ -24,72 +26,67 @@ query ($board: ID!) {
 
 # Single-round-trip fetch for `column get/set/clear`:
 # item.board.id + column definition (from board.columns) + current value.
-COLUMN_CONTEXT = """
-query ($id: ID!, $cols: [String!]!) {
-  items(ids: [$id]) {
+COLUMN_CONTEXT = f"""
+query ($id: ID!, $cols: [String!]!) {{
+  items(ids: [$id]) {{
     id
     name
-    board {
+    board {{
       id
-      columns(ids: $cols) {
+      columns(ids: $cols) {{
         id
         title
         type
         settings_str
-      }
-    }
-    column_values(ids: $cols) {
-      id
-      type
-      text
-      value
-    }
-  }
-}
+      }}
+    }}
+    column_values(ids: $cols) {{ {COLUMN_VALUES_SELECTION} }}
+  }}
+}}
 """.strip()
 
 
-CHANGE_COLUMN_VALUE = """
+CHANGE_COLUMN_VALUE = f"""
 mutation (
   $item: ID!
   $board: ID!
   $col: String!
   $value: JSON!
   $create_labels: Boolean
-) {
+) {{
   change_column_value(
     item_id: $item
     board_id: $board
     column_id: $col
     value: $value
     create_labels_if_missing: $create_labels
-  ) {
+  ) {{
     id
     name
-    column_values(ids: [$col]) { id type text value }
-  }
-}
+    column_values(ids: [$col]) {{ {COLUMN_VALUES_SELECTION} }}
+  }}
+}}
 """.strip()
 
 
-CHANGE_MULTIPLE_COLUMN_VALUES = """
+CHANGE_MULTIPLE_COLUMN_VALUES = f"""
 mutation (
   $item: ID!
   $board: ID!
   $values: JSON!
   $create_labels: Boolean
-) {
+) {{
   change_multiple_column_values(
     item_id: $item
     board_id: $board
     column_values: $values
     create_labels_if_missing: $create_labels
-  ) {
+  ) {{
     id
     name
-    column_values { id type text value }
-  }
-}
+    column_values {{ {COLUMN_VALUES_SELECTION} }}
+  }}
+}}
 """.strip()
 
 

--- a/src/mondo/api/queries/items.py
+++ b/src/mondo/api/queries/items.py
@@ -2,23 +2,25 @@
 
 from __future__ import annotations
 
+from ._fragments import COLUMN_VALUES_SELECTION
+
 # --- items: single item by id ---
 
-ITEM_GET = """
-query ($id: ID!) {
-  items(ids: [$id]) {
+ITEM_GET = f"""
+query ($id: ID!) {{
+  items(ids: [$id]) {{
     id
     name
     state
     created_at
     updated_at
     url
-    creator { id name }
-    group { id title }
-    board { id name }
-    column_values { id type text value }
-  }
-}
+    creator {{ id name }}
+    group {{ id title }}
+    board {{ id name }}
+    column_values {{ {COLUMN_VALUES_SELECTION} }}
+  }}
+}}
 """.strip()
 
 
@@ -33,52 +35,52 @@ query ($id: ID!) {
 """.strip()
 
 
-ITEM_GET_WITH_UPDATES = """
-query ($id: ID!) {
-  items(ids: [$id]) {
+ITEM_GET_WITH_UPDATES = f"""
+query ($id: ID!) {{
+  items(ids: [$id]) {{
     id
     name
     state
     created_at
     updated_at
     url
-    creator { id name }
-    group { id title }
-    board { id name }
-    column_values { id type text value }
-    updates(limit: 100) {
+    creator {{ id name }}
+    group {{ id title }}
+    board {{ id name }}
+    column_values {{ {COLUMN_VALUES_SELECTION} }}
+    updates(limit: 100) {{
       id
       body
       text_body
-      creator { id name }
+      creator {{ id name }}
       created_at
-    }
-  }
-}
+    }}
+  }}
+}}
 """.strip()
 
 
-ITEM_GET_WITH_SUBITEMS = """
-query ($id: ID!) {
-  items(ids: [$id]) {
+ITEM_GET_WITH_SUBITEMS = f"""
+query ($id: ID!) {{
+  items(ids: [$id]) {{
     id
     name
     state
     created_at
     updated_at
     url
-    creator { id name }
-    group { id title }
-    board { id name }
-    column_values { id type text value }
-    subitems {
+    creator {{ id name }}
+    group {{ id title }}
+    board {{ id name }}
+    column_values {{ {COLUMN_VALUES_SELECTION} }}
+    subitems {{
       id
       name
       state
-      column_values { id type text value }
-    }
-  }
-}
+      column_values {{ {COLUMN_VALUES_SELECTION} }}
+    }}
+  }}
+}}
 """.strip()
 
 
@@ -107,10 +109,10 @@ def build_items_page_queries(
     cols_decl = ""
     fields = ["id", "name", "state", "group { id title }"]
     if column_values == "full":
-        fields.append("column_values { id type text value }")
+        fields.append(f"column_values {{ {COLUMN_VALUES_SELECTION} }}")
     elif column_values == "ids":
         cols_decl = ", $cols: [String!]!"
-        fields.append("column_values(ids: $cols) { id type text value }")
+        fields.append(f"column_values(ids: $cols) {{ {COLUMN_VALUES_SELECTION} }}")
     elif column_values != "none":
         raise ValueError(f"unknown column_values mode: {column_values!r}")
     initial = f"""
@@ -142,69 +144,69 @@ ITEMS_PAGE_INITIAL, ITEMS_PAGE_NEXT = build_items_page_queries()
 
 
 # Single-item variant of the server-side column narrowing above.
-ITEM_GET_WITH_COLUMNS = """
-query ($id: ID!, $cols: [String!]!) {
-  items(ids: [$id]) {
+ITEM_GET_WITH_COLUMNS = f"""
+query ($id: ID!, $cols: [String!]!) {{
+  items(ids: [$id]) {{
     id
     name
     state
     created_at
     updated_at
     url
-    creator { id name }
-    group { id title }
-    board { id name }
-    column_values(ids: $cols) { id type text value }
-  }
-}
+    creator {{ id name }}
+    group {{ id title }}
+    board {{ id name }}
+    column_values(ids: $cols) {{ {COLUMN_VALUES_SELECTION} }}
+  }}
+}}
 """.strip()
 
 
 # Export-oriented variants that also pull subitems (field selection costs
 # extra complexity; only use when --include-subitems is on).
-ITEMS_PAGE_INITIAL_WITH_SUBITEMS = """
-query ($boards: [ID!]!, $limit: Int!, $qp: ItemsQuery) {
-  boards(ids: $boards) {
-    items_page(limit: $limit, query_params: $qp) {
+ITEMS_PAGE_INITIAL_WITH_SUBITEMS = f"""
+query ($boards: [ID!]!, $limit: Int!, $qp: ItemsQuery) {{
+  boards(ids: $boards) {{
+    items_page(limit: $limit, query_params: $qp) {{
       cursor
-      items {
+      items {{
         id
         name
         state
-        group { id title }
-        column_values { id type text value }
-        subitems {
+        group {{ id title }}
+        column_values {{ {COLUMN_VALUES_SELECTION} }}
+        subitems {{
           id
           name
           state
-          column_values { id type text value }
-        }
-      }
-    }
-  }
-}
+          column_values {{ {COLUMN_VALUES_SELECTION} }}
+        }}
+      }}
+    }}
+  }}
+}}
 """.strip()
 
 
-ITEMS_PAGE_NEXT_WITH_SUBITEMS = """
-query ($cursor: String!, $limit: Int!) {
-  next_items_page(cursor: $cursor, limit: $limit) {
+ITEMS_PAGE_NEXT_WITH_SUBITEMS = f"""
+query ($cursor: String!, $limit: Int!) {{
+  next_items_page(cursor: $cursor, limit: $limit) {{
     cursor
-    items {
+    items {{
       id
       name
       state
-      group { id title }
-      column_values { id type text value }
-      subitems {
+      group {{ id title }}
+      column_values {{ {COLUMN_VALUES_SELECTION} }}
+      subitems {{
         id
         name
         state
-        column_values { id type text value }
-      }
-    }
-  }
-}
+        column_values {{ {COLUMN_VALUES_SELECTION} }}
+      }}
+    }}
+  }}
+}}
 """.strip()
 
 

--- a/src/mondo/api/queries/subitems.py
+++ b/src/mondo/api/queries/subitems.py
@@ -2,63 +2,65 @@
 
 from __future__ import annotations
 
+from ._fragments import COLUMN_VALUES_SELECTION
+
 # Subitems are nested on a parent item; they have their own (hidden) board
 # and column IDs. Listing = nested `items(ids:[parent]) { subitems { ... } }`.
-SUBITEMS_LIST = """
-query ($parent: ID!) {
-  items(ids: [$parent]) {
+SUBITEMS_LIST = f"""
+query ($parent: ID!) {{
+  items(ids: [$parent]) {{
     id
     name
-    board { id name }
-    subitems {
+    board {{ id name }}
+    subitems {{
       id
       name
       state
       created_at
-      creator { id name }
-      board { id name }
-      column_values { id type text value }
-    }
-  }
-}
+      creator {{ id name }}
+      board {{ id name }}
+      column_values {{ {COLUMN_VALUES_SELECTION} }}
+    }}
+  }}
+}}
 """.strip()
 
 
-SUBITEM_GET = """
-query ($id: ID!) {
-  items(ids: [$id]) {
+SUBITEM_GET = f"""
+query ($id: ID!) {{
+  items(ids: [$id]) {{
     id
     name
     state
     created_at
     updated_at
-    creator { id name }
-    board { id name }
-    parent_item { id name }
-    column_values { id type text value }
-  }
-}
+    creator {{ id name }}
+    board {{ id name }}
+    parent_item {{ id name }}
+    column_values {{ {COLUMN_VALUES_SELECTION} }}
+  }}
+}}
 """.strip()
 
 
-SUBITEM_CREATE = """
+SUBITEM_CREATE = f"""
 mutation (
   $parent: ID!
   $name: String!
   $values: JSON
   $create_labels: Boolean
-) {
+) {{
   create_subitem(
     parent_item_id: $parent
     item_name: $name
     column_values: $values
     create_labels_if_missing: $create_labels
-  ) {
+  ) {{
     id
     name
     state
-    board { id name }
-    column_values { id type text value }
-  }
-}
+    board {{ id name }}
+    column_values {{ {COLUMN_VALUES_SELECTION} }}
+  }}
+}}
 """.strip()

--- a/src/mondo/cache/store.py
+++ b/src/mondo/cache/store.py
@@ -22,12 +22,15 @@ from loguru import logger
 
 from mondo.version import __version__
 
-# SCHEMA_VERSION = 5 since the v5 bump (boards directory gained nested
-# `workspace { id name }`). Adding new entity types — `tags`, `webhooks`,
-# and any future per-entity caches — does NOT bump the schema, since the
-# shape of existing envelopes is unchanged. Only bump when an existing
-# entity's serialized shape changes.
-SCHEMA_VERSION = 5
+# SCHEMA_VERSION = 6 since the v6 bump (items / board_items / subitems
+# column_values gained polymorphic `display_value` / `linked_item_ids`
+# fields (#88); users-directory entries switched to the normalized
+# kind/status shape (#89)). v5 was the boards-directory nested
+# `workspace { id name }` bump. Adding new entity types — `tags`,
+# `webhooks`, and any future per-entity caches — does NOT bump the schema,
+# since the shape of existing envelopes is unchanged. Only bump when an
+# existing entity's serialized shape changes.
+SCHEMA_VERSION = 6
 
 EntityType = Literal[
     "boards",

--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -44,7 +44,7 @@ from mondo.columns import (
     UnknownColumnTypeError,
     clear_payload_for,
     parse_value,
-    render_value,
+    render_entry,
 )
 from mondo.columns.dropdown import iter_dropdown_labels
 from mondo.columns.status import iter_status_labels
@@ -262,7 +262,9 @@ def get_cmd(
     raw: bool = typer.Option(
         False,
         "--raw",
-        help="Return {id, type, value (JSON string), text} instead of human-rendered text.",
+        help="Return the full column_values entry (id, type, value (JSON string), "
+        "text, plus polymorphic fields like display_value/linked_item_ids on "
+        "mirror & board_relation) instead of human-rendered text.",
     ),
 ) -> None:
     """Read a single column value from an item."""
@@ -288,15 +290,8 @@ def get_cmd(
         return
 
     col_type = current.get("type") or "text"
-    value_payload: Any = None
-    raw_value = current.get("value")
-    if raw_value:
-        try:
-            value_payload = json.loads(raw_value)
-        except ValueError:
-            value_payload = raw_value
     try:
-        rendered = render_value(col_type, value_payload, current.get("text"))
+        rendered = render_entry(col_type, current)
     except UnknownColumnTypeError:
         rendered = current.get("text") or ""
     opts.emit(rendered)

--- a/src/mondo/cli/export.py
+++ b/src/mondo/cli/export.py
@@ -157,10 +157,13 @@ def _group_key(item: dict[str, Any]) -> tuple[str | None, str]:
     return (group.get("id"), group.get("title") or "")
 
 
-def _column_text(item: dict[str, Any], col_id: str) -> str:
+def _column_text(item: dict[str, Any], col: dict[str, Any]) -> str:
     for cv in item.get("column_values") or []:
-        if cv.get("id") == col_id:
-            return cv.get("text") or ""
+        if cv.get("id") == col["id"]:
+            # Text-first so the CSV round-trip stays stable (rating/checkbox
+            # export their raw `text`, not glyphs). mirror/board_relation
+            # return a null `text`, so fall back to their `display_value`.
+            return cv.get("text") or cv.get("display_value") or ""
     return ""
 
 
@@ -175,7 +178,7 @@ def _item_row(
         "group": (item.get("group") or {}).get("title"),
     }
     for col, label in zip(columns, labels, strict=True):
-        row[label] = _column_text(item, col["id"])
+        row[label] = _column_text(item, col)
     return row
 
 
@@ -193,7 +196,7 @@ def _subitem_row(
         "state": subitem.get("state"),
     }
     for col, label in zip(columns, labels, strict=True):
-        row[label] = _column_text(subitem, col["id"])
+        row[label] = _column_text(subitem, col)
     return row
 
 

--- a/src/mondo/columns/__init__.py
+++ b/src/mondo/columns/__init__.py
@@ -27,6 +27,7 @@ from mondo.columns.base import (
     parse_value,
     register,
     registered_types,
+    render_entry,
     render_value,
 )
 
@@ -39,5 +40,6 @@ __all__ = [
     "parse_value",
     "register",
     "registered_types",
+    "render_entry",
     "render_value",
 ]

--- a/src/mondo/columns/base.py
+++ b/src/mondo/columns/base.py
@@ -9,6 +9,7 @@ Each codec owns:
 
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any, ClassVar
@@ -34,6 +35,25 @@ class ColumnCodec(ABC):
     @abstractmethod
     def render(self, value: Any, text: str | None) -> str:
         """Convert a column_values entry into a human-friendly display."""
+
+    def render_entry(self, entry: dict[str, Any]) -> str:
+        """Render a full ``column_values`` entry dict (id/type/text/value + any
+        polymorphic fields like ``display_value``/``linked_item_ids``).
+
+        Default: parse the JSON ``value`` and delegate to
+        ``render(value, text)``. Codecs whose read payload only surfaces via an
+        inline fragment (mirror, board_relation) override this to read those
+        fields straight off the entry.
+        """
+        text = entry.get("text")
+        raw = entry.get("value")
+        value: Any = None
+        if raw:
+            try:
+                value = json.loads(raw)
+            except ValueError:
+                value = raw
+        return self.render(value, text)
 
     def clear_payload(self) -> Any:
         """Override when the column doesn't clear with `{}` (checkbox, file, ...)."""
@@ -147,6 +167,16 @@ def parse_filter_value(
 
 def render_value(type_name: str, value: Any, text: str | None) -> str:
     return get_codec(type_name).render(value, text)
+
+
+def render_entry(type_name: str, entry: dict[str, Any]) -> str:
+    """Render a full ``column_values`` entry via its codec's ``render_entry``.
+
+    Prefer this over ``render_value`` at read sites: it lets mirror, formula,
+    board_relation & dependency codecs surface ``display_value`` from the
+    polymorphic inline fragments.
+    """
+    return get_codec(type_name).render_entry(entry)
 
 
 def clear_payload_for(type_name: str) -> Any:

--- a/src/mondo/columns/readonly.py
+++ b/src/mondo/columns/readonly.py
@@ -30,9 +30,25 @@ class _ReadOnly(ColumnCodec):
 class MirrorCodec(_ReadOnly):
     type_name: ClassVar[str] = "mirror"
 
+    def render_entry(self, entry: dict[str, Any]) -> str:
+        # monday returns a null `text` for mirror columns; the computed value
+        # lives in `display_value` (MirrorValue inline fragment).
+        display = entry.get("display_value")
+        if display:
+            return display
+        return entry.get("text") or ""
+
 
 class FormulaCodec(_ReadOnly):
     type_name: ClassVar[str] = "formula"
+
+    def render_entry(self, entry: dict[str, Any]) -> str:
+        # monday returns a null `text` for formula columns; the computed value
+        # lives in `display_value` (FormulaValue inline fragment).
+        display = entry.get("display_value")
+        if display:
+            return display
+        return entry.get("text") or ""
 
 
 class AutoNumberCodec(_ReadOnly):

--- a/src/mondo/columns/relation.py
+++ b/src/mondo/columns/relation.py
@@ -67,6 +67,21 @@ class BoardRelationCodec(ColumnCodec):
     def render(self, value: Any, text: str | None) -> str:
         return text or ""
 
+    def render_entry(self, entry: dict[str, Any]) -> str:
+        # monday returns a null `text` for board_relation; prefer the linked
+        # item names in `display_value`, then `text`, then bare linked ids
+        # (all from the BoardRelationValue inline fragment).
+        display = entry.get("display_value")
+        if display:
+            return display
+        text = entry.get("text")
+        if text:
+            return text
+        linked = entry.get("linked_item_ids")
+        if linked:
+            return ", ".join(str(i) for i in linked)
+        return ""
+
 
 class DependencyCodec(ColumnCodec):
     type_name: ClassVar[str] = "dependency"
@@ -79,6 +94,21 @@ class DependencyCodec(ColumnCodec):
 
     def render(self, value: Any, text: str | None) -> str:
         return text or ""
+
+    def render_entry(self, entry: dict[str, Any]) -> str:
+        # monday returns a null `text` for dependency; prefer the linked item
+        # names in `display_value`, then `text`, then bare linked ids (all from
+        # the DependencyValue inline fragment). Mirrors BoardRelationCodec.
+        display = entry.get("display_value")
+        if display:
+            return display
+        text = entry.get("text")
+        if text:
+            return text
+        linked = entry.get("linked_item_ids")
+        if linked:
+            return ", ".join(str(i) for i in linked)
+        return ""
 
 
 class WorldClockCodec(ColumnCodec):

--- a/tests/unit/test_cache_store.py
+++ b/tests/unit/test_cache_store.py
@@ -104,6 +104,28 @@ def test_envelope_with_wrong_schema_version_is_dropped(tmp_path: Path) -> None:
     assert not store.path.exists()
 
 
+def test_stale_v5_envelope_is_dropped(tmp_path: Path) -> None:
+    # v6 added display_value/linked_item_ids to items/board_items/subitems
+    # column_values; a v5-stamped entry lacks them and must be refetched even
+    # while still within its TTL.
+    store = _store(tmp_path, entity="items")
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text(
+        json.dumps(
+            {
+                "schema_version": 5,
+                "fetched_at": _format_utc(datetime.now(UTC)),
+                "ttl_seconds": 60,
+                "api_endpoint": ENDPOINT,
+                "entries": [{"id": 1}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert store.read() is None
+    assert not store.path.exists()
+
+
 def test_endpoint_mismatch_returns_none_without_deleting(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store.path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_cli_column.py
+++ b/tests/unit/test_cli_column.py
@@ -226,6 +226,81 @@ class TestColumnGet:
         assert parsed["text"] == "Hello"
         assert parsed["type"] == "text"
 
+    def test_raw_mirror_includes_display_value(self, httpx_mock: HTTPXMock) -> None:
+        # #88: --raw passes the full column_values entry through untouched, so
+        # the polymorphic display_value surfaces alongside id/type/value/text.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_context_response(
+                board_id=42,
+                cols=[{"id": "mir", "title": "M", "type": "mirror", "settings_str": "{}"}],
+                values=[
+                    {
+                        "id": "mir",
+                        "type": "mirror",
+                        "text": None,
+                        "value": None,
+                        "display_value": "In progress",
+                    }
+                ],
+            ),
+        )
+        result = runner.invoke(app, ["column", "get", "--item", "1", "--column", "mir", "--raw"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert parsed["type"] == "mirror"
+        assert parsed["display_value"] == "In progress"
+
+    def test_mirror_renders_display_value_when_text_null(self, httpx_mock: HTTPXMock) -> None:
+        # #88: monday returns null `text` for mirror columns; the value comes
+        # back via the MirrorValue inline fragment's `display_value`.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_context_response(
+                board_id=42,
+                cols=[{"id": "mir", "title": "M", "type": "mirror", "settings_str": "{}"}],
+                values=[
+                    {
+                        "id": "mir",
+                        "type": "mirror",
+                        "text": None,
+                        "value": None,
+                        "display_value": "In progress",
+                    }
+                ],
+            ),
+        )
+        result = runner.invoke(app, ["column", "get", "--item", "1", "--column", "mir"])
+        assert result.exit_code == 0, result.stdout
+        assert result.stdout.strip() == '"In progress"'
+
+    def test_board_relation_renders_display_value(self, httpx_mock: HTTPXMock) -> None:
+        # #88: board_relation also returns null `text`; linked item names come
+        # back via the BoardRelationValue inline fragment.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_context_response(
+                board_id=42,
+                cols=[{"id": "rel", "title": "R", "type": "board_relation", "settings_str": "{}"}],
+                values=[
+                    {
+                        "id": "rel",
+                        "type": "board_relation",
+                        "text": None,
+                        "value": '{"linkedPulseIds":[{"linkedPulseId":111}]}',
+                        "display_value": "Linked Item A",
+                        "linked_item_ids": ["111"],
+                    }
+                ],
+            ),
+        )
+        result = runner.invoke(app, ["column", "get", "--item", "1", "--column", "rel"])
+        assert result.exit_code == 0, result.stdout
+        assert result.stdout.strip() == '"Linked Item A"'
+
 
 class TestColumnSet:
     def test_codec_parsed_status(self, httpx_mock: HTTPXMock) -> None:

--- a/tests/unit/test_cli_export.py
+++ b/tests/unit/test_cli_export.py
@@ -804,3 +804,102 @@ class TestDuplicateNames:
         result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "md"])
         assert result.exit_code == 0, result.stdout
         assert result.stdout.count("## Sprint") == 2
+
+
+class TestDisplayValue:
+    """mirror / board_relation cells export display_value, not their null text."""
+
+    def test_board_relation_exports_display_value(self, httpx_mock: HTTPXMock) -> None:
+        cols = _ok(
+            {
+                "boards": [
+                    {
+                        "id": "42",
+                        "name": "B",
+                        "columns": [
+                            {
+                                "id": "link",
+                                "title": "Linked",
+                                "type": "board_relation",
+                                "archived": False,
+                            },
+                            {
+                                "id": "mir",
+                                "title": "Mirrored",
+                                "type": "mirror",
+                                "archived": False,
+                            },
+                        ],
+                    }
+                ]
+            }
+        )
+        # monday returns null `text` for both types; the readable value lives in
+        # display_value (board_relation also carries linked_item_ids).
+        item = {
+            "id": "1",
+            "name": "A",
+            "state": "active",
+            "group": {"id": "topics", "title": "Topics"},
+            "column_values": [
+                {
+                    "id": "link",
+                    "type": "board_relation",
+                    "text": None,
+                    "value": None,
+                    "display_value": "Item X, Item Y",
+                    "linked_item_ids": ["101", "102"],
+                },
+                {
+                    "id": "mir",
+                    "type": "mirror",
+                    "text": None,
+                    "value": None,
+                    "display_value": "42",
+                },
+            ],
+        }
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=cols)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_items_page([item]))
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "csv"])
+        assert result.exit_code == 0, result.stdout
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[0] == ["id", "name", "state", "group", "Linked", "Mirrored"]
+        assert rows[1][4] == "Item X, Item Y"
+        assert rows[1][5] == "42"
+
+    def test_export_stays_text_first_for_round_trip(self, httpx_mock: HTTPXMock) -> None:
+        # Round-trip guard: rating/checkbox cells must export monday's raw
+        # `text` ("3" / "v"), NOT codec glyphs ("★★★" / "✓") — the CSV
+        # export→import cycle re-parses these strings via parse_value.
+        cols = _ok(
+            {
+                "boards": [
+                    {
+                        "id": "42",
+                        "name": "B",
+                        "columns": [
+                            {"id": "rate", "title": "Rating", "type": "rating", "archived": False},
+                            {"id": "done", "title": "Done", "type": "checkbox", "archived": False},
+                        ],
+                    }
+                ]
+            }
+        )
+        item = {
+            "id": "1",
+            "name": "A",
+            "state": "active",
+            "group": {"id": "topics", "title": "Topics"},
+            "column_values": [
+                {"id": "rate", "type": "rating", "text": "3", "value": '{"rating":3}'},
+                {"id": "done", "type": "checkbox", "text": "v", "value": '{"checked":"true"}'},
+            ],
+        }
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=cols)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_items_page([item]))
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "csv"])
+        assert result.exit_code == 0, result.stdout
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[1][4] == "3"
+        assert rows[1][5] == "v"

--- a/tests/unit/test_cli_item_columns.py
+++ b/tests/unit/test_cli_item_columns.py
@@ -19,10 +19,15 @@ import pytest
 from pytest_httpx import HTTPXMock
 from typer.testing import CliRunner
 
+from mondo.api.queries._fragments import COLUMN_VALUES_SELECTION
 from mondo.cli.main import app
 
 ENDPOINT = "https://api.monday.com/v2"
 runner = CliRunner()
+
+# Full `column_values` selection as emitted into the query (#88 added the
+# polymorphic mirror/board_relation inline fragments).
+FULL_COLUMN_VALUES = f"column_values {{ {COLUMN_VALUES_SELECTION} }}"
 
 
 @pytest.fixture(autouse=True)
@@ -132,7 +137,7 @@ class TestItemListColumns:
         result = runner.invoke(app, ["item", "list", "--board", "42"])
         assert result.exit_code == 0
         body = _bodies(httpx_mock)[-1]
-        assert "column_values { id type text value }" in body["query"]
+        assert FULL_COLUMN_VALUES in body["query"]
 
 
 class TestItemListAutoSlim:
@@ -186,7 +191,7 @@ class TestItemListAutoSlim:
         )
         result = runner.invoke(app, ["-q", expression, "item", "list", "--board", "42"])
         assert result.exit_code == 0, result.output
-        assert "column_values { id type text value }" in _bodies(httpx_mock)[-1]["query"]
+        assert FULL_COLUMN_VALUES in _bodies(httpx_mock)[-1]["query"]
 
     def test_no_projection_keeps_full_shape(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok(_items_page([{"id": "1"}])))
@@ -232,7 +237,7 @@ class TestItemListAutoSlim:
             ],
         )
         assert result.exit_code == 0, result.output
-        assert "column_values { id type text value }" in _bodies(httpx_mock)[-1]["query"]
+        assert FULL_COLUMN_VALUES in _bodies(httpx_mock)[-1]["query"]
 
     def test_dry_run_shows_cols_variable(self, httpx_mock: HTTPXMock) -> None:
         result = runner.invoke(

--- a/tests/unit/test_codec_readonly.py
+++ b/tests/unit/test_codec_readonly.py
@@ -12,6 +12,7 @@ from mondo.columns import (
     UnknownColumnTypeError,
     parse_value,
     readonly,  # noqa: F401
+    render_entry,
     render_value,
 )
 
@@ -51,3 +52,35 @@ def test_truly_unknown_type_still_raises_unknown() -> None:
     """A type not in any registered module stays undiscoverable."""
     with pytest.raises(UnknownColumnTypeError):
         parse_value("some_made_up_type", "x", {})
+
+
+class TestMirrorRenderEntry:
+    """#88: mirror columns return a null `text`; the computed value lives in
+    the `display_value` inline-fragment field."""
+
+    def test_prefers_display_value_when_text_null(self) -> None:
+        entry = {"id": "mir", "type": "mirror", "text": None, "display_value": "42, 99"}
+        assert render_entry("mirror", entry) == "42, 99"
+
+    def test_falls_back_to_text(self) -> None:
+        entry = {"id": "mir", "type": "mirror", "text": "legacy", "display_value": None}
+        assert render_entry("mirror", entry) == "legacy"
+
+    def test_empty_when_neither(self) -> None:
+        assert render_entry("mirror", {"id": "mir", "type": "mirror"}) == ""
+
+
+class TestFormulaRenderEntry:
+    """#88: formula columns return a null `text`; the computed value lives in
+    the `display_value` inline-fragment field."""
+
+    def test_prefers_display_value_when_text_null(self) -> None:
+        entry = {"id": "f", "type": "formula", "text": None, "display_value": "1500"}
+        assert render_entry("formula", entry) == "1500"
+
+    def test_falls_back_to_text(self) -> None:
+        entry = {"id": "f", "type": "formula", "text": "legacy", "display_value": None}
+        assert render_entry("formula", entry) == "legacy"
+
+    def test_empty_when_neither(self) -> None:
+        assert render_entry("formula", {"id": "f", "type": "formula"}) == ""

--- a/tests/unit/test_codec_relation.py
+++ b/tests/unit/test_codec_relation.py
@@ -7,6 +7,7 @@ import pytest
 from mondo.columns import (
     parse_value,
     relation,  # noqa: F401
+    render_entry,
     render_value,
 )
 
@@ -57,6 +58,45 @@ class TestBoardRelation:
             parse_value("board_relation", '{"item_ids": ["a", "b"]}', {})
 
 
+class TestBoardRelationRenderEntry:
+    """#88: board_relation returns a null `text`; linked item names come back
+    in the `display_value` inline-fragment field (with `linked_item_ids`)."""
+
+    def test_prefers_display_value(self) -> None:
+        entry = {
+            "id": "rel",
+            "type": "board_relation",
+            "text": None,
+            "display_value": "Alpha, Beta",
+            "linked_item_ids": ["111", "222"],
+        }
+        assert render_entry("board_relation", entry) == "Alpha, Beta"
+
+    def test_falls_back_to_text(self) -> None:
+        entry = {
+            "id": "rel",
+            "type": "board_relation",
+            "text": "Alpha",
+            "display_value": None,
+            "linked_item_ids": ["111"],
+        }
+        assert render_entry("board_relation", entry) == "Alpha"
+
+    def test_falls_back_to_linked_ids(self) -> None:
+        entry = {
+            "id": "rel",
+            "type": "board_relation",
+            "text": None,
+            "display_value": None,
+            "linked_item_ids": ["111", "222"],
+        }
+        assert render_entry("board_relation", entry) == "111, 222"
+
+    def test_empty_when_nothing_linked(self) -> None:
+        entry = {"id": "rel", "type": "board_relation", "display_value": "", "linked_item_ids": []}
+        assert render_entry("board_relation", entry) == ""
+
+
 class TestDependency:
     def test_multiple(self) -> None:
         assert parse_value("dependency", "111,222", {}) == {"item_ids": [111, 222]}
@@ -66,6 +106,37 @@ class TestDependency:
 
     def test_json_object_shape_accepted(self) -> None:
         assert parse_value("dependency", '{"item_ids":[7,8]}', {}) == {"item_ids": [7, 8]}
+
+
+class TestDependencyRenderEntry:
+    """#88: dependency returns a null `text`; linked item names come back in
+    the `display_value` inline-fragment field (with `linked_item_ids`)."""
+
+    def test_prefers_display_value(self) -> None:
+        entry = {
+            "id": "dep",
+            "type": "dependency",
+            "text": None,
+            "display_value": "Task A, Task B",
+            "linked_item_ids": ["111", "222"],
+        }
+        assert render_entry("dependency", entry) == "Task A, Task B"
+
+    def test_falls_back_to_text_then_linked_ids(self) -> None:
+        entry = {"id": "dep", "type": "dependency", "text": "Task A", "display_value": None}
+        assert render_entry("dependency", entry) == "Task A"
+        entry = {
+            "id": "dep",
+            "type": "dependency",
+            "text": None,
+            "display_value": None,
+            "linked_item_ids": ["111", "222"],
+        }
+        assert render_entry("dependency", entry) == "111, 222"
+
+    def test_empty_when_nothing_linked(self) -> None:
+        entry = {"id": "dep", "type": "dependency", "display_value": "", "linked_item_ids": []}
+        assert render_entry("dependency", entry) == ""
 
 
 class TestWorldClock:

--- a/tests/unit/test_column_values_fragment.py
+++ b/tests/unit/test_column_values_fragment.py
@@ -1,0 +1,72 @@
+"""#88: every `column_values` selection must request the polymorphic
+`display_value` (mirror, formula) and `display_value`/`linked_item_ids`
+(board_relation, dependency) inline fragments, so typed reads no longer need
+raw GraphQL escapes."""
+
+from __future__ import annotations
+
+import pytest
+
+from mondo.api.queries import (
+    CHANGE_COLUMN_VALUE,
+    CHANGE_MULTIPLE_COLUMN_VALUES,
+    COLUMN_CONTEXT,
+    ITEM_GET,
+    ITEM_GET_WITH_COLUMNS,
+    ITEM_GET_WITH_SUBITEMS,
+    ITEM_GET_WITH_UPDATES,
+    ITEMS_PAGE_INITIAL,
+    ITEMS_PAGE_INITIAL_WITH_SUBITEMS,
+    ITEMS_PAGE_NEXT,
+    ITEMS_PAGE_NEXT_WITH_SUBITEMS,
+    SUBITEM_CREATE,
+    SUBITEM_GET,
+    SUBITEMS_LIST,
+    build_items_page_queries,
+)
+
+MIRROR_FRAGMENT = "... on MirrorValue { display_value }"
+RELATION_FRAGMENT = "... on BoardRelationValue { display_value linked_item_ids }"
+FORMULA_FRAGMENT = "... on FormulaValue { display_value }"
+DEPENDENCY_FRAGMENT = "... on DependencyValue { display_value linked_item_ids }"
+ALL_FRAGMENTS = (MIRROR_FRAGMENT, RELATION_FRAGMENT, FORMULA_FRAGMENT, DEPENDENCY_FRAGMENT)
+
+QUERIES_WITH_COLUMN_VALUES = [
+    ITEM_GET,
+    ITEM_GET_WITH_UPDATES,
+    ITEM_GET_WITH_SUBITEMS,
+    ITEM_GET_WITH_COLUMNS,
+    ITEMS_PAGE_INITIAL,
+    ITEMS_PAGE_NEXT,
+    ITEMS_PAGE_INITIAL_WITH_SUBITEMS,
+    ITEMS_PAGE_NEXT_WITH_SUBITEMS,
+    COLUMN_CONTEXT,
+    CHANGE_COLUMN_VALUE,
+    CHANGE_MULTIPLE_COLUMN_VALUES,
+    SUBITEMS_LIST,
+    SUBITEM_GET,
+    SUBITEM_CREATE,
+]
+
+
+@pytest.mark.parametrize("query", QUERIES_WITH_COLUMN_VALUES)
+def test_query_contains_display_value_fragments(query: str) -> None:
+    for fragment in ALL_FRAGMENTS:
+        assert fragment in query
+
+
+@pytest.mark.parametrize("mode", ["full", "ids"])
+def test_items_page_builder_includes_fragments(mode: str) -> None:
+    initial, next_q = build_items_page_queries(column_values=mode)
+    for q in (initial, next_q):
+        for fragment in ALL_FRAGMENTS:
+            assert fragment in q
+
+
+def test_items_page_builder_none_mode_has_no_fragments() -> None:
+    # `--fields id,name` drops column_values entirely — no fragments expected.
+    initial, next_q = build_items_page_queries(column_values="none")
+    for q in (initial, next_q):
+        assert "column_values" not in q
+        for fragment in ALL_FRAGMENTS:
+            assert fragment not in q

--- a/tests/unit/test_complexity.py
+++ b/tests/unit/test_complexity.py
@@ -45,6 +45,24 @@ class TestInjector:
         q = "not-a-query"
         assert inject_complexity_field(q) == q
 
+    def test_preserves_inline_fragments(self) -> None:
+        # #88: column_values now carries polymorphic inline fragments. The
+        # injector walks braces to find the root close; balanced fragment
+        # braces must not confuse it or get dropped.
+        q = (
+            "query { items { column_values { "
+            "id type text value "
+            "... on MirrorValue { display_value } "
+            "... on BoardRelationValue { display_value linked_item_ids } "
+            "} } }"
+        )
+        out = inject_complexity_field(q)
+        assert "reset_in_x_seconds" in out
+        assert "... on MirrorValue { display_value }" in out
+        assert "... on BoardRelationValue { display_value linked_item_ids }" in out
+        # complexity field is appended at root level, after the items block.
+        assert out.rindex("complexity") > out.rindex("linked_item_ids")
+
 
 # --- ComplexityMeter ---
 


### PR DESCRIPTION
Resolves #88.

## What

Typed reads returned a null `text` for computed columns, forcing agents to escape to raw GraphQL (the single largest escape-hatch source in the usage audit). Now:

- A shared `COLUMN_VALUES_SELECTION` constant (`api/queries/_fragments.py`) adds polymorphic inline fragments for **all four** computed-column types — `MirrorValue`/`FormulaValue` (`display_value`) and `BoardRelationValue`/`DependencyValue` (`display_value` + `linked_item_ids`) — interpolated into every `column_values` selection (items, columns, subitems queries; verified none missed).
- New overridable `ColumnCodec.render_entry(entry)` hook; the four computed-column codecs prefer `display_value` (relation types fall back to text, then linked ids). `column get` renders through it; JSON outputs (`item list/get -o json`) carry the new fields automatically.
- Exports stay **text-first** (`display_value` only when `text` is null) so the CSV export→import round-trip is byte-stable for rating/checkbox (guarded by a new test).
- Cache `SCHEMA_VERSION` 5→6 so stale cached items without the new fields are dropped (hunk is textually identical to #89's branch — merges clean in either order).

## Verification

- Unit: +30 tests (fragment presence across all 14 query constants + builder modes, render_entry fallback chains for all four types, complexity-injector fragment preservation, export round-trip guard, raw-output shape). Full suite: 1924 passed.
- Live (playground board 5094861043, cleaned up): board_relation column end-to-end — `column get` rendered the linked item name from `display_value` (text was null), `item get -o json` carried `display_value`/`linked_item_ids`, mutation responses too. Mirror: the live API accepted and parsed the fragment; the API-created mirror computed an empty value (monday-side config nuance), so mirror rendering is covered by unit tests.

## Review trail

Implemented + reviewed via subagents: gpt-5.5 (codex) round 1 → fixed export gap, cache version bump, help text; 8-angle adversarially-verified review → caught and fixed a codec-render export regression (rating/checkbox glyphs breaking re-import), added formula/dependency to the fragment set; security review PASS-WITH-NOTES (the two notes are pre-existing CSV/terminal hardening gaps, tracked separately); gpt-5.5 round 2 → APPROVE-WITH-NITS (stale skill-reference docs; deferred to the post-merge docs-sync PR by convention).

Known accepted trade-off: the fragments add a small constant complexity cost to every column_values selection on boards without computed columns; making them conditional would need state-dependent query building (rejected for simplicity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)