### PR TITLE
fix(column): stop dry-run column set from minting tags via create_or_get_tag

### DIFF
--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -437,8 +437,20 @@ def set_cmd(
                     usage_error_or_exit(f"--raw value is not valid JSON: {e}")
             else:
                 if col_type == "tags":
-                    # Resolve tag names to IDs before the codec sees them.
-                    raw_input = resolve_tag_names_to_ids(client, board_id, raw_input)
+                    if opts.dry_run:
+                        # resolve_tag_names_to_ids mints tags via
+                        # create_or_get_tag — a real mutation — so only accept
+                        # values that are already ids; names need a live call.
+                        if not _tags_value_all_ids(raw_input):
+                            handle_mondo_error_or_exit(
+                                ValidationError(
+                                    "resolving tag names requires a live call; "
+                                    "use tag ids in --dry-run."
+                                )
+                            )
+                    else:
+                        # Resolve tag names to IDs before the codec sees them.
+                        raw_input = resolve_tag_names_to_ids(client, board_id, raw_input)
                 try:
                     parsed = parse_value(
                         col_type, raw_input, settings, create_labels=create_labels_if_missing

--- a/tests/unit/test_cli_column.py
+++ b/tests/unit/test_cli_column.py
@@ -495,6 +495,69 @@ class TestColumnSet:
         body = json.loads(httpx_mock.get_requests()[-1].content)
         assert body["variables"]["value"] == json.dumps({"tag_ids": [1001, 1002]})
 
+    def test_dry_run_tag_names_issue_no_mutation(self, httpx_mock: HTTPXMock) -> None:
+        # A tags value given as names can't be resolved in --dry-run without a
+        # real create_or_get_tag mutation, so it errors instead of writing.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_context_response(
+                board_id=42,
+                cols=[{"id": "tags", "title": "T", "type": "tags", "settings_str": "{}"}],
+                values=[{"id": "tags", "type": "tags", "text": "", "value": None}],
+            ),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "column",
+                "set",
+                "--item",
+                "1",
+                "--column",
+                "tags",
+                "--value",
+                "urgent,blocked",
+            ],
+        )
+        assert result.exit_code == 5, result.output
+        assert "tag ids in --dry-run" in ((result.output or "") + (result.stderr or ""))
+        # Only the read-only context fetch happened; create_or_get_tag never fired.
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
+    def test_dry_run_tag_ids_pass_through(self, httpx_mock: HTTPXMock) -> None:
+        # Numeric tag ids need no resolution, so --dry-run works offline-ish
+        # (only the read-only context fetch).
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_context_response(
+                board_id=42,
+                cols=[{"id": "tags", "title": "T", "type": "tags", "settings_str": "{}"}],
+                values=[{"id": "tags", "type": "tags", "text": "", "value": None}],
+            ),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "column",
+                "set",
+                "--item",
+                "1",
+                "--column",
+                "tags",
+                "--value",
+                "1001,1002",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+        assert parsed["variables"]["value"] == json.dumps({"tag_ids": [1001, 1002]})
+        assert len(httpx_mock.get_requests()) == 1
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
     def test_clear_shaped_value_hints_column_clear(self, httpx_mock: HTTPXMock) -> None:
         """#91: an "empty" payload against a dropdown fails the codec and the
         error points at `column clear`."""


### PR DESCRIPTION
## What

Single-item `mondo column set --dry-run` (non-batch) on a `tags` column resolved tag names via `resolve_tag_names_to_ids` **before** the dry-run check — issuing a real `create_or_get_tag` mutation. Dry-run must never write.

The `col_type == "tags"` branch in `set_cmd` now mirrors the guard already used by `column set --batch` (`_build_column_set_row_vars`):

- values whose comma-separated parts are all numeric ids pass straight through to the codec (no live call needed),
- names raise `ValidationError` — `resolving tag names requires a live call; use tag ids in --dry-run.` (exit 5).

Live (non-dry-run) runs are unchanged.

## Tests

Added the non-batch equivalents of the existing batch tests in `tests/unit/test_cli_column.py::TestColumnSet`:

- `test_dry_run_tag_names_issue_no_mutation` — names under `--dry-run` exit 5 and no `create_or_get_tag` request is dispatched,
- `test_dry_run_tag_ids_pass_through` — numeric ids emit the `{"tag_ids": [...]}` payload with only the read-only context fetch.

Full non-integration suite: 1980 passed, 6 skipped. Ruff check/format clean.

## Reviewer note

While verifying, I found the same leak exists in `item create` (single and `--batch`): `build_column_values` in `src/mondo/services/items.py` resolves tag names with a live client unconditionally, and the dry-run check happens only after variables are built. Not fixed here — tracked as a follow-up.