### PR TITLE
fix(users): migrate user/me queries to 2026-07 API, bump pin (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,7 +959,7 @@ Env-var expansion (`${VAR}`) is supported.
 
 ```yaml
 default_profile: personal
-api_version: "2026-01"
+api_version: "2026-07"
 
 profiles:
   personal:
@@ -1017,7 +1017,7 @@ directory is resident. Full contract: [`docs/caching.md`](docs/caching.md).
 # Global Options panel
 --profile NAME / MONDO_PROFILE              Select config profile
 --api-token TOKEN / MONDAY_API_TOKEN        Override API token (flag wins over env)
---api-version YYYY-MM / MONDAY_API_VERSION  Pin API version (default: 2026-01)
+--api-version YYYY-MM / MONDAY_API_VERSION  Pin API version (default: 2026-07)
 --verbose,-v                                INFO-level logging to stderr
 --debug                                     Full request/response to stderr (token redacted)
 --yes,-y                                    Skip confirmation prompts

--- a/docs/implementation-phase-1.md
+++ b/docs/implementation-phase-1.md
@@ -304,7 +304,7 @@ file uploads, aggregation API, multi-level boards, and full workspace docs.
 | Week column is double-nested | Week codec builds `{"week": {"startDate": "...", "endDate": "..."}}` |
 | Root `items(ids:)` with >100 IDs or no IDs is throttled to 1/2min | We paginate via `items_page` everywhere — never hit the rate-limited form |
 | `items_page` cursor lifetime is 60 minutes | `iter_items_page` catches `CursorExpiredError` and restarts |
-| API versions shift quarterly | Always pinned via `API-Version` header; defaults to `2026-01` (current as of April 2026) |
+| API versions shift quarterly | Always pinned via `API-Version` header; defaults to `2026-07` (current as of July 2026) |
 | Errors carry `extensions.request_id` (since 2025-05) | Every `MondoError` surfaces it in `str(exc)` |
 | Idempotency keys not supported | Every mutation has `--dry-run`; `item archive` (reversible) is preferred over `delete` |
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -118,7 +118,7 @@ mondo/
 Exposed on every command via a Typer callback:
 - `--profile NAME` / `MONDO_PROFILE` — select profile from config.yaml
 - `--api-token TOKEN` / `MONDAY_API_TOKEN` — override token
-- `--api-version YYYY-MM` / `MONDAY_API_VERSION` — pin API version (default: `2026-01`, the Current version as of April 2026)
+- `--api-version YYYY-MM` / `MONDAY_API_VERSION` — pin API version (default: `2026-07`, the Current version as of July 2026)
 - `--output,-o {table,json,jsonc,yaml,tsv,csv,none}` (default `table` when stdout is a TTY, `json` otherwise — az-style auto-detection)
 - `--query,-q <jmespath>` — JMESPath projection applied before rendering 
 - `--jq <expr>` — courtesy shortcut, shells out to `jq` if present (else errors)

--- a/docs/project codename mondo.md
+++ b/docs/project codename mondo.md
@@ -126,7 +126,7 @@ mondo/
 Exposed on every command via a Typer callback:
 - `--profile NAME` / `MONDO_PROFILE` — select profile from config.yaml
 - `--api-token TOKEN` / `MONDAY_API_TOKEN` — override token
-- `--api-version YYYY-MM` / `MONDAY_API_VERSION` — pin API version (default: `2026-01`, the Current version as of April 2026)
+- `--api-version YYYY-MM` / `MONDAY_API_VERSION` — pin API version (default: `2026-07`, the Current version as of July 2026)
 - `--output,-o {table,json,jsonc,yaml,tsv,csv,none}` (default `table` when stdout is a TTY, `json` otherwise — az-style auto-detection)
 - `--query,-q <jmespath>` — JMESPath projection applied before rendering
 - `--jq <expr>` — courtesy shortcut, shells out to `jq` if present (else errors)

--- a/src/mondo/api/queries/me.py
+++ b/src/mondo/api/queries/me.py
@@ -8,7 +8,7 @@ query {
     id
     name
     email
-    is_admin
+    kind
     account { id name slug tier }
   }
 }
@@ -45,15 +45,12 @@ query {
     id
     name
     email
-    is_admin
-    is_guest
-    is_view_only
-    is_pending
-    enabled
+    kind
+    status
     created_at
     last_activity
     title
-    photo_thumb
+    photo_url { thumb }
     teams { id name }
     account {
       id

--- a/src/mondo/api/queries/users.py
+++ b/src/mondo/api/queries/users.py
@@ -2,36 +2,36 @@
 
 from __future__ import annotations
 
-# monday-api.md §14. UserKind: all|non_guests|guests|non_pending.
+# monday-api.md §14. Migrated to API 2026-07: `kind`/`non_active`/`newest_first`
+# args were removed; use `user_kind`/`status`/`sort`. The deprecated boolean
+# User fields (is_admin/is_guest/is_view_only/enabled/is_pending) are replaced
+# by `kind`/`status`; mondo derives the legacy booleans in `normalize_user`.
 USERS_LIST_PAGE = """
 query (
   $limit: Int!
   $page: Int!
   $ids: [ID!]
-  $kind: UserKind
+  $userKind: UserKindFilterInput
   $emails: [String!]
   $name: String
-  $nonActive: Boolean
-  $newestFirst: Boolean
+  $status: [UserStatus!]
+  $sort: [UsersSortInput!]
 ) {
   users(
     limit: $limit
     page: $page
     ids: $ids
-    kind: $kind
+    user_kind: $userKind
     emails: $emails
     name: $name
-    non_active: $nonActive
-    newest_first: $newestFirst
+    status: $status
+    sort: $sort
   ) {
     id
     name
     email
-    enabled
-    is_admin
-    is_guest
-    is_pending
-    is_view_only
+    kind
+    status
     created_at
     last_activity
     title
@@ -46,15 +46,12 @@ query ($ids: [ID!]!) {
     id
     name
     email
-    enabled
-    is_admin
-    is_guest
-    is_pending
-    is_view_only
+    kind
+    status
     created_at
     last_activity
     title
-    photo_thumb
+    photo_url { thumb }
     teams { id name }
     account { id name slug tier }
   }
@@ -65,7 +62,7 @@ query ($ids: [ID!]!) {
 USERS_DEACTIVATE = """
 mutation ($ids: [ID!]!) {
   deactivate_users(user_ids: $ids) {
-    deactivated_users { id name enabled }
+    deactivated_users { id name status }
     errors { message code user_id }
   }
 }
@@ -75,7 +72,7 @@ mutation ($ids: [ID!]!) {
 USERS_ACTIVATE = """
 mutation ($ids: [ID!]!) {
   activate_users(user_ids: $ids) {
-    activated_users { id name enabled }
+    activated_users { id name status }
     errors { message code user_id }
   }
 }
@@ -87,7 +84,7 @@ mutation ($ids: [ID!]!) {
 USERS_UPDATE_AS_ADMINS = """
 mutation ($ids: [ID!]!) {
   update_multiple_users_as_admins(user_ids: $ids) {
-    updated_users { id name is_admin }
+    updated_users { id name kind }
     errors { message code user_id }
   }
 }
@@ -97,7 +94,7 @@ mutation ($ids: [ID!]!) {
 USERS_UPDATE_AS_MEMBERS = """
 mutation ($ids: [ID!]!) {
   update_multiple_users_as_members(user_ids: $ids) {
-    updated_users { id name is_admin }
+    updated_users { id name kind }
     errors { message code user_id }
   }
 }
@@ -107,7 +104,7 @@ mutation ($ids: [ID!]!) {
 USERS_UPDATE_AS_GUESTS = """
 mutation ($ids: [ID!]!) {
   update_multiple_users_as_guests(user_ids: $ids) {
-    updated_users { id name is_guest }
+    updated_users { id name kind }
     errors { message code user_id }
   }
 }
@@ -117,7 +114,7 @@ mutation ($ids: [ID!]!) {
 USERS_UPDATE_AS_VIEWERS = """
 mutation ($ids: [ID!]!) {
   update_multiple_users_as_viewers(user_ids: $ids) {
-    updated_users { id name is_view_only }
+    updated_users { id name kind }
     errors { message code user_id }
   }
 }

--- a/src/mondo/cache/directory.py
+++ b/src/mondo/cache/directory.py
@@ -42,6 +42,7 @@ from mondo.domain.normalize import (
     normalize_doc_entry,
     normalize_folder_entry,
 )
+from mondo.domain.users import normalize_user
 
 # Block-fetch page size for `get_doc_blocks` — picked to match the existing
 # CLI default in `mondo/cli/doc.py`. Doc bodies can be hundreds of blocks;
@@ -208,24 +209,21 @@ def _fetch_all_workspaces(client: MondayClient) -> list[dict[str, Any]]:
 
 
 def _fetch_all_users(client: MondayClient) -> list[dict[str, Any]]:
-    # monday's `non_active` is either/or: true returns ONLY disabled users,
-    # false returns ONLY active. To cover both, we run both queries and merge
-    # (dedup by id — shouldn't collide, but be defensive).
-    active = fetch_pages_concurrent(
-        client,
-        query=USERS_LIST_PAGE,
-        variables={"nonActive": False},
-        collection_key="users",
-        limit=MAX_BOARDS_PAGE_SIZE,
-    )
-    disabled = fetch_pages_concurrent(
-        client,
-        query=USERS_LIST_PAGE,
-        variables={"nonActive": True},
-        collection_key="users",
-        limit=MAX_BOARDS_PAGE_SIZE,
-    )
-    return _dedup_by_id(active + disabled)
+    # On API 2026-07, `status: [ACTIVE, INACTIVE]` returns the full directory
+    # in one pass — the INACTIVE bucket also surfaces PENDING users — so the
+    # old two-fetch (active + non_active) merge is no longer needed. Entries
+    # are normalized so the cache carries the derived legacy booleans that the
+    # client-side filters in `user list` rely on.
+    return [
+        normalize_user(entry)
+        for entry in fetch_pages_concurrent(
+            client,
+            query=USERS_LIST_PAGE,
+            variables={"status": ["ACTIVE", "INACTIVE"]},
+            collection_key="users",
+            limit=MAX_BOARDS_PAGE_SIZE,
+        )
+    ]
 
 
 def _fetch_all_teams(client: MondayClient) -> list[dict[str, Any]]:

--- a/src/mondo/cache/store.py
+++ b/src/mondo/cache/store.py
@@ -22,12 +22,15 @@ from loguru import logger
 
 from mondo.version import __version__
 
-# SCHEMA_VERSION = 5 since the v5 bump (boards directory gained nested
-# `workspace { id name }`). Adding new entity types — `tags`, `webhooks`,
-# and any future per-entity caches — does NOT bump the schema, since the
-# shape of existing envelopes is unchanged. Only bump when an existing
-# entity's serialized shape changes.
-SCHEMA_VERSION = 5
+# SCHEMA_VERSION = 6 since the v6 bump (items / board_items / subitems
+# column_values gained polymorphic `display_value` / `linked_item_ids`
+# fields (#88); users-directory entries switched to the normalized
+# kind/status shape (#89)). v5 was the boards-directory nested
+# `workspace { id name }` bump. Adding new entity types — `tags`,
+# `webhooks`, and any future per-entity caches — does NOT bump the schema,
+# since the shape of existing envelopes is unchanged. Only bump when an
+# existing entity's serialized shape changes.
+SCHEMA_VERSION = 6
 
 EntityType = Literal[
     "boards",

--- a/src/mondo/cli/auth.py
+++ b/src/mondo/cli/auth.py
@@ -13,6 +13,7 @@ from mondo.api.queries import ME_QUERY
 from mondo.cli._examples import epilog_for
 from mondo.cli._exec import handle_mondo_error_or_exit, usage_error_or_exit
 from mondo.cli.context import GlobalOpts
+from mondo.domain.users import normalize_user
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -35,7 +36,7 @@ def whoami(ctx: typer.Context) -> None:
     except MondoError as e:
         handle_mondo_error_or_exit(e)
 
-    me = (result.get("data") or {}).get("me") or {}
+    me = normalize_user((result.get("data") or {}).get("me") or {})
     opts.emit(me)
 
 
@@ -61,7 +62,7 @@ def status(ctx: typer.Context) -> None:
     except MondoError as e:
         handle_mondo_error_or_exit(e)
 
-    me = (result.get("data") or {}).get("me") or {}
+    me = normalize_user((result.get("data") or {}).get("me") or {})
     account = me.get("account") or {}
 
     payload = {

--- a/src/mondo/cli/me.py
+++ b/src/mondo/cli/me.py
@@ -12,13 +12,14 @@ import typer
 from mondo.api.queries import ACCOUNT_ONLY, ME_FULL
 from mondo.cli._exec import execute
 from mondo.cli.context import GlobalOpts
+from mondo.domain.users import normalize_user
 
 
 def me_command(ctx: typer.Context) -> None:
     """Print the authenticated user (id, name, teams, account)."""
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
     data = execute(opts, ME_FULL, {})
-    opts.emit(data.get("me") or {})
+    opts.emit(normalize_user(data.get("me") or {}))
 
 
 def account_command(ctx: typer.Context) -> None:

--- a/src/mondo/cli/user.py
+++ b/src/mondo/cli/user.py
@@ -35,6 +35,7 @@ from mondo.cli._examples import epilog_for
 from mondo.cli._exec import client_or_exit, execute, handle_mondo_error_or_exit
 from mondo.cli.context import GlobalOpts
 from mondo.domain.resolve import resolve_required_id
+from mondo.domain.users import normalize_user
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -62,6 +63,46 @@ _ROLE_TO_MUTATION = {
     UserRole.guest: (USERS_UPDATE_AS_GUESTS, "update_multiple_users_as_guests"),
     UserRole.viewer: (USERS_UPDATE_AS_VIEWERS, "update_multiple_users_as_viewers"),
 }
+
+
+def _user_kind_arg(kind: UserKind | None) -> dict[str, list[str]] | None:
+    """Map `--kind guests` to the server `user_kind` filter. Only `guests`
+    goes server-side; `non_guests`/`non_pending` are handled client-side."""
+    if kind is UserKind.guests:
+        return {"in": ["GUEST"]}
+    return None
+
+
+def _status_arg(non_active: bool) -> list[str]:
+    """Map `--include-deactivated` to the `status` arg. Default returns only
+    ACTIVE users; the flag truly *includes* deactivated users by fetching
+    ACTIVE + INACTIVE (monday's INACTIVE bucket also surfaces PENDING). This
+    matches the directory cache's `_fetch_all_users` arg exactly, so the
+    live and cache paths return the same set. Verified live on API 2026-07:
+    `["ACTIVE"]` and `["ACTIVE", "INACTIVE"]` returned 159 and 271 users
+    respectively, the latter identical to the cache path's result set."""
+    return ["ACTIVE", "INACTIVE"] if non_active else ["ACTIVE"]
+
+
+def _sort_arg(newest_first: bool) -> list[dict[str, str]] | None:
+    if newest_first:
+        return [{"field": "CREATED_AT", "direction": "DESC"}]
+    return None
+
+
+# Keys in the activate/deactivate/update-role payloads that hold user records
+# selecting the new `kind`/`status` scalars — normalized so the derived legacy
+# booleans (`enabled`, `is_admin`, ...) stay in the emitted envelope.
+_ENVELOPE_USER_KEYS = ("deactivated_users", "activated_users", "updated_users")
+
+
+def _normalize_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    out = dict(envelope)
+    for key in _ENVELOPE_USER_KEYS:
+        users = out.get(key)
+        if isinstance(users, list):
+            out[key] = [normalize_user(u) for u in users]
+    return out
 
 
 # ----- read commands -----
@@ -95,7 +136,7 @@ def list_cmd(
         False,
         "--include-deactivated",
         "--non-active",
-        help="Include deactivated users.",
+        help="Include deactivated (and pending) users alongside active ones.",
     ),
     newest_first: bool = typer.Option(
         False, "--newest-first", help="Sort by most recently created."
@@ -146,12 +187,20 @@ def list_cmd(
 
     variables: dict[str, Any] = {
         "ids": None,
-        "kind": kind.value if kind else None,
+        "userKind": _user_kind_arg(kind),
         "emails": email or None,
         "name": name,
-        "nonActive": True if non_active else None,
-        "newestFirst": True if newest_first else None,
+        "status": _status_arg(non_active),
+        "sort": _sort_arg(newest_first),
     }
+
+    # `non_guests`/`non_pending` are applied client-side: monday's `not_in`
+    # filter is a no-op server-side (verified live on 2026-07), and there's no
+    # server-side way to drop PENDING (the INACTIVE bucket always includes it).
+    # `guests` is also re-filtered client-side (belt-and-suspenders), so it
+    # must fetch fully too — otherwise --max-items could truncate on rows the
+    # client-side filter would drop.
+    client_kind_filter = kind in (UserKind.non_guests, UserKind.guests, UserKind.non_pending)
 
     if opts.dry_run:
         opts.emit(
@@ -173,10 +222,21 @@ def list_cmd(
                 variables=variables,
                 collection_key="users",
                 limit=limit,
-                max_items=None if name_fuzzy else max_items,
+                max_items=None if (name_fuzzy or client_kind_filter) else max_items,
             )
     except MondoError as e:
         handle_mondo_error_or_exit(e)
+    items = [normalize_user(u) for u in items]
+    if kind is UserKind.non_guests:
+        items = [u for u in items if not u.get("is_guest")]
+    elif kind is UserKind.guests:
+        # Belt-and-suspenders: the server `user_kind {in: [GUEST]}` filter is
+        # kept as an optimization, but guests are re-filtered client-side so
+        # the live and cache paths agree even if the server filter regresses
+        # (its `not_in` sibling is already a server-side no-op).
+        items = [u for u in items if u.get("is_guest")]
+    elif kind is UserKind.non_pending:
+        items = [u for u in items if not u.get("is_pending")]
     if name_fuzzy is not None:
         from mondo.domain.filters import apply_fuzzy
 
@@ -186,8 +246,8 @@ def list_cmd(
             threshold=prefs.fuzzy_threshold,
             include_score=fuzzy_score_flag,
         )
-        if max_items is not None:
-            items = items[:max_items]
+    if max_items is not None:
+        items = items[:max_items]
     opts.emit(items)
 
 
@@ -291,7 +351,7 @@ def get_cmd(
     users = data.get("users") or []
     if not users:
         handle_mondo_error_or_exit(NotFoundError(f"user {user_id} not found."))
-    opts.emit(users[0])
+    opts.emit(normalize_user(users[0]))
 
 
 # ----- write commands -----
@@ -311,7 +371,7 @@ def deactivate_cmd(
     variables = {"ids": user}
     data = execute(opts, USERS_DEACTIVATE, variables)
     invalidate_entity(opts, "users")
-    opts.emit(data.get("deactivate_users") or {})
+    opts.emit(_normalize_envelope(data.get("deactivate_users") or {}))
 
 
 @app.command("activate", epilog=epilog_for("user activate"))
@@ -326,7 +386,7 @@ def activate_cmd(
     variables = {"ids": user}
     data = execute(opts, USERS_ACTIVATE, variables)
     invalidate_entity(opts, "users")
-    opts.emit(data.get("activate_users") or {})
+    opts.emit(_normalize_envelope(data.get("activate_users") or {}))
 
 
 @app.command("update-role", epilog=epilog_for("user update-role"))
@@ -351,7 +411,7 @@ def update_role_cmd(
     variables = {"ids": user}
     data = execute(opts, query, variables)
     invalidate_entity(opts, "users")
-    opts.emit(data.get(response_key) or {})
+    opts.emit(_normalize_envelope(data.get(response_key) or {}))
 
 
 @app.command("add-to-team", epilog=epilog_for("user add-to-team"))

--- a/src/mondo/config/loader.py
+++ b/src/mondo/config/loader.py
@@ -17,7 +17,7 @@ from typing import Any
 from mondo.config.schema import Config
 
 DEFAULT_API_URL = "https://api.monday.com/v2"
-DEFAULT_API_VERSION = "2026-01"
+DEFAULT_API_VERSION = "2026-07"
 
 _ENV_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 

--- a/src/mondo/config/schema.py
+++ b/src/mondo/config/schema.py
@@ -91,7 +91,7 @@ class Config(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     default_profile: str = "default"
-    api_version: str = "2026-01"
+    api_version: str = "2026-07"
     profiles: dict[str, Profile] = Field(default_factory=dict)
     cache: CacheConfig | None = None
 

--- a/src/mondo/domain/users.py
+++ b/src/mondo/domain/users.py
@@ -1,0 +1,46 @@
+"""Normalize monday `User` records to a stable output shape.
+
+API 2026-07 replaced the boolean role/state fields with the `kind` and
+`status` scalars (the old fields are deprecated, removal targeted 2026-10).
+mondo migrates its queries to the new fields but keeps emitting the legacy
+booleans so existing consumers/scripts don't break, deriving them here while
+also passing `kind`/`status` through untouched.
+
+Runtime values verified live on API 2026-07:
+- `kind`: "admin" | "member" | "guest" | "view_only" (+ service kinds).
+- `status`: "ACTIVE" | "INACTIVE" | "PENDING".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_user(user: dict[str, Any]) -> dict[str, Any]:
+    """Return `user` with legacy boolean fields derived from `kind`/`status`.
+
+    Derivation keys off field *presence* in the source, not its value: a
+    partial selection that never fetched `kind`/`status`/`photo_url` stays
+    lossless (the derived keys are omitted), but a selected-but-null source
+    emits the derived key as ``None`` rather than dropping it — so consumers
+    see a stable shape. New fields (`kind`, `status`, `photo_url`) are
+    preserved as-is.
+    """
+    out = dict(user)
+
+    if "kind" in user:
+        kind = user["kind"]
+        out["is_admin"] = kind == "admin" if kind is not None else None
+        out["is_guest"] = kind == "guest" if kind is not None else None
+        out["is_view_only"] = kind == "view_only" if kind is not None else None
+
+    if "status" in user:
+        status = user["status"]
+        out["enabled"] = status == "ACTIVE" if status is not None else None
+        out["is_pending"] = status == "PENDING" if status is not None else None
+
+    if "photo_url" in user:
+        photo_url = user["photo_url"]
+        out["photo_thumb"] = photo_url.get("thumb") if isinstance(photo_url, dict) else None
+
+    return out

--- a/src/mondo/help/profiles.md
+++ b/src/mondo/help/profiles.md
@@ -7,7 +7,7 @@ team — `mondo` handles these through named profiles in
 ## Minimal config
 
     default_profile: personal
-    api_version: "2026-01"
+    api_version: "2026-07"
 
     profiles:
       personal:
@@ -62,6 +62,6 @@ setting came from:
 
     mondo --debug auth status
     # token source: keyring (profile=personal)
-    # api_version: 2026-01 (source=profile.work)
+    # api_version: 2026-07 (source=profile.work)
 
 See also: `mondo help auth`, `mondo help output`.

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -17,6 +17,7 @@ import pytest
 from typer.testing import CliRunner
 
 from mondo.cli.main import app
+from mondo.config import DEFAULT_API_VERSION
 
 MONDAY_TEST_TOKEN_ENV = "MONDAY_TEST_TOKEN"
 MONDAY_TEST_WORKSPACE_ID_ENV = "MONDAY_TEST_WORKSPACE_ID"
@@ -24,7 +25,9 @@ MONDO_TEST_WORKSPACE_ID_ENV = "MONDO_TEST_WORKSPACE_ID"
 MONDO_TEST_BOARD_ID_ENV = "MONDO_TEST_BOARD_ID"
 MONDO_TEST_DOC_ID_ENV = "MONDO_TEST_DOC_ID"
 DEFAULT_PLAYGROUND_WORKSPACE_ID = 592446
-API_VERSION = "2026-01"
+# Pin the live suite to the CLI's own default so query migrations (e.g. the
+# 2026-07 user/me migration) can't drift apart from the version tests run on.
+API_VERSION = DEFAULT_API_VERSION
 
 runner = CliRunner()
 

--- a/tests/skill_eval/conftest.py
+++ b/tests/skill_eval/conftest.py
@@ -18,6 +18,7 @@ import pytest
 from dotenv import load_dotenv
 
 from tests.integration._helpers import (
+    API_VERSION,
     MONDO_TEST_BOARD_ID_ENV,
     CleanupPlan,
     invoke_json,
@@ -97,7 +98,7 @@ def eval_extra_env() -> dict[str, str]:
     token = os.environ.get("MONDAY_TEST_TOKEN")
     if token:
         env["MONDAY_API_TOKEN"] = token
-    env["MONDAY_API_VERSION"] = "2026-01"
+    env["MONDAY_API_VERSION"] = API_VERSION
     env["MONDO_NO_CACHE_NOTICE"] = "1"
     env["MONDO_NO_PROJECTION_WARNINGS"] = "1"
     return env
@@ -110,7 +111,7 @@ def _eval_env_shim(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     if not token:
         return
     monkeypatch.setenv("MONDAY_API_TOKEN", token)
-    monkeypatch.setenv("MONDAY_API_VERSION", "2026-01")
+    monkeypatch.setenv("MONDAY_API_VERSION", API_VERSION)
     monkeypatch.setenv("MONDO_NO_CACHE_NOTICE", "1")
     monkeypatch.setenv("MONDO_NO_PROJECTION_WARNINGS", "1")
     monkeypatch.setenv("MONDO_HOME", str(tmp_path / "mondo_home"))

--- a/tests/unit/test_cache_directory.py
+++ b/tests/unit/test_cache_directory.py
@@ -154,37 +154,32 @@ def test_get_workspaces_cold_then_warm(tmp_path: Path) -> None:
 # -- users -------------------------------------------------------------------
 
 
-def test_get_users_covers_both_active_and_disabled(tmp_path: Path) -> None:
+def test_get_users_single_fetch_all_statuses(tmp_path: Path) -> None:
     store = _store(tmp_path, "users")
     client = FakeClient(
         [
-            {"data": {"users": [{"id": "1", "name": "Active Ann", "enabled": True}]}},
-            {"data": {"users": [{"id": "2", "name": "Disabled Dan", "enabled": False}]}},
+            {
+                "data": {
+                    "users": [
+                        {"id": "1", "name": "Active Ann", "kind": "member", "status": "ACTIVE"},
+                        {"id": "2", "name": "Disabled Dan", "kind": "member", "status": "INACTIVE"},
+                    ]
+                }
+            },
         ]
     )
 
     result = get_users(client, store=store)
 
-    # Two API calls: one with nonActive=False, one with nonActive=True
-    assert len(client.calls) == 2
-    seen_flags = {call[1].get("nonActive") for call in client.calls if call[1]}
-    assert seen_flags == {True, False}
-    # Both users merged into the cache
+    # One API call on 2026-07: status: [ACTIVE, INACTIVE] returns the full
+    # directory (the INACTIVE bucket also surfaces PENDING).
+    assert len(client.calls) == 1
+    assert client.calls[0][1].get("status") == ["ACTIVE", "INACTIVE"]
     assert {e["id"] for e in result.entries} == {"1", "2"}
-
-
-def test_get_users_dedupes_when_apis_overlap(tmp_path: Path) -> None:
-    store = _store(tmp_path, "users")
-    duplicate = {"id": "1", "name": "Maybe Both"}
-    client = FakeClient(
-        [
-            {"data": {"users": [duplicate]}},
-            {"data": {"users": [duplicate]}},
-        ]
-    )
-
-    result = get_users(client, store=store)
-    assert len(result.entries) == 1
+    # Entries are normalized so the derived legacy booleans are cached.
+    by_id = {e["id"]: e for e in result.entries}
+    assert by_id["1"]["enabled"] is True
+    assert by_id["2"]["enabled"] is False
 
 
 # -- teams -------------------------------------------------------------------

--- a/tests/unit/test_cli_cache_paths.py
+++ b/tests/unit/test_cli_cache_paths.py
@@ -301,16 +301,13 @@ class TestWorkspaceListCache:
 
 class TestUserListCache:
     def test_cache_prime_and_warm(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
-        # Priming issues two queries (nonActive=false + nonActive=true).
+        # Priming issues a single query (status: [ACTIVE, INACTIVE]) on 2026-07.
         httpx_mock.add_response(
             url=ENDPOINT,
             method="POST",
-            json=_ok({"users": [{"id": "1", "name": "Zoe", "email": "z@x", "enabled": True}]}),
-        )
-        httpx_mock.add_response(
-            url=ENDPOINT,
-            method="POST",
-            json=_ok({"users": []}),
+            json=_ok(
+                {"users": [{"id": "1", "name": "Zoe", "email": "z@x", "status": "ACTIVE"}]}
+            ),
         )
         r1 = runner.invoke(app, ["user", "list"])
         assert r1.exit_code == 0, r1.stdout

--- a/tests/unit/test_cli_user.py
+++ b/tests/unit/test_cli_user.py
@@ -62,8 +62,6 @@ class TestList:
             [
                 "user",
                 "list",
-                "--kind",
-                "non_guests",
                 "--email",
                 "a@x.com",
                 "--email",
@@ -76,11 +74,170 @@ class TestList:
         )
         assert result.exit_code == 0, result.stdout
         v = _last_body(httpx_mock)["variables"]
-        assert v["kind"] == "non_guests"
         assert v["emails"] == ["a@x.com", "b@x.com"]
         assert v["name"] == "Ali"
-        assert v["nonActive"] is True
-        assert v["newestFirst"] is True
+        # --non-active → status: [ACTIVE, INACTIVE] — the flag *includes*
+        # deactivated users alongside active ones, matching the cache path.
+        assert v["status"] == ["ACTIVE", "INACTIVE"]
+        # --newest-first → sort by created_at DESC.
+        assert v["sort"] == [{"field": "CREATED_AT", "direction": "DESC"}]
+
+    def test_default_status_is_active(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"users": []}))
+        result = runner.invoke(app, ["user", "list"])
+        assert result.exit_code == 0, result.stdout
+        v = _last_body(httpx_mock)["variables"]
+        assert v["status"] == ["ACTIVE"]
+        assert v["userKind"] is None
+        assert v["sort"] is None
+
+    def test_kind_guests_maps_to_server_user_kind(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"users": []}))
+        result = runner.invoke(app, ["user", "list", "--kind", "guests"])
+        assert result.exit_code == 0, result.stdout
+        v = _last_body(httpx_mock)["variables"]
+        assert v["userKind"] == {"in": ["GUEST"]}
+
+    def test_kind_guests_also_filters_client_side(self, httpx_mock: HTTPXMock) -> None:
+        # Belt-and-suspenders: even if the server `user_kind {in: [GUEST]}`
+        # filter regresses to a no-op (like its `not_in` sibling), guests are
+        # re-filtered client-side so live and cache paths agree.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "users": [
+                        {"id": "1", "name": "Member", "kind": "member", "status": "ACTIVE"},
+                        {"id": "2", "name": "Guesty", "kind": "guest", "status": "ACTIVE"},
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["user", "list", "--kind", "guests"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert [u["name"] for u in parsed] == ["Guesty"]
+
+    def test_kind_guests_max_items_slices_after_client_filter(self, httpx_mock: HTTPXMock) -> None:
+        # --max-items must not truncate the fetch before the client-side guest
+        # filter runs: with a regressed server filter returning [member, guest],
+        # --max-items 1 has to yield the guest, not an empty list.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "users": [
+                        {"id": "1", "name": "Member", "kind": "member", "status": "ACTIVE"},
+                        {"id": "2", "name": "Guesty", "kind": "guest", "status": "ACTIVE"},
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["user", "list", "--kind", "guests", "--max-items", "1"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert [u["name"] for u in parsed] == ["Guesty"]
+
+    def test_kind_non_guests_filters_client_side(self, httpx_mock: HTTPXMock) -> None:
+        # `not_in` is a server-side no-op on 2026-07, so non_guests drops
+        # guests client-side from the derived `is_guest` boolean.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "users": [
+                        {"id": "1", "name": "Member", "kind": "member", "status": "ACTIVE"},
+                        {"id": "2", "name": "Guesty", "kind": "guest", "status": "ACTIVE"},
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["user", "list", "--kind", "non_guests"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert [u["name"] for u in parsed] == ["Member"]
+        # No server-side user_kind filter is sent for non_guests.
+        assert _last_body(httpx_mock)["variables"]["userKind"] is None
+
+    def test_kind_non_pending_with_include_deactivated_live(self, httpx_mock: HTTPXMock) -> None:
+        # `--include-deactivated` sends status: [ACTIVE, INACTIVE] (monday's
+        # INACTIVE bucket also surfaces PENDING). `--kind non_pending` then
+        # drops PENDING client-side, leaving the inactive row.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "users": [
+                        {"id": "1", "name": "Inactive", "kind": "member", "status": "INACTIVE"},
+                        {"id": "2", "name": "Pending", "kind": "member", "status": "PENDING"},
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(
+            app, ["user", "list", "--kind", "non_pending", "--include-deactivated"]
+        )
+        assert result.exit_code == 0, result.stdout
+        # Exact status variable sent to the server.
+        assert _last_body(httpx_mock)["variables"]["status"] == ["ACTIVE", "INACTIVE"]
+        parsed = json.loads(result.stdout)
+        assert [u["name"] for u in parsed] == ["Inactive"]
+
+    def test_kind_non_pending_with_include_deactivated_cache(
+        self, httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Same scenario through the cache path: the directory fetch primes with
+        # status: [ACTIVE, INACTIVE], the cache keeps everyone when the flag is
+        # set, and `non_pending` drops PENDING client-side — identical result to
+        # the live path, so cache/live agreement is regression-tested.
+        monkeypatch.setenv("MONDO_CACHE_ENABLED", "true")
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "users": [
+                        {"id": "1", "name": "Inactive", "kind": "member", "status": "INACTIVE"},
+                        {"id": "2", "name": "Pending", "kind": "member", "status": "PENDING"},
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(
+            app, ["user", "list", "--kind", "non_pending", "--include-deactivated"]
+        )
+        assert result.exit_code == 0, result.stdout
+        # The directory cache primes with status: [ACTIVE, INACTIVE].
+        assert _last_body(httpx_mock)["variables"]["status"] == ["ACTIVE", "INACTIVE"]
+        parsed = json.loads(result.stdout)
+        assert [u["name"] for u in parsed] == ["Inactive"]
+
+    def test_derives_legacy_booleans(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "users": [
+                        {"id": "1", "name": "Adm", "kind": "admin", "status": "ACTIVE"},
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["user", "list"])
+        assert result.exit_code == 0, result.stdout
+        u = json.loads(result.stdout)[0]
+        assert u["kind"] == "admin"
+        assert u["status"] == "ACTIVE"
+        assert u["is_admin"] is True
+        assert u["is_guest"] is False
+        assert u["is_view_only"] is False
+        assert u["enabled"] is True
+        assert u["is_pending"] is False
 
     def test_dry_run(self, httpx_mock: HTTPXMock) -> None:
         result = runner.invoke(app, ["--dry-run", "user", "list"])
@@ -111,6 +268,33 @@ class TestGet:
         result = runner.invoke(app, ["user", "get", "--id", "999"])
         assert result.exit_code == 6
 
+    def test_derives_photo_thumb_and_booleans(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok(
+                {
+                    "users": [
+                        {
+                            "id": "42",
+                            "name": "Vera",
+                            "kind": "view_only",
+                            "status": "PENDING",
+                            "photo_url": {"thumb": "https://x/thumb.png"},
+                        }
+                    ]
+                }
+            ),
+        )
+        result = runner.invoke(app, ["user", "get", "--id", "42"])
+        assert result.exit_code == 0, result.stdout
+        u = json.loads(result.stdout)
+        assert u["is_view_only"] is True
+        assert u["is_admin"] is False
+        assert u["is_pending"] is True
+        assert u["enabled"] is False
+        assert u["photo_thumb"] == "https://x/thumb.png"
+
 
 # --- deactivate / activate ---
 
@@ -128,7 +312,7 @@ class TestDeactivate:
             json=_ok(
                 {
                     "deactivate_users": {
-                        "deactivated_users": [{"id": "1", "enabled": False}],
+                        "deactivated_users": [{"id": "1", "name": "A", "status": "INACTIVE"}],
                         "errors": [],
                     }
                 }
@@ -141,6 +325,9 @@ class TestDeactivate:
         assert result.exit_code == 0, result.stdout
         v = _last_body(httpx_mock)["variables"]
         assert v == {"ids": [1, 2]}
+        # `status` from the response is normalized back into `enabled`.
+        parsed = json.loads(result.stdout)
+        assert parsed["deactivated_users"][0]["enabled"] is False
 
 
 class TestActivate:
@@ -151,7 +338,7 @@ class TestActivate:
             json=_ok(
                 {
                     "activate_users": {
-                        "activated_users": [{"id": "1", "enabled": True}],
+                        "activated_users": [{"id": "1", "name": "A", "status": "ACTIVE"}],
                         "errors": [],
                     }
                 }
@@ -161,6 +348,8 @@ class TestActivate:
         assert result.exit_code == 0, result.stdout
         v = _last_body(httpx_mock)["variables"]
         assert v == {"ids": [1]}
+        parsed = json.loads(result.stdout)
+        assert parsed["activated_users"][0]["enabled"] is True
 
 
 # --- update-role ---
@@ -174,7 +363,7 @@ class TestUpdateRole:
             json=_ok(
                 {
                     "update_multiple_users_as_admins": {
-                        "updated_users": [{"id": "1", "is_admin": True}],
+                        "updated_users": [{"id": "1", "name": "A", "kind": "admin"}],
                         "errors": [],
                     }
                 }
@@ -187,6 +376,9 @@ class TestUpdateRole:
         assert result.exit_code == 0, result.stdout
         body = _last_body(httpx_mock)
         assert "update_multiple_users_as_admins" in body["query"]
+        # `kind` from the response is normalized back into `is_admin`.
+        parsed = json.loads(result.stdout)
+        assert parsed["updated_users"][0]["is_admin"] is True
 
     def test_member(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(

--- a/tests/unit/test_normalize_user.py
+++ b/tests/unit/test_normalize_user.py
@@ -1,0 +1,85 @@
+"""Unit tests for `normalize_user` — the 2026-07 kind/status → legacy-boolean
+derivation. Combinations match the runtime values verified live on the API."""
+
+from __future__ import annotations
+
+import pytest
+
+from mondo.domain.users import normalize_user
+
+
+@pytest.mark.parametrize(
+    ("kind", "is_admin", "is_guest", "is_view_only"),
+    [
+        ("admin", True, False, False),
+        ("member", False, False, False),
+        ("guest", False, True, False),
+        ("view_only", False, False, True),
+    ],
+)
+def test_kind_derivation(kind, is_admin, is_guest, is_view_only) -> None:
+    out = normalize_user({"id": "1", "kind": kind})
+    assert out["is_admin"] is is_admin
+    assert out["is_guest"] is is_guest
+    assert out["is_view_only"] is is_view_only
+    assert out["kind"] == kind  # new field preserved
+
+
+@pytest.mark.parametrize(
+    ("status", "enabled", "is_pending"),
+    [
+        ("ACTIVE", True, False),
+        ("INACTIVE", False, False),
+        ("PENDING", False, True),
+    ],
+)
+def test_status_derivation(status, enabled, is_pending) -> None:
+    out = normalize_user({"id": "1", "status": status})
+    assert out["enabled"] is enabled
+    assert out["is_pending"] is is_pending
+    assert out["status"] == status  # new field preserved
+
+
+def test_photo_url_thumb_derivation() -> None:
+    out = normalize_user({"id": "1", "photo_url": {"thumb": "https://x/t.png"}})
+    assert out["photo_thumb"] == "https://x/t.png"
+    assert out["photo_url"] == {"thumb": "https://x/t.png"}
+
+
+def test_partial_record_only_derives_present_fields() -> None:
+    # A mutation payload that selected only `kind` must not invent status keys.
+    out = normalize_user({"id": "1", "name": "A", "kind": "member"})
+    assert "is_admin" in out
+    assert "enabled" not in out
+    assert "is_pending" not in out
+    assert "photo_thumb" not in out
+
+
+def test_no_new_fields_is_lossless() -> None:
+    src = {"id": "1", "name": "Legacy"}
+    assert normalize_user(src) == src
+
+
+def test_missing_photo_thumb_key() -> None:
+    out = normalize_user({"id": "1", "photo_url": {}})
+    assert out["photo_thumb"] is None
+
+
+def test_null_photo_url_emits_none_thumb() -> None:
+    # `photo_url` selected but null → keep a stable shape, not a dropped key.
+    out = normalize_user({"id": "1", "photo_url": None})
+    assert "photo_thumb" in out
+    assert out["photo_thumb"] is None
+
+
+def test_null_kind_emits_none_booleans() -> None:
+    out = normalize_user({"id": "1", "kind": None})
+    assert out["is_admin"] is None
+    assert out["is_guest"] is None
+    assert out["is_view_only"] is None
+
+
+def test_null_status_emits_none_booleans() -> None:
+    out = normalize_user({"id": "1", "status": None})
+    assert out["enabled"] is None
+    assert out["is_pending"] is None


### PR DESCRIPTION
Resolves #89.

## What

monday's 2026-07 API **removed** (not deprecated) `Query.users`' `kind`/`newest_first`/`non_active` args, and the legacy User fields are removal-targeted for 2026-10. The replacement args don't exist on our 2026-01 pin, so the query migration and the pin bump land together (the API-watch state confirms user/me is the only mondo-relevant break on 2026-07):

- `DEFAULT_API_VERSION` → `2026-07` (config default + schema).
- `users` args → `user_kind: UserKindFilterInput`, `status: [UserStatus!]`, `sort: [UsersSortInput!]`; User fields → `kind`/`status`/`photo_url { thumb }` in USERS_LIST_PAGE, USER_GET, ME_QUERY, ME_FULL and the role/activate mutation selections.
- **Output contract stays stable**: new `normalize_user` (domain/users.py) derives the legacy booleans (`is_admin`/`is_guest`/`is_view_only`/`enabled`/`is_pending`/`photo_thumb`) from `kind`/`status`/`photo_url` — presence-based, so selected-but-null sources emit `None` instead of dropping keys. New fields are emitted alongside.
- `--kind guests` → server `user_kind {in: [GUEST]}` **plus** a client-side re-filter (belt-and-suspenders; the sibling `not_in` filter is a live-verified server-side no-op, so `non_guests`/`non_pending` are client-side; all client-filtered kinds fetch fully so `--max-items` slices after filtering).
- **Behavior fix**: `--include-deactivated` on the live path now truly *includes* (sends `status: [ACTIVE, INACTIVE]`, live-verified 159 → 271 users, identical to the cache path) instead of the old either/or that returned ONLY deactivated users, contradicting the flag's help text.
- Directory cache: one `status:[ACTIVE,INACTIVE]` fetch (was two calls), entries normalized before caching; cache `SCHEMA_VERSION` 5→6 (hunk textually identical to #88's branch — merges clean in either order).
- Live-test fixtures (`tests/integration/_helpers.py`, `tests/skill_eval/conftest.py`) now pin `MONDAY_API_VERSION` to `DEFAULT_API_VERSION` instead of a hardcoded `2026-01` — this was a real bug caught when the live skill-eval suite ran the new queries against the old version.
- Docs: stale 2026-01 pin claims updated.

## Verification

- Runtime enum values verified live: `kind` = `admin`/`member`/`guest`/`view_only`; `status` = `ACTIVE`/`INACTIVE`/`PENDING` (PENDING bucket empty on this account, surfaced via INACTIVE).
- Live read-only on 2026-07: `auth whoami`/`status`, `me`, `account`, `user list` (default / `--kind guests` / `non_guests` / `--include-deactivated` with exact counts), `user get`, plus unrelated-surface smoke (`board get`, `item list`, `doc get`) — all clean.
- Full suite: 1909 passed (includes the live skill-eval tasks on the main checkout, which spawn headless Claude agents against the playground board).

## Review trail

gpt-5.5 (codex) round 1 → fixed cache/live `--include-deactivated` divergence, presence-based normalize_user, impossible test fixture; 8-angle adversarially-verified review → cache schema bump (CONFIRMED), guests client-side fallback; security review PASS; gpt-5.5 round 2 → APPROVE-WITH-NITS, the nit (`--kind guests --max-items` truncation under a regressed server filter) fixed with a regression test.

Notes (deliberate): client-side kind filters fetch the full directory before slicing (correctness over bound fetches; ~271 users here); `mondo schema user` lists raw selected fields and not the derived booleans — same pre-existing pattern as boards, to be picked up by the docs/output-contract sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)