### PR TITLE
feat(column): add column set --batch + clear-shaped value hint (#90, #91)

### DIFF
--- a/src/mondo/cli/_batch.py
+++ b/src/mondo/cli/_batch.py
@@ -13,12 +13,22 @@ Two pure helpers — no I/O, fully unit-testable:
 `var_names` is the ordered list of variables declared by the original
 template (without leading `$`). Callers iterate the chunk and build the
 flattened variables dict by setting `out[f"{name}_{i}"] = value_for_row_i`.
+
+On top of those, `run_aliased_batch` / `build_batch_chunks_repr` drive the
+whole chunk fan-out shared by `item create --batch` and `column set --batch`,
+so the callers only supply the template plus their per-row variables.
 """
 
 from __future__ import annotations
 
 import re
-from typing import Any
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from mondo.api.errors import MondoError
+
+if TYPE_CHECKING:
+    from mondo.api.client import MondayClient
 
 # `mutation ( $a: T! $b: T ) { body }` — DOTALL so the body can span lines.
 # Greedy `.*` for body so the closing `}` matches the outermost brace.
@@ -148,3 +158,117 @@ def chunk_inputs[T](items: list[T], size: int) -> list[list[T]]:
     if size < 1:
         raise ValueError("size must be >= 1")
     return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+# ----- shared batch driver -----
+#
+# `item create --batch` and `column set --batch` fan an aliased mutation the
+# same way: chunk the rows, compile one document per chunk, flatten each row's
+# variables with a `_i` suffix, execute with `surface_partial_errors=True`, and
+# map the response back per row. The three functions below are that shared
+# machinery — the callers only differ in the template and how they build
+# `per_row_vars` / `result_rows`.
+
+
+def _chunk_builder(template: str) -> Callable[[int], tuple[str, list[str]]]:
+    """Return a memoized `build_aliased_mutation(template, count)`.
+
+    Every full-size chunk in a batch has the same length, so compiling the
+    aliased document once and reusing it avoids re-running the regex rewrite
+    for each chunk (only the shorter trailing chunk, if any, compiles anew).
+    """
+    cache: dict[int, tuple[str, list[str]]] = {}
+
+    def build(count: int) -> tuple[str, list[str]]:
+        got = cache.get(count)
+        if got is None:
+            got = build_aliased_mutation(template, count)
+            cache[count] = got
+        return got
+
+    return build
+
+
+def _flatten_chunk_vars(var_names: list[str], vars_chunk: list[dict[str, Any]]) -> dict[str, Any]:
+    """Flatten a chunk of per-row variable dicts into one `{name_i: value}` map."""
+    flat: dict[str, Any] = {}
+    for i, vars_row in enumerate(vars_chunk):
+        for name in var_names:
+            flat[f"{name}_{i}"] = vars_row[name]
+    return flat
+
+
+def _failed_rows(rows: list[dict[str, Any]], base_index: int, error: str) -> list[dict[str, Any]]:
+    """Build failure envelopes for `rows`, matching `parse_aliased_response`."""
+    return [
+        {
+            "ok": False,
+            "row_index": base_index + i,
+            "name": row.get("name", ""),
+            "error": error,
+        }
+        for i, row in enumerate(rows)
+    ]
+
+
+def build_batch_chunks_repr(
+    template: str, per_row_vars: list[dict[str, Any]], chunk_size: int
+) -> list[dict[str, Any]]:
+    """Return the `--dry-run` representation of a batch: one entry per HTTP call
+    that would be made, each with the aliased `query`, the flattened
+    `variables`, and the absolute `row_indices` the chunk covers."""
+    build = _chunk_builder(template)
+    chunks_repr: list[dict[str, Any]] = []
+    for chunk_idx, vars_chunk in enumerate(chunk_inputs(per_row_vars, chunk_size)):
+        query, var_names = build(len(vars_chunk))
+        base = chunk_idx * chunk_size
+        chunks_repr.append(
+            {
+                "query": query,
+                "variables": _flatten_chunk_vars(var_names, vars_chunk),
+                "row_indices": list(range(base, base + len(vars_chunk))),
+            }
+        )
+    return chunks_repr
+
+
+def run_aliased_batch(
+    client: MondayClient,
+    template: str,
+    per_row_vars: list[dict[str, Any]],
+    result_rows: list[dict[str, Any]],
+    *,
+    chunk_size: int,
+) -> list[dict[str, Any]]:
+    """Execute an aliased multi-mutation batch and return per-row result
+    envelopes (see `parse_aliased_response` for their shape).
+
+    `per_row_vars` supplies each row's mutation variables; `result_rows`
+    supplies each row's `name` for the envelope (the two are index-aligned).
+    Each chunk becomes one `build_aliased_mutation` document (memoized by chunk
+    length) executed with `surface_partial_errors=True`, so GraphQL-layer
+    per-row failures land in the envelope.
+
+    An HTTP-layer `MondoError` (rate-limit/complexity/network) raised mid-batch
+    is caught here rather than propagated: the failing chunk's rows are marked
+    failed with the error message, every not-yet-attempted row is marked
+    `aborted: <error>`, and the driver stops. The caller still gets a complete
+    envelope for every requested row and can invalidate caches for the chunks
+    that did run."""
+    build = _chunk_builder(template)
+    vars_chunks = chunk_inputs(per_row_vars, chunk_size)
+    row_chunks = chunk_inputs(result_rows, chunk_size)
+    results: list[dict[str, Any]] = []
+    for chunk_idx, (vars_chunk, row_chunk) in enumerate(zip(vars_chunks, row_chunks, strict=True)):
+        base = chunk_idx * chunk_size
+        query, var_names = build(len(vars_chunk))
+        flat = _flatten_chunk_vars(var_names, vars_chunk)
+        try:
+            response = client.execute(query, variables=flat, surface_partial_errors=True)
+        except MondoError as e:
+            results.extend(_failed_rows(row_chunk, base, str(e)))
+            attempted = base + len(row_chunk)
+            results.extend(_failed_rows(result_rows[attempted:], attempted, f"aborted: {e}"))
+            break
+        results.extend(parse_aliased_response(response, row_chunk, base_index=base))
+    return results

--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 import json
 import sys
+from contextlib import nullcontext
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import typer
 
-from mondo.api.errors import MondoError, NotFoundError, ValidationError
+from mondo.api.errors import MondoError, NotFoundError, UsageError, ValidationError
 from mondo.api.queries import (
     CHANGE_COLUMN_VALUE,
     CHANGE_MULTIPLE_COLUMN_VALUES,
@@ -25,6 +26,7 @@ from mondo.api.queries import (
     COLUMN_DELETE,
     COLUMN_RENAME,
 )
+from mondo.cli._batch import build_batch_chunks_repr, run_aliased_batch
 from mondo.cli._cache_flags import reject_mutually_exclusive
 from mondo.cli._cache_invalidate import invalidate_board_items_cache, invalidate_entity
 from mondo.cli._confirm import confirm_or_abort as _confirm
@@ -51,8 +53,11 @@ from mondo.columns.status import iter_status_labels
 from mondo.domain.column_cache import fetch_board_columns, invalidate_columns_cache
 from mondo.domain.columns_resolve import parse_settings, resolve_tag_names_to_ids
 from mondo.domain.resolve import resolve_by_filters, resolve_required_id
+from mondo.services.items import fetch_column_defs, read_batch_rows
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from mondo.api.client import MondayClient
 
 app = typer.Typer(
@@ -101,6 +106,32 @@ def _load_value(value: str | None, from_file: Path | None, from_stdin: bool) -> 
         return sys.stdin.read()
     assert value is not None
     return value
+
+
+_CLEAR_SHAPED_JSON: tuple[Any, ...] = ({}, [], None, {"labels": []}, {"labels": None})
+
+
+def _clear_hint(raw_input: str, item_id: int, column_id: str) -> str:
+    """Return a `column clear` hint (#91) when `raw_input` looks like an
+    attempt to empty a column, else an empty string.
+
+    Clear-shaped inputs are the empty/whitespace string, the literals
+    `{}` / `null` / `[]`, or JSON that parses to `{}`, `[]`, `null`, or
+    `{"labels": []}` / `{"labels": null}`. Appended to a codec's
+    ValueError so agents blindly passing an "empty" payload get pointed
+    at the command that actually clears a column.
+    """
+    stripped = raw_input.strip()
+    clear_shaped = stripped in ("", "{}", "null", "[]")
+    if not clear_shaped:
+        try:
+            parsed = json.loads(stripped)
+        except ValueError:
+            return ""
+        clear_shaped = any(parsed == candidate for candidate in _CLEAR_SHAPED_JSON)
+    if not clear_shaped:
+        return ""
+    return f" To empty a column, use: mondo column clear --item {item_id} --column {column_id}"
 
 
 # ----- commands -----
@@ -305,11 +336,36 @@ def get_cmd(
 @app.command("set", epilog=epilog_for("column set"))
 def set_cmd(
     ctx: typer.Context,
-    item_id: int = typer.Option(..., "--item", help="Item ID."),
-    column_id: str = typer.Option(..., "--column", help="Column ID."),
+    item_id: int | None = typer.Option(
+        None, "--item", help="Item ID (single-item mode; omit when using --batch)."
+    ),
+    column_id: str | None = typer.Option(
+        None,
+        "--column",
+        help="Column ID (single-item mode; default column for --batch rows omitting one).",
+    ),
     value: str | None = typer.Option(None, "--value", help="Value (codec-parsed)."),
     from_file: Path | None = typer.Option(None, "--from-file", help="Read value from a file."),
     from_stdin: bool = typer.Option(False, "--from-stdin", help="Read value from stdin."),
+    board_flag: int | None = typer.Option(
+        None,
+        "--board",
+        help="Board ID. Required with (and only valid with) --batch.",
+    ),
+    batch: Path | None = typer.Option(
+        None,
+        "--batch",
+        help=(
+            "Bulk-set from a JSON array (use '-' for stdin) of {item, value} or "
+            "{item, column, value} rows. Requires --board. Mutually exclusive "
+            "with --item / --value / --from-file / --from-stdin."
+        ),
+    ),
+    chunk_size: int = typer.Option(
+        10,
+        "--chunk-size",
+        help="Rows per HTTP call when --batch is used (default 10).",
+    ),
     create_labels_if_missing: bool = typer.Option(
         False,
         "--create-labels-if-missing",
@@ -321,8 +377,49 @@ def set_cmd(
         help="Treat --value as pre-parsed raw JSON; skip the codec.",
     ),
 ) -> None:
-    """Set a single column value, using the registered codec for the column's type."""
+    """Set a single column value, using the registered codec for the column's type.
+
+    Two modes:
+    - Single (default): pass --item and --column (+ --value/--from-file/--from-stdin).
+    - Bulk: pass --board and --batch <path|-> with a JSON array of {item, value}
+      or {item, column, value} rows. --column supplies the default column for
+      rows omitting one. The chunk is fanned into one GraphQL document per
+      chunk via aliasing, so N rows = one HTTP call (with --chunk-size 10).
+    """
     opts: GlobalOpts = ctx.ensure_object(GlobalOpts)
+
+    if batch is not None:
+        if item_id is not None or value is not None or from_file is not None or from_stdin:
+            usage_error_or_exit(
+                "--batch is mutually exclusive with --item / --value / "
+                "--from-file / --from-stdin. Express per-row settings in the "
+                "JSON array."
+            )
+        if board_flag is None:
+            usage_error_or_exit("--board is required with --batch.")
+        if chunk_size < 1:
+            usage_error_or_exit("--chunk-size must be >= 1.")
+        try:
+            rows = read_batch_rows(batch)
+        except UsageError as e:
+            usage_error_or_exit(str(e))
+        _run_column_set_batch(
+            opts,
+            board_flag,
+            rows,
+            default_column=column_id,
+            raw=column_raw,
+            create_labels=create_labels_if_missing,
+            chunk_size=chunk_size,
+        )
+        return
+
+    if board_flag is not None:
+        usage_error_or_exit("--board is only valid with --batch.")
+    if item_id is None:
+        usage_error_or_exit("--item is required (or pass --board --batch <path|-> for bulk).")
+    if column_id is None:
+        usage_error_or_exit("--column is required.")
     raw_input = _load_value(value, from_file, from_stdin)
 
     client = client_or_exit(opts)
@@ -352,7 +449,8 @@ def set_cmd(
                         col_type, raw_input, settings, create_labels=create_labels_if_missing
                     )
                 except ValueError as e:
-                    handle_mondo_error_or_exit(ValidationError(str(e)))
+                    hint = _clear_hint(raw_input, item_id, column_id)
+                    handle_mondo_error_or_exit(ValidationError(f"{e}{hint}"))
                 except UnknownColumnTypeError as e:
                     if col_type == "name":
                         # The item title masquerades as a `name` column in
@@ -409,6 +507,245 @@ def set_cmd(
     invalidate_entity(opts, "items", scope=str(item_id))
     invalidate_board_items_cache(opts, board_id)
     opts.emit(data.get("change_column_value") or {})
+
+
+def _tags_value_all_ids(raw: str) -> bool:
+    """True when every comma-separated part of a tags value is already a
+    numeric id, so no name→id resolution (a live `create_or_get_tag`
+    mutation) is needed. Mirrors the pass-through check in
+    `resolve_tag_names_to_ids`."""
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    return all(p.isdigit() or (p.startswith("-") and p[1:].isdigit()) for p in parts)
+
+
+def _build_column_set_row_vars(
+    board_id: int,
+    defs: dict[str, dict[str, Any]],
+    row: dict[str, Any],
+    index: int,
+    *,
+    default_column: str | None,
+    raw: bool,
+    create_labels: bool,
+    dry_run: bool,
+) -> tuple[dict[str, Any], int, str, Callable[[MondayClient, dict[str, int]], str] | None]:
+    """Render one `column set --batch` row into CHANGE_COLUMN_VALUE variables.
+
+    This is the batch's phase-1 validation: it parses/validates the row fully
+    but never mints anything. Returns `(variables, item_id, column_id,
+    finalizer)`. `finalizer` is `None` unless the row targets a `tags` column
+    in a live (non-`--raw`, non-`--dry-run`) run: resolving tag names goes
+    through `create_or_get_tag` (a real mutation), so it's deferred until every
+    row has validated — the caller runs the finalizer in phase 2 to fill in the
+    `value`, keeping a bad row from leaving half-minted tags behind.
+
+    Raises `UsageError` (exit 2) for structural problems (missing/invalid item,
+    no column, missing value) and `ValidationError` (exit 5) for codec parse
+    failures and non-codec-able values (structured payloads / JSON null) — all
+    naming the row index.
+    """
+    item_raw = row.get("item")
+    if item_raw is None or (isinstance(item_raw, str) and not item_raw.strip()):
+        raise UsageError(f"--batch row {index}: missing required 'item' field.")
+    # Accept only genuine integer ids or digit-only strings. `int()` would
+    # silently truncate 1.9 → 1 and coerce True → 1, which is dangerous for a
+    # bulk writer (bool is an int subclass, so it must be rejected first).
+    if isinstance(item_raw, bool):
+        raise UsageError(f"--batch row {index}: 'item' must be an integer id, got {item_raw!r}.")
+    if isinstance(item_raw, int):
+        item_id = item_raw
+    elif isinstance(item_raw, str) and item_raw.strip().isdigit():
+        item_id = int(item_raw.strip())
+    else:
+        raise UsageError(f"--batch row {index}: 'item' must be an integer id, got {item_raw!r}.")
+
+    column_id = row.get("column") or default_column
+    if not column_id:
+        raise UsageError(f"--batch row {index}: no 'column' in the row and no --column default.")
+    if column_id == "name":
+        # The item title masquerades as a `name` column but isn't settable via
+        # change_column_value — including --raw. Guard both modes up front.
+        raise ValidationError(
+            f"--batch row {index}: 'name' is the item's title, not a settable "
+            f'column. Use: mondo item rename {item_id} --board {board_id} --name "<new name>"'
+        )
+
+    if "value" not in row:
+        raise UsageError(f"--batch row {index}: missing required 'value' field.")
+    value = row["value"]
+
+    finalizer: Callable[[MondayClient, dict[str, int]], str] | None = None
+    if raw:
+        json_value: str | None = json.dumps(value)
+    else:
+        definition = defs.get(column_id)
+        if definition is None:
+            raise ValidationError(
+                f"--batch row {index}: column {column_id!r} not found on board {board_id}."
+            )
+        col_type = definition["type"]
+        settings = parse_settings(definition.get("settings_str"))
+        # Normalize the row value for codec input. Strings pass through; bare
+        # scalars (int/float/bool) are codec shorthand and get stringified,
+        # mirroring services.items.build_column_values. Structured payloads
+        # (dict/list) and JSON null can't feed a codec — point at --raw (and,
+        # when the value looks like an attempt to empty a column, at
+        # `column clear` via the #91 hint).
+        if isinstance(value, (dict, list)) or value is None:
+            hint = _clear_hint(json.dumps(value), item_id, column_id)
+            if isinstance(value, dict):
+                detail = "a JSON object; pass --raw to send a literal JSON payload"
+            elif isinstance(value, list):
+                detail = "a JSON array; pass --raw to send a literal JSON payload"
+            else:
+                detail = "JSON null"
+            raise ValidationError(
+                f"--batch row {index}: value for column {column_id!r} is {detail}.{hint}"
+            )
+        str_value = value if isinstance(value, str) else json.dumps(value)
+        if col_type == "tags" and not dry_run:
+            # resolve_tag_names_to_ids mints tags via create_or_get_tag — a
+            # real mutation. Defer it (and the codec) to phase 2 so it only
+            # runs once the whole batch has validated.
+            def _finalize_tags(
+                cl: MondayClient,
+                cache: dict[str, int],
+                _str_value: str = str_value,
+                _settings: dict[str, Any] = settings,
+                _create_labels: bool = create_labels,
+                _column_id: str = column_id,
+                _index: int = index,
+            ) -> str:
+                resolved = resolve_tag_names_to_ids(cl, board_id, _str_value, cache=cache)
+                try:
+                    parsed_tags = parse_value(
+                        "tags", resolved, _settings, create_labels=_create_labels
+                    )
+                except ValueError as e:
+                    hint = _clear_hint(resolved, item_id, _column_id)
+                    raise ValidationError(
+                        f"--batch row {_index} (column {_column_id}): {e}{hint}"
+                    ) from e
+                return json.dumps(parsed_tags)
+
+            finalizer = _finalize_tags
+            json_value = None  # phase 2 fills this in
+        else:
+            # dry_run tags: resolve_tag_names_to_ids would write, so only
+            # accept values that are already ids; names need a live call.
+            if col_type == "tags" and not _tags_value_all_ids(str_value):
+                raise ValidationError(
+                    f"--batch row {index} (column {column_id}): resolving tag "
+                    "names requires a live call; use tag ids in --dry-run."
+                )
+            try:
+                parsed = parse_value(col_type, str_value, settings, create_labels=create_labels)
+            except ValueError as e:
+                hint = _clear_hint(str_value, item_id, column_id)
+                raise ValidationError(f"--batch row {index} (column {column_id}): {e}{hint}") from e
+            except UnknownColumnTypeError as e:
+                raise ValidationError(
+                    f"--batch row {index}: no codec for column type {col_type!r}. "
+                    f"Use --raw to send a literal JSON payload. Details: {e}"
+                ) from e
+            json_value = json.dumps(parsed)
+
+    variables = {
+        "item": item_id,
+        "board": board_id,
+        "col": column_id,
+        "value": json_value,
+        "create_labels": create_labels or None,
+    }
+    return variables, item_id, column_id, finalizer
+
+
+def _run_column_set_batch(
+    opts: GlobalOpts,
+    board_id: int,
+    rows: list[dict[str, Any]],
+    *,
+    default_column: str | None,
+    raw: bool,
+    create_labels: bool,
+    chunk_size: int,
+) -> None:
+    """Execute a batched `column set`. Column defs are fetched once for the
+    whole board (the point of the batch), each chunk is fanned into a single
+    multi-mutation document via aliasing, and per-row success/failure is
+    aggregated into one envelope."""
+    # Codec dispatch needs the board's column defs + a client for tag
+    # resolution; --raw skips both, so `--dry-run --raw` is fully offline.
+    needs_preflight = not raw
+    client: MondayClient | None = None
+    if needs_preflight or not opts.dry_run:
+        client = client_or_exit(opts)
+
+    results: list[dict[str, Any]] = []
+    try:
+        defs: dict[str, dict[str, Any]] = {}
+        tag_cache: dict[str, int] = {}
+        ctx_mgr: Any = client if client is not None else nullcontext()
+        with ctx_mgr:
+            if needs_preflight and client is not None:
+                # Strict fetch: an inaccessible/missing board must surface as
+                # a board-not-found (exit 6), not empty defs that make every
+                # column look "not found" (a misleading exit 5).
+                try:
+                    defs = fetch_column_defs(opts, client, board_id, strict=True)
+                except NotFoundError as e:
+                    raise NotFoundError(f"board {board_id} not found.") from e
+            # Phase 1: validate/parse every row without minting anything.
+            per_row = [
+                _build_column_set_row_vars(
+                    board_id,
+                    defs,
+                    row,
+                    i,
+                    default_column=default_column,
+                    raw=raw,
+                    create_labels=create_labels,
+                    dry_run=opts.dry_run,
+                )
+                for i, row in enumerate(rows)
+            ]
+            # Phase 2: now that the whole batch validated, run the deferred
+            # tag-resolution finalizers (create_or_get_tag) and fill in values.
+            for variables, _item, _col, finalizer in per_row:
+                if finalizer is not None:
+                    assert client is not None
+                    variables["value"] = finalizer(client, tag_cache)
+            per_row_vars = [v for v, _item, _col, _f in per_row]
+            name_rows = [{"name": f"{item}:{col}"} for _v, item, col, _f in per_row]
+
+            if opts.dry_run:
+                opts.emit(
+                    {
+                        "chunks": build_batch_chunks_repr(
+                            CHANGE_COLUMN_VALUE, per_row_vars, chunk_size
+                        )
+                    }
+                )
+                raise typer.Exit(0)
+
+            assert client is not None
+            results = run_aliased_batch(
+                client, CHANGE_COLUMN_VALUE, per_row_vars, name_rows, chunk_size=chunk_size
+            )
+    except MondoError as e:
+        handle_mondo_error_or_exit(e)
+
+    if create_labels:
+        invalidate_columns_cache(opts.columns_cache_store_for_invalidation(board_id))
+    invalidate_board_items_cache(opts, board_id)
+    for item_id in {item for _v, item, _col, _f in per_row}:
+        invalidate_entity(opts, "items", scope=str(item_id))
+
+    failed = sum(1 for r in results if not r["ok"])
+    summary = {"requested": len(rows), "updated": len(results) - failed, "failed": failed}
+    opts.emit({"summary": summary, "results": results})
+    if failed:
+        raise typer.Exit(code=1)
 
 
 @app.command("set-many", epilog=epilog_for("column set-many"))

--- a/src/mondo/cli/item.py
+++ b/src/mondo/cli/item.py
@@ -33,7 +33,7 @@ from mondo.api.queries import (
     SUBITEMS_LIST,
     build_items_page_queries,
 )
-from mondo.cli._batch import build_aliased_mutation, chunk_inputs, parse_aliased_response
+from mondo.cli._batch import build_batch_chunks_repr, run_aliased_batch
 from mondo.cli._cache_invalidate import invalidate_board_items_cache, invalidate_entity
 from mondo.cli._confirm import confirm_or_abort as _confirm
 from mondo.cli._examples import epilog_for
@@ -795,6 +795,7 @@ def _run_batch(
 
         ctx_mgr: Any = client if client is not None else nullcontext()
         per_row_vars: list[dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
         try:
             with ctx_mgr:
                 for row in rows:
@@ -811,39 +812,15 @@ def _run_batch(
                         )
                     )
                 if opts.dry_run:
-                    chunks_repr: list[dict[str, Any]] = []
-                    for chunk_idx, vars_chunk in enumerate(chunk_inputs(per_row_vars, chunk_size)):
-                        query, var_names = build_aliased_mutation(ITEM_CREATE, len(vars_chunk))
-                        flat: dict[str, Any] = {}
-                        base = chunk_idx * chunk_size
-                        for i, vars_row in enumerate(vars_chunk):
-                            for name_ in var_names:
-                                flat[f"{name_}_{i}"] = vars_row[name_]
-                        chunks_repr.append(
-                            {
-                                "query": query,
-                                "variables": flat,
-                                "row_indices": list(range(base, base + len(vars_chunk))),
-                            }
-                        )
-                    opts.emit({"chunks": chunks_repr})
+                    opts.emit(
+                        {"chunks": build_batch_chunks_repr(ITEM_CREATE, per_row_vars, chunk_size)}
+                    )
                     raise typer.Exit(0)
 
-                results: list[dict[str, Any]] = []
                 assert client is not None
-                row_chunks = chunk_inputs(rows, chunk_size)
-                vars_chunks = chunk_inputs(per_row_vars, chunk_size)
-                for chunk_idx, (row_chunk, vars_chunk) in enumerate(
-                    zip(row_chunks, vars_chunks, strict=True)
-                ):
-                    query, var_names = build_aliased_mutation(ITEM_CREATE, len(vars_chunk))
-                    flat = {}
-                    for i, vars_row in enumerate(vars_chunk):
-                        for name_ in var_names:
-                            flat[f"{name_}_{i}"] = vars_row[name_]
-                    response = client.execute(query, variables=flat, surface_partial_errors=True)
-                    base = chunk_idx * chunk_size
-                    results.extend(parse_aliased_response(response, row_chunk, base_index=base))
+                results = run_aliased_batch(
+                    client, ITEM_CREATE, per_row_vars, rows, chunk_size=chunk_size
+                )
         except ValueError as e:
             handle_mondo_error_or_exit(ValidationError(str(e)))
     except MondoError as e:

--- a/src/mondo/services/items.py
+++ b/src/mondo/services/items.py
@@ -120,9 +120,11 @@ def build_query_params(
     return qp or None
 
 
-def read_batch_input(source: Path) -> list[dict[str, Any]]:
-    """Read the `--batch` source and validate it's a JSON array of objects
-    each carrying a `name`. Use `Path("-")` for stdin."""
+def read_batch_rows(source: Path) -> list[dict[str, Any]]:
+    """Read a `--batch` source and validate it parses to a non-empty JSON array
+    of objects. Use `Path("-")` for stdin. Per-command field validation (e.g.
+    `name` for item create, `item`/`value` for column set) is layered on top by
+    the caller so its errors can name the target column/field."""
     text = sys.stdin.read() if str(source) == "-" else source.read_text(encoding="utf-8")
     try:
         parsed = json.loads(text)
@@ -135,9 +137,17 @@ def read_batch_input(source: Path) -> list[dict[str, Any]]:
     for i, row in enumerate(parsed):
         if not isinstance(row, dict):
             raise UsageError(f"--batch row {i}: expected object, got {type(row).__name__}.")
+    return parsed
+
+
+def read_batch_input(source: Path) -> list[dict[str, Any]]:
+    """Read the `item create --batch` source: a non-empty JSON array of objects
+    each carrying a `name`. Use `Path("-")` for stdin."""
+    rows = read_batch_rows(source)
+    for i, row in enumerate(rows):
         if not row.get("name"):
             raise UsageError(f"--batch row {i}: missing required 'name' field.")
-    return parsed
+    return rows
 
 
 def parse_column_mapping(tokens: list[str]) -> list[dict[str, Any]]:
@@ -174,6 +184,7 @@ def fetch_column_defs(
     *,
     no_cache: bool = False,
     refresh: bool = False,
+    strict: bool = False,
 ) -> dict[str, dict[str, Any]]:
     """One-shot fetch of `{col_id: {type, settings_str, ...}}` for a board.
 
@@ -181,11 +192,18 @@ def fetch_column_defs(
     query otherwise. Silently returns `{}` when the board isn't visible — the
     caller's codec dispatch will treat unknown columns as raw passthroughs,
     mirroring the previous behavior when the API returned no boards.
+
+    Pass `strict=True` to re-raise `NotFoundError` instead of swallowing it:
+    a bulk caller needs to tell a bad/inaccessible board apart from a
+    genuinely unknown column, otherwise the empty defs make every column
+    look "not found".
     """
     try:
         store = opts.columns_cache_store(board_id, no_cache=no_cache)
         columns = fetch_board_columns(client, board_id, store=store, refresh=refresh)
     except NotFoundError:
+        if strict:
+            raise
         return {}
     return {c["id"]: c for c in columns}
 

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from mondo.api.queries import ITEM_CREATE
+from mondo.api.queries import CHANGE_COLUMN_VALUE, ITEM_CREATE
 from mondo.cli._batch import (
     build_aliased_mutation,
     chunk_inputs,
@@ -46,6 +46,23 @@ def test_build_multiple_aliases() -> None:
     # The variable schema returned matches the template, not a per-row copy.
     assert len(var_names) == 7
     assert var_names == ["board", "name", "group", "values", "create_labels", "prm", "relto"]
+
+
+def test_build_change_column_value_aliases() -> None:
+    """`column set --batch` fans CHANGE_COLUMN_VALUE the same way (#90)."""
+    query, var_names = build_aliased_mutation(CHANGE_COLUMN_VALUE, 2)
+    assert "m_0: change_column_value(" in query
+    assert "m_1: change_column_value(" in query
+    # Per-row scopes for every declared variable.
+    for i in range(2):
+        assert f"$item_{i}: ID!" in query
+        assert f"$board_{i}: ID!" in query
+        assert f"$col_{i}: String!" in query
+        assert f"$value_{i}: JSON!" in query
+        assert f"$create_labels_{i}: Boolean" in query
+    # Un-suffixed declarations must be gone.
+    assert "$item: ID!" not in query
+    assert var_names == ["item", "board", "col", "value", "create_labels"]
 
 
 def test_build_count_zero_raises() -> None:

--- a/tests/unit/test_cli_column.py
+++ b/tests/unit/test_cli_column.py
@@ -44,6 +44,11 @@ def _context_response(board_id: int, cols: list[dict], values: list[dict]) -> di
     )
 
 
+def _columns_response(board_id: int, cols: list[dict]) -> dict:
+    """Shape returned by COLUMNS_ON_BOARD (used by fetch_column_defs)."""
+    return _ok({"boards": [{"id": str(board_id), "name": "B", "columns": cols}]})
+
+
 class TestColumnList:
     def test_emits_simplified_columns(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(
@@ -414,6 +419,600 @@ class TestColumnSet:
         assert result.exit_code == 0, result.stdout
         body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["variables"]["value"] == json.dumps({"tag_ids": [1001, 1002]})
+
+    def test_clear_shaped_value_hints_column_clear(self, httpx_mock: HTTPXMock) -> None:
+        """#91: an "empty" payload against a dropdown fails the codec and the
+        error points at `column clear`."""
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_context_response(
+                board_id=42,
+                cols=[
+                    {
+                        "id": "dd",
+                        "title": "D",
+                        "type": "dropdown",
+                        "settings_str": json.dumps({"labels": [{"id": 1, "name": "Red"}]}),
+                    }
+                ],
+                values=[{"id": "dd", "type": "dropdown", "text": "", "value": None}],
+            ),
+        )
+        result = runner.invoke(
+            app,
+            ["column", "set", "--item", "1", "--column", "dd", "--value", '{"labels":[]}'],
+        )
+        assert result.exit_code == 5, result.output
+        combined = (result.output or "") + (result.stderr or "")
+        assert "mondo column clear --item 1 --column dd" in combined
+        # No mutation was attempted (only the context fetch).
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_ordinary_bad_value_has_no_clear_hint(self, httpx_mock: HTTPXMock) -> None:
+        """The clear hint must not fire on a genuinely wrong label."""
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_context_response(
+                board_id=42,
+                cols=[
+                    {
+                        "id": "dd",
+                        "title": "D",
+                        "type": "dropdown",
+                        "settings_str": json.dumps({"labels": [{"id": 1, "name": "Red"}]}),
+                    }
+                ],
+                values=[{"id": "dd", "type": "dropdown", "text": "", "value": None}],
+            ),
+        )
+        result = runner.invoke(
+            app,
+            ["column", "set", "--item", "1", "--column", "dd", "--value", "Nope"],
+        )
+        assert result.exit_code == 5, result.output
+        combined = (result.output or "") + (result.stderr or "")
+        assert "unknown dropdown label" in combined
+        assert "mondo column clear" not in combined
+
+
+_TEXT_COLS = [{"id": "text", "title": "T", "type": "text", "settings_str": "{}"}]
+
+
+class TestColumnSetBatch:
+    def test_sets_three_in_one_mutation_call(self, httpx_mock: HTTPXMock) -> None:
+        # Column defs fetch (once for the board), then one aliased mutation.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, _TEXT_COLS))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={
+                "data": {
+                    "m_0": {"id": "1", "name": "a"},
+                    "m_1": {"id": "2", "name": "b"},
+                    "m_2": {"id": "3", "name": "c"},
+                },
+                "extensions": {"request_id": "r"},
+            },
+        )
+        rows = [
+            {"item": 1, "value": "A"},
+            {"item": "2", "value": "B"},
+            {"item": 3, "column": "text", "value": "C"},
+        ]
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "text", "--batch", "-"],
+            input=json.dumps(rows),
+        )
+        assert result.exit_code == 0, result.output
+        env = json.loads(result.stdout)
+        assert env["summary"] == {"requested": 3, "updated": 3, "failed": 0}
+        assert [r["name"] for r in env["results"]] == ["1:text", "2:text", "3:text"]
+        # defs fetch + one mutation call = 2 HTTP requests total.
+        assert len(httpx_mock.get_requests()) == 2
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert "m_0:" in body["query"] and "m_2:" in body["query"]
+        assert body["variables"]["item_0"] == 1
+        assert body["variables"]["value_2"] == '"C"'
+
+    def test_chunking_splits_calls(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, _TEXT_COLS))
+        for chunk_idx in range(3):
+            httpx_mock.add_response(
+                url=ENDPOINT,
+                method="POST",
+                json={
+                    "data": {
+                        f"m_{i}": {"id": str(chunk_idx * 10 + i), "name": "x"}
+                        for i in range(2 if chunk_idx < 2 else 1)
+                    },
+                    "extensions": {"request_id": "r"},
+                },
+            )
+        rows = [{"item": i, "value": str(i)} for i in range(5)]
+        result = runner.invoke(
+            app,
+            [
+                "column",
+                "set",
+                "--board",
+                "42",
+                "--column",
+                "text",
+                "--chunk-size",
+                "2",
+                "--batch",
+                "-",
+            ],
+            input=json.dumps(rows),
+        )
+        assert result.exit_code == 0, result.output
+        env = json.loads(result.stdout)
+        assert env["summary"]["updated"] == 5
+        # defs fetch + 3 mutation calls.
+        assert len(httpx_mock.get_requests()) == 4
+        assert [r["row_index"] for r in env["results"]] == [0, 1, 2, 3, 4]
+
+    def test_partial_failure_exits_1(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, _TEXT_COLS))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={
+                "data": {"m_0": {"id": "1", "name": "a"}, "m_1": None},
+                "errors": [{"message": "Column value error", "path": ["m_1"]}],
+                "extensions": {"request_id": "r"},
+            },
+        )
+        rows = [{"item": 1, "value": "A"}, {"item": 2, "value": "B"}]
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "text", "--batch", "-"],
+            input=json.dumps(rows),
+        )
+        assert result.exit_code == 1, result.output
+        env = json.loads(result.stdout)
+        assert env["summary"] == {"requested": 2, "updated": 1, "failed": 1}
+        assert env["results"][0]["ok"] is True
+        assert env["results"][1]["ok"] is False
+        assert env["results"][1]["error"] == "Column value error"
+
+    def test_mid_batch_http_error_emits_partial_envelope_exits_1(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """An HTTP-layer failure on a later chunk keeps earlier successes and
+        marks the failing + not-attempted rows failed, still exiting 1 with a
+        full envelope (rather than aborting with the raw error)."""
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, _TEXT_COLS))
+        # Chunk 0 (row 0) succeeds.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={"data": {"m_0": {"id": "1", "name": "a"}}, "extensions": {"request_id": "r"}},
+        )
+        # Chunk 1 (row 1) fails at the HTTP layer (400 -> non-retryable). Chunk
+        # 2 (row 2) is never attempted.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", status_code=400, json={})
+        rows = [{"item": i, "value": str(i)} for i in range(3)]
+        result = runner.invoke(
+            app,
+            [
+                "column",
+                "set",
+                "--board",
+                "42",
+                "--column",
+                "text",
+                "--chunk-size",
+                "1",
+                "--batch",
+                "-",
+            ],
+            input=json.dumps(rows),
+        )
+        assert result.exit_code == 1, result.output
+        env = json.loads(result.stdout)
+        assert env["summary"] == {"requested": 3, "updated": 1, "failed": 2}
+        assert env["results"][0]["ok"] is True
+        assert env["results"][1]["ok"] is False
+        assert "HTTP 400" in env["results"][1]["error"]
+        assert env["results"][2]["ok"] is False
+        assert env["results"][2]["error"].startswith("aborted:")
+        # defs fetch + chunk 0 + chunk 1 = 3 calls; chunk 2 never went out.
+        assert len(httpx_mock.get_requests()) == 3
+
+    def test_dry_run_raw_is_offline(self, httpx_mock: HTTPXMock) -> None:
+        rows = [{"item": 1, "value": {"index": 2}}, {"item": 2, "value": {"index": 3}}]
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "column",
+                "set",
+                "--board",
+                "42",
+                "--column",
+                "status",
+                "--raw",
+                "--chunk-size",
+                "1",
+                "--batch",
+                "-",
+            ],
+            input=json.dumps(rows),
+        )
+        assert result.exit_code == 0, result.output
+        env = json.loads(result.stdout)
+        assert len(env["chunks"]) == 2
+        assert env["chunks"][0]["row_indices"] == [0]
+        assert env["chunks"][1]["row_indices"] == [1]
+        assert "m_0:" in env["chunks"][0]["query"]
+        assert env["chunks"][0]["variables"]["value_0"] == json.dumps({"index": 2})
+        # --raw dry-run touches the network zero times.
+        assert httpx_mock.get_requests() == []
+
+    def test_raw_mode_sends_json_verbatim(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={"data": {"m_0": {"id": "1", "name": "a"}}, "extensions": {"request_id": "r"}},
+        )
+        rows = [{"item": 1, "value": {"index": 7}}]
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "status", "--raw", "--batch", "-"],
+            input=json.dumps(rows),
+        )
+        assert result.exit_code == 0, result.output
+        # No defs fetch in raw mode: a single mutation call.
+        assert len(httpx_mock.get_requests()) == 1
+        body = json.loads(httpx_mock.get_requests()[0].content)
+        assert body["variables"]["value_0"] == json.dumps({"index": 7})
+
+    def test_per_row_column_overrides_default(self, httpx_mock: HTTPXMock) -> None:
+        cols = [
+            {"id": "text", "title": "T", "type": "text", "settings_str": "{}"},
+            {"id": "num", "title": "N", "type": "numbers", "settings_str": "{}"},
+        ]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, cols))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={
+                "data": {"m_0": {"id": "1", "name": "a"}, "m_1": {"id": "2", "name": "b"}},
+                "extensions": {"request_id": "r"},
+            },
+        )
+        rows = [{"item": 1, "value": "hi"}, {"item": 2, "column": "num", "value": "5"}]
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "text", "--batch", "-"],
+            input=json.dumps(rows),
+        )
+        assert result.exit_code == 0, result.output
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body["variables"]["col_0"] == "text"
+        assert body["variables"]["col_1"] == "num"
+
+    def test_bad_codec_value_exits_5_naming_row(self, httpx_mock: HTTPXMock) -> None:
+        cols = [
+            {
+                "id": "status",
+                "title": "S",
+                "type": "status",
+                "settings_str": json.dumps({"labels": {"0": "Working on it", "1": "Done"}}),
+            }
+        ]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, cols))
+        rows = [{"item": 1, "value": "Done"}, {"item": 2, "value": "Nope"}]
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "status", "--batch", "-"],
+            input=json.dumps(rows),
+        )
+        assert result.exit_code == 5, result.output
+        combined = (result.output or "") + (result.stderr or "")
+        assert "row 1" in combined
+        # Failed fast before any mutation: only the defs fetch went out.
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_clear_shaped_row_value_hints_column_clear(self, httpx_mock: HTTPXMock) -> None:
+        cols = [
+            {
+                "id": "dd",
+                "title": "D",
+                "type": "dropdown",
+                "settings_str": json.dumps({"labels": [{"id": 1, "name": "Red"}]}),
+            }
+        ]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, cols))
+        rows = [{"item": 7, "value": '{"labels":[]}'}]
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "dd", "--batch", "-"],
+            input=json.dumps(rows),
+        )
+        assert result.exit_code == 5, result.output
+        combined = (result.output or "") + (result.stderr or "")
+        assert "mondo column clear --item 7 --column dd" in combined
+
+    def test_requires_board(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app,
+            ["column", "set", "--column", "text", "--batch", "-"],
+            input=json.dumps([{"item": 1, "value": "A"}]),
+        )
+        assert result.exit_code == 2, result.output
+        assert "--board is required" in ((result.output or "") + (result.stderr or ""))
+        assert httpx_mock.get_requests() == []
+
+    def test_board_without_batch_errors(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--item", "1", "--column", "text", "--value", "A"],
+        )
+        assert result.exit_code == 2, result.output
+        assert "--board is only valid with --batch" in (
+            (result.output or "") + (result.stderr or "")
+        )
+        assert httpx_mock.get_requests() == []
+
+    def test_mutex_with_item(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--item", "1", "--batch", "-"],
+            input=json.dumps([{"item": 1, "value": "A"}]),
+        )
+        assert result.exit_code == 2, result.output
+        assert httpx_mock.get_requests() == []
+
+    def test_non_array_exits_2(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "text", "--batch", "-"],
+            input='{"item": 1, "value": "A"}',
+        )
+        assert result.exit_code == 2, result.output
+        assert httpx_mock.get_requests() == []
+
+    def test_empty_array_exits_2(self, httpx_mock: HTTPXMock) -> None:
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "text", "--batch", "-"],
+            input="[]",
+        )
+        assert result.exit_code == 2, result.output
+        assert httpx_mock.get_requests() == []
+
+    def test_row_missing_item_exits_2(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, _TEXT_COLS))
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "text", "--batch", "-"],
+            input=json.dumps([{"value": "A"}]),
+        )
+        assert result.exit_code == 2, result.output
+        assert "row 0" in ((result.output or "") + (result.stderr or ""))
+
+    def test_row_missing_value_exits_2(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, _TEXT_COLS))
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "text", "--batch", "-"],
+            input=json.dumps([{"item": 1}]),
+        )
+        assert result.exit_code == 2, result.output
+        assert "row 0" in ((result.output or "") + (result.stderr or ""))
+
+    def test_row_no_column_no_default_exits_2(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, _TEXT_COLS))
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--batch", "-"],
+            input=json.dumps([{"item": 1, "value": "A"}]),
+        )
+        assert result.exit_code == 2, result.output
+        assert "row 0" in ((result.output or "") + (result.stderr or ""))
+
+    def test_structured_value_without_raw_exits_5(self, httpx_mock: HTTPXMock) -> None:
+        # A dict/list value can't feed a codec: it's a ValidationError (exit 5)
+        # that points at --raw, not the old exit-2 "must be a string".
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, _TEXT_COLS))
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "text", "--batch", "-"],
+            input=json.dumps([{"item": 1, "value": {"a": 1}}]),
+        )
+        assert result.exit_code == 5, result.output
+        assert "--raw" in ((result.output or "") + (result.stderr or ""))
+        # Failed before any mutation: only the defs fetch went out.
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_scalar_value_stringified_in_codec_mode(self, httpx_mock: HTTPXMock) -> None:
+        # Natural JSON like {"item":1,"value":5} for a numbers column: the bare
+        # scalar is stringified and fed to the codec (no --raw needed).
+        cols = [{"id": "num", "title": "N", "type": "numbers", "settings_str": "{}"}]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, cols))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={"data": {"m_0": {"id": "1", "name": "a"}}, "extensions": {"request_id": "r"}},
+        )
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "num", "--batch", "-"],
+            input=json.dumps([{"item": 1, "value": 5}]),
+        )
+        assert result.exit_code == 0, result.output
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        # numbers codec renders the scalar to the string "5".
+        assert body["variables"]["value_0"] == '"5"'
+
+    def test_float_item_id_rejected_naming_row(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, _TEXT_COLS))
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "text", "--batch", "-"],
+            input=json.dumps([{"item": 1.9, "value": "A"}]),
+        )
+        assert result.exit_code == 2, result.output
+        combined = (result.output or "") + (result.stderr or "")
+        assert "row 0" in combined and "integer id" in combined
+        # Never dispatched a mutation.
+        assert all(b"change_column_value" not in r.content for r in httpx_mock.get_requests())
+
+    def test_bool_item_id_rejected(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, _TEXT_COLS))
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "text", "--batch", "-"],
+            input=json.dumps([{"item": True, "value": "A"}]),
+        )
+        assert result.exit_code == 2, result.output
+        assert "integer id" in ((result.output or "") + (result.stderr or ""))
+
+    def test_name_pseudo_column_points_at_item_rename(self, httpx_mock: HTTPXMock) -> None:
+        cols = [{"id": "name", "title": "Name", "type": "name", "settings_str": "{}"}]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, cols))
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "name", "--batch", "-"],
+            input=json.dumps([{"item": 7, "value": "New title"}]),
+        )
+        assert result.exit_code == 5, result.output
+        combined = (result.output or "") + (result.stderr or "")
+        assert "mondo item rename" in combined
+        # Failed fast at preflight — no mutation dispatched.
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_name_pseudo_column_rejected_in_raw_mode_too(self) -> None:
+        # --raw skips the codec but the `name` guard must still fire: the
+        # title is never settable via change_column_value. Fully offline.
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "name", "--raw", "--batch", "-"],
+            input=json.dumps([{"item": 7, "value": "New title"}]),
+        )
+        assert result.exit_code == 5, result.output
+        combined = (result.output or "") + (result.stderr or "")
+        assert "mondo item rename" in combined
+
+    def test_dry_run_tag_names_issue_no_mutation(self, httpx_mock: HTTPXMock) -> None:
+        # A tags value given as names can't be resolved in --dry-run without a
+        # real create_or_get_tag mutation, so it errors instead of writing.
+        cols = [{"id": "tags", "title": "Tags", "type": "tags", "settings_str": "{}"}]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, cols))
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "column",
+                "set",
+                "--board",
+                "42",
+                "--column",
+                "tags",
+                "--batch",
+                "-",
+            ],
+            input=json.dumps([{"item": 1, "value": "urgent,blocked"}]),
+        )
+        assert result.exit_code == 5, result.output
+        assert "tag ids in --dry-run" in ((result.output or "") + (result.stderr or ""))
+        # Only the read-only defs fetch happened; create_or_get_tag never fired.
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
+    def test_dry_run_tag_ids_pass_through(self, httpx_mock: HTTPXMock) -> None:
+        # Numeric tag ids need no resolution, so --dry-run works offline-ish
+        # (only the read-only defs fetch).
+        cols = [{"id": "tags", "title": "Tags", "type": "tags", "settings_str": "{}"}]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, cols))
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "column",
+                "set",
+                "--board",
+                "42",
+                "--column",
+                "tags",
+                "--batch",
+                "-",
+            ],
+            input=json.dumps([{"item": 1, "value": "1001,1002"}]),
+        )
+        assert result.exit_code == 0, result.output
+        env = json.loads(result.stdout)
+        assert env["chunks"][0]["variables"]["value_0"] == json.dumps({"tag_ids": [1001, 1002]})
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
+    def test_tag_minting_deferred_until_whole_batch_validates(self, httpx_mock: HTTPXMock) -> None:
+        """A later row's codec error aborts with nothing minted: tag-name
+        resolution (create_or_get_tag) is deferred until every row validates,
+        so an earlier tags-by-name row leaves no half-created tags behind."""
+        cols = [
+            {"id": "tags", "title": "Tags", "type": "tags", "settings_str": "{}"},
+            {
+                "id": "status",
+                "title": "S",
+                "type": "status",
+                "settings_str": json.dumps({"labels": {"0": "Working on it", "1": "Done"}}),
+            },
+        ]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, cols))
+        rows = [
+            {"item": 1, "column": "tags", "value": "urgent,blocked"},
+            {"item": 2, "column": "status", "value": "Nope"},  # invalid label
+        ]
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--batch", "-"],
+            input=json.dumps(rows),
+        )
+        assert result.exit_code != 0, result.output
+        assert result.exit_code == 5, result.output
+        # Failed before phase 2, so no tag was ever minted; only defs fetched.
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_tag_names_resolved_when_batch_valid(self, httpx_mock: HTTPXMock) -> None:
+        """Happy path: once the whole batch validates, phase 2 resolves tag
+        names to ids (one create_or_get_tag) and the mutation carries them."""
+        cols = [{"id": "tags", "title": "Tags", "type": "tags", "settings_str": "{}"}]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(42, cols))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_or_get_tag": {"id": "1001", "name": "urgent"}}),
+        )
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={"data": {"m_0": {"id": "1", "name": "a"}}, "extensions": {"request_id": "r"}},
+        )
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "42", "--column", "tags", "--batch", "-"],
+            input=json.dumps([{"item": 1, "value": "urgent"}]),
+        )
+        assert result.exit_code == 0, result.output
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body["variables"]["value_0"] == json.dumps({"tag_ids": [1001]})
+
+    def test_bad_board_surfaces_not_found(self, httpx_mock: HTTPXMock) -> None:
+        # An inaccessible/missing board yields no column defs; batch mode must
+        # report board-not-found (exit 6), not a misleading column-not-found.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_ok({"boards": []}))
+        result = runner.invoke(
+            app,
+            ["column", "set", "--board", "999", "--column", "text", "--batch", "-"],
+            input=json.dumps([{"item": 1, "value": "A"}]),
+        )
+        assert result.exit_code == 6, result.output
+        assert "board 999 not found" in ((result.output or "") + (result.stderr or ""))
 
 
 class TestColumnSetMany:

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -893,6 +893,46 @@ class TestItemCreateBatch:
         assert env["results"][1]["ok"] is False
         assert env["results"][1]["error"] == "Group not found"
 
+    def test_batch_mid_batch_http_error_emits_partial_envelope_exits_1(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        """A mid-batch HTTP-layer failure keeps earlier successes: the failing
+        + not-attempted rows are marked failed and the command still emits the
+        envelope and exits 1 (rather than aborting with the raw error)."""
+        rows = [{"name": chr(ord("A") + i)} for i in range(3)]
+        batch_file = tmp_path / "rows.json"
+        batch_file.write_text(json.dumps(rows))
+        # Chunk 0 succeeds; chunk 1 fails at HTTP layer (400 -> non-retryable);
+        # chunk 2 is never attempted.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json={"data": {"m_0": {"id": "11", "name": "A"}}, "extensions": {"request_id": "r"}},
+        )
+        httpx_mock.add_response(url=ENDPOINT, method="POST", status_code=400, json={})
+        result = runner.invoke(
+            app,
+            [
+                "item",
+                "create",
+                "--board",
+                "42",
+                "--batch",
+                str(batch_file),
+                "--chunk-size",
+                "1",
+            ],
+        )
+        assert result.exit_code == 1, result.stdout
+        env = json.loads(result.stdout)
+        assert env["summary"] == {"requested": 3, "created": 1, "failed": 2}
+        assert env["results"][0]["ok"] is True
+        assert env["results"][1]["ok"] is False
+        assert "HTTP 400" in env["results"][1]["error"]
+        assert env["results"][2]["error"].startswith("aborted:")
+        # chunk 0 + chunk 1 = 2 calls; chunk 2 never went out.
+        assert len(httpx_mock.get_requests()) == 2
+
     def test_batch_dry_run_emits_chunks_without_calling_api(
         self, httpx_mock: HTTPXMock, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Resolves #90, resolves #91.

## What

**#90 — `column set --batch`**: agents were shell-looping `column set` (~2.4s/item) and hitting 120s timeouts on ~100-item boards. Now:

- `mondo column set --board <id> --batch <path|-> [--column <default>] [--chunk-size N] [--raw] [--create-labels-if-missing]` — JSON rows `{item, value}` or `{item, column, value}`; a 100-item update becomes ~10 HTTP calls in one invocation.
- Batch is board-scoped (`--board` required) so column defs are fetched **once**; a bad board is a clean not-found (exit 6). Strict row validation: item ids accept only non-bool ints / digit-only strings (no `1.9`→1 truncation); the `name` pseudo-column is rejected with the `item rename` hint in **both** codec and `--raw` modes; bare scalars are codec-stringified while dict/list/null get a `--raw` suggestion.
- Values are codec-parsed per column type; tag names resolve via `create_or_get_tag` in a **two-phase** flow (validate every row first, then mint) so a bad row can no longer leave orphan tags — and `--dry-run` never mutates (tag names in dry-run are a validation error; ids pass).
- The batch orchestration lives in a shared driver (`cli/_batch.py`: `run_aliased_batch` with per-chunk-length memoized document building, `build_batch_chunks_repr` for dry-run) used by **both** this command and `item create --batch`. Mid-batch HTTP-layer failures (429/network) now emit a partial `{summary, results}` envelope (failed chunk + `aborted:` rows) with cache invalidation instead of losing everything — `item create --batch` inherits this improvement.
- Envelope: `{"summary": {requested, updated, failed}, "results": [...]}` with per-row `name` `"<item>:<col>"`; exit 1 on any row failure; dry-run mirrors item create's `{chunks: [...]}`.

**#91 — clear-shaped hint**: when `column set` gets `""`/`{}`/`null`/`[]`/`{"labels":[]}` and the codec rejects it, the error now appends `To empty a column, use: mondo column clear --item <id> --column <col>` (single-item and batch rows) — pointing at the right command instead of the misleading `--create-labels-if-missing`.

## Verification

- Unit: +25 tests (validation matrix, aliased composition, dry-run shape, partial-failure envelopes for both commands, tag-deferral asserting zero `create_or_get_tag` calls, clear-hint firing and non-firing, raw name guard). Full suite: 1925 passed (incl. live skill-eval).
- Live (playground board 5094861043, all cleaned up): 3-item batch write verified via `column get`; mixed batch with a bad row → per-row failure + exit 1; the #91 hint verified against a real dropdown with `{"labels":[]}`.

## Review trail

gpt-5.5 (codex) round 1 → fixed lossy id coercion, dry-run tag mutation, scalar handling, name column, board-not-found; 8-angle adversarially-verified review → partial-failure envelope, two-phase tags, shared-driver consolidation + memoized document build (CONFIRMED findings); security review PASS-WITH-NOTES (no injection path — user strings only ever travel as GraphQL variables; notes are low-severity footgun guards: no `--chunk-size` ceiling, whole-file batch reads); gpt-5.5 round 2 → found the raw-mode name-guard bypass, fixed + regression-tested; gpt-5.5 round 3 targeted verification → APPROVE, no findings.

Deliberate non-fix: no client-side item↔board membership pre-check for batch rows — monday rejects mismatches per-row server-side (`ok:false`), which is the accepted behavior. Adjacent pre-existing bug found (item create --batch --dry-run can mint tags) — tracked separately, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)