### PR TITLE
fix(items): stop item/subitem create --dry-run from minting tags

### DIFF
--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -51,7 +51,11 @@ from mondo.columns import (
 from mondo.columns.dropdown import iter_dropdown_labels
 from mondo.columns.status import iter_status_labels
 from mondo.domain.column_cache import fetch_board_columns, invalidate_columns_cache
-from mondo.domain.columns_resolve import parse_settings, resolve_tag_names_to_ids
+from mondo.domain.columns_resolve import (
+    parse_settings,
+    resolve_tag_names_to_ids,
+    tags_value_all_ids,
+)
 from mondo.domain.resolve import resolve_by_filters, resolve_required_id
 from mondo.services.items import fetch_column_defs, read_batch_rows
 
@@ -504,15 +508,6 @@ def set_cmd(
     opts.emit(data.get("change_column_value") or {})
 
 
-def _tags_value_all_ids(raw: str) -> bool:
-    """True when every comma-separated part of a tags value is already a
-    numeric id, so no name→id resolution (a live `create_or_get_tag`
-    mutation) is needed. Mirrors the pass-through check in
-    `resolve_tag_names_to_ids`."""
-    parts = [p.strip() for p in raw.split(",") if p.strip()]
-    return all(p.isdigit() or (p.startswith("-") and p[1:].isdigit()) for p in parts)
-
-
 def _build_column_set_row_vars(
     board_id: int,
     defs: dict[str, dict[str, Any]],
@@ -628,7 +623,7 @@ def _build_column_set_row_vars(
         else:
             # dry_run tags: resolve_tag_names_to_ids would write, so only
             # accept values that are already ids; names need a live call.
-            if col_type == "tags" and not _tags_value_all_ids(str_value):
+            if col_type == "tags" and not tags_value_all_ids(str_value):
                 raise ValidationError(
                     f"--batch row {index} (column {column_id}): resolving tag "
                     "names requires a live call; use tag ids in --dry-run."

--- a/src/mondo/cli/item.py
+++ b/src/mondo/cli/item.py
@@ -738,6 +738,7 @@ def create_cmd(
                 row,
                 raw_columns=raw_columns,
                 create_labels_default=create_labels_if_missing,
+                dry_run=opts.dry_run,
             )
     except ValueError as e:
         handle_mondo_error_or_exit(ValidationError(str(e)))
@@ -809,6 +810,7 @@ def _run_batch(
                             create_labels_default=create_labels_default,
                             tag_cache=tag_cache,
                             column_defs=column_defs,
+                            dry_run=opts.dry_run,
                         )
                     )
                 if opts.dry_run:

--- a/src/mondo/cli/subitem.py
+++ b/src/mondo/cli/subitem.py
@@ -261,6 +261,7 @@ def create_cmd(
                         columns,
                         raw_mode=False,
                         create_labels=create_labels_if_missing,
+                        dry_run=opts.dry_run,
                     )
             except MondoError as e:
                 handle_mondo_error_or_exit(e)

--- a/src/mondo/domain/columns_resolve.py
+++ b/src/mondo/domain/columns_resolve.py
@@ -33,6 +33,15 @@ def parse_settings(raw: str | None) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def tags_value_all_ids(raw: str) -> bool:
+    """True when every comma-separated part of a tags value is already a
+    numeric id, so no name→id resolution (a live `create_or_get_tag`
+    mutation) is needed. Mirrors the pass-through check in
+    `resolve_tag_names_to_ids`."""
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    return all(p.isdigit() or (p.startswith("-") and p[1:].isdigit()) for p in parts)
+
+
 def resolve_tag_names_to_ids(
     client: MondayClient,
     board_id: int,

--- a/src/mondo/services/items.py
+++ b/src/mondo/services/items.py
@@ -17,7 +17,11 @@ from typing import TYPE_CHECKING, Any
 from mondo.api.errors import NotFoundError, UsageError
 from mondo.api.pagination import iter_items_page
 from mondo.domain.column_cache import fetch_board_columns
-from mondo.domain.columns_resolve import parse_settings, resolve_tag_names_to_ids
+from mondo.domain.columns_resolve import (
+    parse_settings,
+    resolve_tag_names_to_ids,
+    tags_value_all_ids,
+)
 from mondo.domain.resolve import resolve_by_filters
 from mondo.util.kvparse import parse_column_kv
 
@@ -218,6 +222,7 @@ def build_column_values(
     create_labels: bool = False,
     tag_cache: dict[str, int] | None = None,
     column_defs: dict[str, dict[str, Any]] | None = None,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Apply codecs to `--column K=V` pairs, using live board column types.
 
@@ -228,6 +233,10 @@ def build_column_values(
     in a batch: a 50-row batch tagging "urgent" issues one
     `create_or_get_tag` instead of fifty, and `fetch_column_defs` runs
     once per batch instead of once per row.
+
+    `dry_run=True` forbids the tag name→id resolution (a real
+    `create_or_get_tag` mutation): tags values must already be numeric ids,
+    otherwise `ValueError` is raised.
     """
     from mondo.columns import UnknownColumnTypeError, parse_value
 
@@ -251,7 +260,17 @@ def build_column_values(
         settings = parse_settings(definition.get("settings_str"))
         str_value = raw_value if isinstance(raw_value, str) else json.dumps(raw_value)
         if col_type == "tags":
-            str_value = resolve_tag_names_to_ids(client, board_id, str_value, cache=tag_cache)
+            if dry_run:
+                # resolve_tag_names_to_ids mints tags via create_or_get_tag —
+                # a real mutation — so dry-run only accepts values that are
+                # already ids.
+                if not tags_value_all_ids(str_value):
+                    raise ValueError(
+                        f"--column {col_id}={raw_value!r}: resolving tag names "
+                        "requires a live call; use tag ids in --dry-run."
+                    )
+            else:
+                str_value = resolve_tag_names_to_ids(client, board_id, str_value, cache=tag_cache)
         try:
             out[col_id] = parse_value(col_type, str_value, settings, create_labels=create_labels)
         except UnknownColumnTypeError:
@@ -272,6 +291,7 @@ def build_create_variables_for_row(
     create_labels_default: bool,
     tag_cache: dict[str, int] | None = None,
     column_defs: dict[str, dict[str, Any]] | None = None,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Render one batch row into the `ITEM_CREATE` variable dict.
 
@@ -299,6 +319,7 @@ def build_create_variables_for_row(
                 create_labels=create_labels,
                 tag_cache=tag_cache,
                 column_defs=column_defs,
+                dry_run=dry_run,
             )
     prm = row.get("position_relative_method")
     if prm is not None:

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -962,6 +962,43 @@ class TestItemCreateBatch:
         # No HTTP calls were made.
         assert httpx_mock.get_requests() == []
 
+    def test_batch_dry_run_tag_names_issue_no_mutation(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        # A tags value given as names can't be resolved in --dry-run without a
+        # real create_or_get_tag mutation, so it errors instead of writing.
+        cols = [{"id": "tags", "type": "tags"}]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(cols))
+        batch_file = tmp_path / "items.json"
+        batch_file.write_text(json.dumps([{"name": "A", "columns": ["tags=urgent,blocked"]}]))
+        result = runner.invoke(
+            app,
+            ["--dry-run", "item", "create", "--board", "42", "--batch", str(batch_file)],
+        )
+        assert result.exit_code == 5, result.output
+        assert "tag ids in --dry-run" in ((result.output or "") + (result.stderr or ""))
+        # Only the read-only defs fetch happened; create_or_get_tag never fired.
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
+    def test_batch_dry_run_tag_ids_pass_through(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        # Numeric tag ids need no resolution, so --dry-run works offline-ish
+        # (only the read-only defs fetch).
+        cols = [{"id": "tags", "type": "tags"}]
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_columns_response(cols))
+        batch_file = tmp_path / "items.json"
+        batch_file.write_text(json.dumps([{"name": "A", "columns": ["tags=1001,1002"]}]))
+        result = runner.invoke(
+            app,
+            ["--dry-run", "item", "create", "--board", "42", "--batch", str(batch_file)],
+        )
+        assert result.exit_code == 0, result.output
+        env = json.loads(result.stdout)
+        values = env["chunks"][0]["variables"]["values_0"]
+        assert json.loads(values) == {"tags": {"tag_ids": [1001, 1002]}}
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
     def test_batch_mutex_with_single_item_flags(
         self, httpx_mock: HTTPXMock, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## What

`mondo item create --dry-run` (single and `--batch`) and `mondo subitem create --dry-run` with a tags column value given as tag **names** still issued real `create_or_get_tag` mutations during codec preflight. Dry-run must never write.

## How

Mirrors the guard `column set --batch` already has (#94):

- `build_column_values` / `build_create_variables_for_row` (`src/mondo/services/items.py`) gain a `dry_run: bool = False` parameter. For tags columns under dry-run, values that are already numeric ids pass straight to the codec; names raise `ValueError` → `ValidationError` (exit 5) with the same message as `column set --batch`: *"resolving tag names requires a live call; use tag ids in --dry-run."*
- `cli/item.py` (single create + `_run_batch`) and `cli/subitem.py` pass `dry_run=opts.dry_run`. All three commands go through the shared helper, so one guard closes all three leaks.
- The all-ids check moves from `cli/column.py` (`_tags_value_all_ids`) into `domain/columns_resolve.py` as `tags_value_all_ids`, shared by both callers — no behavior change on the column path.

## Tests

Two new unit tests in `TestItemCreateBatch`, modeled on the `column set --batch` ones:

- tag names under `--dry-run` → exit 5, and no request on the wire contains `create_or_get_tag` (only the read-only column-defs fetch happens);
- numeric tag ids pass through to a `{"tags": {"tag_ids": [1001, 1002]}}` payload in the emitted chunks, again with no tag mutation.

Full non-integration suite: 1980 passed. Ruff lint + format clean.

## Reviewer notes

The single-item `column set --dry-run` (non-batch) path has the same leak (`resolve_tag_names_to_ids` at `cli/column.py` runs before its dry-run check) — deliberately left out of scope; it's tracked as a follow-up task.