### PR TITLE
fix(aggregate): drop 2026-07-removed AggregateGroupByResult value_* fields

### DIFF
--- a/src/mondo/api/queries/me.py
+++ b/src/mondo/api/queries/me.py
@@ -90,6 +90,8 @@ query {
 
 
 # Aggregation API (2026-01+). Returns [AggregateGroupByResult { ... }].
+# 2026-07 removed the typed `value_*` variants from AggregateGroupByResult;
+# only the generic `value: JSON` remains.
 AGGREGATE_BOARD = """
 query ($q: AggregateQueryInput!) {
   aggregate(query: $q) {
@@ -99,13 +101,7 @@ query ($q: AggregateQueryInput!) {
         value {
           __typename
           ... on AggregateBasicAggregationResult { result }
-          ... on AggregateGroupByResult {
-            value_string
-            value_int
-            value_float
-            value_boolean
-            value
-          }
+          ... on AggregateGroupByResult { value }
         }
       }
     }

--- a/src/mondo/cli/aggregate.py
+++ b/src/mondo/cli/aggregate.py
@@ -137,10 +137,8 @@ def _flatten_entry_value(value: dict[str, Any] | None) -> Any:
     # AggregateBasicAggregationResult
     if "result" in value and value.get("__typename") == "AggregateBasicAggregationResult":
         return value.get("result")
-    # AggregateGroupByResult — prefer the typed variant, fall back to generic `value`.
-    for k in ("value_string", "value_int", "value_float", "value_boolean"):
-        if value.get(k) is not None:
-            return value[k]
+    # AggregateGroupByResult — 2026-07 removed the typed `value_*` variants;
+    # the generic `value: JSON` already carries the native scalar.
     return value.get("value")
 
 

--- a/tests/unit/test_cli_3i.py
+++ b/tests/unit/test_cli_3i.py
@@ -239,10 +239,6 @@ class TestAggregate:
                                         "alias": "status",
                                         "value": {
                                             "__typename": "AggregateGroupByResult",
-                                            "value_string": "Done",
-                                            "value_int": None,
-                                            "value_float": None,
-                                            "value_boolean": None,
                                             "value": "Done",
                                         },
                                     },

--- a/tests/unit/test_selection.py
+++ b/tests/unit/test_selection.py
@@ -64,7 +64,7 @@ class TestExtractSelectedFields:
         assert "AggregateBasicAggregationResult" not in fields
         assert "AggregateGroupByResult" not in fields
         assert "result" in fields
-        assert "value_string" in fields
+        assert "value" in fields
         assert "__typename" in fields
 
     def test_line_comments_stripped(self) -> None:


### PR DESCRIPTION
Post-merge fallout from #93's API pin bump, caught by the live integration suite: 2026-07 removed the typed `value_*` variants from `AggregateGroupByResult` (only `value: JSON` remains), so `mondo aggregate board` hard-failed with `Cannot query field "value_string"`. The schema-watch diff had missed it (its grep focus list doesn't include Aggregate types).

- `AGGREGATE_BOARD` now selects `... on AggregateGroupByResult { value }` only; `_flatten_entry_value` reads the generic `value` (which carries the native scalar).
- Unit fixtures/assertions updated.
- Live-verified: `tests/integration/test_live_readonly.py::test_live_aggregate_board` passes; full non-integration suite 1984 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)