### PR TITLE
fix(dry-run): never mint tags via create_or_get_tag under --dry-run

### DIFF
--- a/.claude/skills/monday-api-watch/scripts/snapshot_monday_schema.py
+++ b/.claude/skills/monday-api-watch/scripts/snapshot_monday_schema.py
@@ -52,10 +52,11 @@ VERSIONS_QUERY = "query { versions { kind value display_name } }"
 def _token() -> str:
     tok = os.environ.get("MONDAY_API_TOKEN")
     if not tok and os.path.exists(".env"):
-        for line in open(".env"):
-            if line.startswith("MONDAY_API_TOKEN="):
-                tok = line.split("=", 1)[1].strip()
-                break
+        with open(".env") as fh:
+            for line in fh:
+                if line.startswith("MONDAY_API_TOKEN="):
+                    tok = line.split("=", 1)[1].strip()
+                    break
     if not tok:
         sys.exit("error: MONDAY_API_TOKEN not set (env or ./.env)")
     return tok
@@ -100,7 +101,8 @@ def snapshot(api_version: str) -> list[str]:
         lines.append(f"{t['kind']} {name}")
         for f in t.get("fields") or []:
             args = ", ".join(
-                f"{a['name']}: {_typeref(a['type'])}" for a in sorted(f["args"], key=lambda a: a["name"])
+                f"{a['name']}: {_typeref(a['type'])}"
+                for a in sorted(f["args"], key=lambda a: a["name"])
             )
             sig = f"({args})" if args else ""
             lines.append(f"{name}.{f['name']}{sig}: {_typeref(f['type'])}{_dep(f)}")

--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -52,6 +52,7 @@ from mondo.columns.dropdown import iter_dropdown_labels
 from mondo.columns.status import iter_status_labels
 from mondo.domain.column_cache import fetch_board_columns, invalidate_columns_cache
 from mondo.domain.columns_resolve import (
+    DRY_RUN_TAG_NAMES_MSG,
     parse_settings,
     resolve_tag_names_to_ids,
     tags_value_all_ids,
@@ -441,20 +442,15 @@ def set_cmd(
                     usage_error_or_exit(f"--raw value is not valid JSON: {e}")
             else:
                 if col_type == "tags":
-                    if opts.dry_run:
-                        # resolve_tag_names_to_ids mints tags via
-                        # create_or_get_tag — a real mutation. Dry-run must
-                        # never write, so only ids are accepted here.
-                        if not tags_value_all_ids(raw_input):
-                            handle_mondo_error_or_exit(
-                                ValidationError(
-                                    "resolving tag names requires a live "
-                                    "call; use tag ids in --dry-run."
-                                )
-                            )
-                    else:
-                        # Resolve tag names to IDs before the codec sees them.
-                        raw_input = resolve_tag_names_to_ids(client, board_id, raw_input)
+                    # Resolve tag names to IDs before the codec sees them. The
+                    # shared resolver refuses name→id resolution under dry-run
+                    # (create_or_get_tag is a real mutation), raising ValueError.
+                    try:
+                        raw_input = resolve_tag_names_to_ids(
+                            client, board_id, raw_input, dry_run=opts.dry_run
+                        )
+                    except ValueError as e:
+                        handle_mondo_error_or_exit(ValidationError(str(e)))
                 try:
                     parsed = parse_value(
                         col_type, raw_input, settings, create_labels=create_labels_if_missing
@@ -637,8 +633,7 @@ def _build_column_set_row_vars(
             # accept values that are already ids; names need a live call.
             if col_type == "tags" and not tags_value_all_ids(str_value):
                 raise ValidationError(
-                    f"--batch row {index} (column {column_id}): resolving tag "
-                    "names requires a live call; use tag ids in --dry-run."
+                    f"--batch row {index} (column {column_id}): {DRY_RUN_TAG_NAMES_MSG}"
                 )
             try:
                 parsed = parse_value(col_type, str_value, settings, create_labels=create_labels)

--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -51,7 +51,11 @@ from mondo.columns import (
 from mondo.columns.dropdown import iter_dropdown_labels
 from mondo.columns.status import iter_status_labels
 from mondo.domain.column_cache import fetch_board_columns, invalidate_columns_cache
-from mondo.domain.columns_resolve import parse_settings, resolve_tag_names_to_ids
+from mondo.domain.columns_resolve import (
+    parse_settings,
+    resolve_tag_names_to_ids,
+    tags_value_all_ids,
+)
 from mondo.domain.resolve import resolve_by_filters, resolve_required_id
 from mondo.services.items import fetch_column_defs, read_batch_rows
 
@@ -437,8 +441,20 @@ def set_cmd(
                     usage_error_or_exit(f"--raw value is not valid JSON: {e}")
             else:
                 if col_type == "tags":
-                    # Resolve tag names to IDs before the codec sees them.
-                    raw_input = resolve_tag_names_to_ids(client, board_id, raw_input)
+                    if opts.dry_run:
+                        # resolve_tag_names_to_ids mints tags via
+                        # create_or_get_tag — a real mutation. Dry-run must
+                        # never write, so only ids are accepted here.
+                        if not tags_value_all_ids(raw_input):
+                            handle_mondo_error_or_exit(
+                                ValidationError(
+                                    "resolving tag names requires a live "
+                                    "call; use tag ids in --dry-run."
+                                )
+                            )
+                    else:
+                        # Resolve tag names to IDs before the codec sees them.
+                        raw_input = resolve_tag_names_to_ids(client, board_id, raw_input)
                 try:
                     parsed = parse_value(
                         col_type, raw_input, settings, create_labels=create_labels_if_missing
@@ -502,15 +518,6 @@ def set_cmd(
     invalidate_entity(opts, "items", scope=str(item_id))
     invalidate_board_items_cache(opts, board_id)
     opts.emit(data.get("change_column_value") or {})
-
-
-def _tags_value_all_ids(raw: str) -> bool:
-    """True when every comma-separated part of a tags value is already a
-    numeric id, so no name→id resolution (a live `create_or_get_tag`
-    mutation) is needed. Mirrors the pass-through check in
-    `resolve_tag_names_to_ids`."""
-    parts = [p.strip() for p in raw.split(",") if p.strip()]
-    return all(p.isdigit() or (p.startswith("-") and p[1:].isdigit()) for p in parts)
 
 
 def _build_column_set_row_vars(
@@ -628,7 +635,7 @@ def _build_column_set_row_vars(
         else:
             # dry_run tags: resolve_tag_names_to_ids would write, so only
             # accept values that are already ids; names need a live call.
-            if col_type == "tags" and not _tags_value_all_ids(str_value):
+            if col_type == "tags" and not tags_value_all_ids(str_value):
                 raise ValidationError(
                     f"--batch row {index} (column {column_id}): resolving tag "
                     "names requires a live call; use tag ids in --dry-run."

--- a/src/mondo/cli/import_.py
+++ b/src/mondo/cli/import_.py
@@ -26,10 +26,7 @@ import typer
 
 from mondo.api.errors import MondoError, NotFoundError, UsageError
 from mondo.api.pagination import iter_items_page
-from mondo.api.queries import (
-    CREATE_OR_GET_TAG,
-    ITEM_CREATE,
-)
+from mondo.api.queries import ITEM_CREATE
 from mondo.cli._examples import epilog_for
 from mondo.cli._exec import (
     client_or_exit,
@@ -38,6 +35,7 @@ from mondo.cli._exec import (
 )
 from mondo.cli.context import GlobalOpts
 from mondo.domain.column_cache import fetch_board_columns, invalidate_columns_cache
+from mondo.domain.columns_resolve import resolve_tag_names_to_ids
 from mondo.domain.resolve import resolve_required_id
 
 if TYPE_CHECKING:
@@ -123,21 +121,6 @@ def _fetch_existing_names(client: MondayClient, board_id: int) -> set[str]:
     return names
 
 
-def _resolve_tag_names_to_ids(client: MondayClient, board_id: int, value: str) -> str:
-    parts = [p.strip() for p in value.split(",") if p.strip()]
-    ids: list[int] = []
-    for part in parts:
-        if part.isdigit() or (part.startswith("-") and part[1:].isdigit()):
-            ids.append(int(part))
-            continue
-        data = client.execute(CREATE_OR_GET_TAG, {"name": part, "board": board_id})
-        tag = ((data.get("data") or {}).get("create_or_get_tag")) or {}
-        if not tag.get("id"):
-            raise MondoError(f"create_or_get_tag returned no id for {part!r}")
-        ids.append(int(tag["id"]))
-    return ",".join(str(i) for i in ids)
-
-
 def _encode_row(
     client: MondayClient,
     board_id: int,
@@ -146,6 +129,7 @@ def _encode_row(
     col_defs: dict[str, dict[str, Any]],
     *,
     create_labels: bool = False,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Turn a CSV row (header → string value) into a monday column_values dict."""
     from mondo.columns import UnknownColumnTypeError, parse_value
@@ -167,7 +151,13 @@ def _encode_row(
             continue
         settings = _parse_settings(definition.get("settings_str"))
         if col_type == "tags":
-            raw = _resolve_tag_names_to_ids(client, board_id, raw)
+            # Shared resolver refuses name→id resolution under dry-run
+            # (create_or_get_tag is a real mutation), raising ValueError —
+            # surfaced as this row's failure, same as a codec ValueError.
+            try:
+                raw = resolve_tag_names_to_ids(client, board_id, raw, dry_run=dry_run)
+            except ValueError as e:
+                raise ValueError(f"column {col_id}={raw!r}: {e}") from e
         try:
             out[col_id] = parse_value(col_type, raw, settings, create_labels=create_labels)
         except UnknownColumnTypeError:
@@ -275,6 +265,7 @@ def board_cmd(
                         header_to_col_id,
                         col_defs,
                         create_labels=create_labels_if_missing,
+                        dry_run=opts.dry_run,
                     )
                 except ValueError as e:
                     results.append({"status": "failed", "name": name, "error": str(e)})

--- a/src/mondo/cli/item.py
+++ b/src/mondo/cli/item.py
@@ -738,6 +738,7 @@ def create_cmd(
                 row,
                 raw_columns=raw_columns,
                 create_labels_default=create_labels_if_missing,
+                dry_run=opts.dry_run,
             )
     except ValueError as e:
         handle_mondo_error_or_exit(ValidationError(str(e)))
@@ -809,6 +810,7 @@ def _run_batch(
                             create_labels_default=create_labels_default,
                             tag_cache=tag_cache,
                             column_defs=column_defs,
+                            dry_run=opts.dry_run,
                         )
                     )
                 if opts.dry_run:

--- a/src/mondo/cli/subitem.py
+++ b/src/mondo/cli/subitem.py
@@ -261,6 +261,7 @@ def create_cmd(
                         columns,
                         raw_mode=False,
                         create_labels=create_labels_if_missing,
+                        dry_run=opts.dry_run,
                     )
             except MondoError as e:
                 handle_mondo_error_or_exit(e)

--- a/src/mondo/domain/columns_resolve.py
+++ b/src/mondo/domain/columns_resolve.py
@@ -16,6 +16,11 @@ from mondo.api.queries import CREATE_OR_GET_TAG
 if TYPE_CHECKING:
     from mondo.api.client import MondayClient
 
+# Raised (as ValueError) when a `--dry-run` tags value carries names rather
+# than ids: name→id resolution needs the `create_or_get_tag` mutation, which
+# a dry run must never issue. Callers add their own context prefix.
+DRY_RUN_TAG_NAMES_MSG = "resolving tag names requires a live call; use tag ids in --dry-run."
+
 
 def parse_settings(raw: str | None) -> dict[str, Any]:
     """Best-effort parse of a column's `settings_str`.
@@ -39,6 +44,7 @@ def resolve_tag_names_to_ids(
     raw: str,
     *,
     cache: dict[str, int] | None = None,
+    dry_run: bool = False,
 ) -> str:
     """Resolve a comma-separated list of tag names *or* ids to a comma-id string.
 
@@ -49,7 +55,13 @@ def resolve_tag_names_to_ids(
     `cache` (when provided) memoises name → id within one CLI invocation —
     a 50-row batch tagging the same `urgent` label won't issue 50 identical
     `create_or_get_tag` mutations.
+
+    `dry_run=True` forbids name→id resolution: `create_or_get_tag` is a real
+    mutation a dry run must never issue. All-id values still pass through (no
+    client call); any name raises `ValueError(DRY_RUN_TAG_NAMES_MSG)`.
     """
+    if dry_run and not tags_value_all_ids(raw):
+        raise ValueError(DRY_RUN_TAG_NAMES_MSG)
     parts = [p.strip() for p in raw.split(",") if p.strip()]
     if not parts:
         return ""

--- a/src/mondo/domain/columns_resolve.py
+++ b/src/mondo/domain/columns_resolve.py
@@ -38,6 +38,11 @@ def parse_settings(raw: str | None) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _is_tag_id(part: str) -> bool:
+    """True when a single tags-value part is already a numeric id."""
+    return part.isdigit() or (part.startswith("-") and part[1:].isdigit())
+
+
 def resolve_tag_names_to_ids(
     client: MondayClient,
     board_id: int,
@@ -67,7 +72,7 @@ def resolve_tag_names_to_ids(
         return ""
     resolved_ids: list[int] = []
     for part in parts:
-        if part.isdigit() or (part.startswith("-") and part[1:].isdigit()):
+        if _is_tag_id(part):
             resolved_ids.append(int(part))
             continue
         if cache is not None and part in cache:
@@ -89,7 +94,6 @@ def resolve_tag_names_to_ids(
 def tags_value_all_ids(raw: str) -> bool:
     """True when every comma-separated part of a tags value is already a
     numeric id, so no name→id resolution (a live `create_or_get_tag`
-    mutation) is needed. Mirrors the pass-through check in
-    `resolve_tag_names_to_ids`."""
+    mutation) is needed."""
     parts = [p.strip() for p in raw.split(",") if p.strip()]
-    return all(p.isdigit() or (p.startswith("-") and p[1:].isdigit()) for p in parts)
+    return all(_is_tag_id(p) for p in parts)

--- a/src/mondo/domain/columns_resolve.py
+++ b/src/mondo/domain/columns_resolve.py
@@ -72,3 +72,12 @@ def resolve_tag_names_to_ids(
             cache[part] = tag_id_int
         resolved_ids.append(tag_id_int)
     return ",".join(str(i) for i in resolved_ids)
+
+
+def tags_value_all_ids(raw: str) -> bool:
+    """True when every comma-separated part of a tags value is already a
+    numeric id, so no name→id resolution (a live `create_or_get_tag`
+    mutation) is needed. Mirrors the pass-through check in
+    `resolve_tag_names_to_ids`."""
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    return all(p.isdigit() or (p.startswith("-") and p[1:].isdigit()) for p in parts)

--- a/src/mondo/services/items.py
+++ b/src/mondo/services/items.py
@@ -17,10 +17,7 @@ from typing import TYPE_CHECKING, Any
 from mondo.api.errors import NotFoundError, UsageError
 from mondo.api.pagination import iter_items_page
 from mondo.domain.column_cache import fetch_board_columns
-from mondo.domain.columns_resolve import (
-    parse_settings,
-    resolve_tag_names_to_ids,
-)
+from mondo.domain.columns_resolve import parse_settings, resolve_tag_names_to_ids
 from mondo.domain.resolve import resolve_by_filters
 from mondo.util.kvparse import parse_column_kv
 

--- a/src/mondo/services/items.py
+++ b/src/mondo/services/items.py
@@ -17,7 +17,11 @@ from typing import TYPE_CHECKING, Any
 from mondo.api.errors import NotFoundError, UsageError
 from mondo.api.pagination import iter_items_page
 from mondo.domain.column_cache import fetch_board_columns
-from mondo.domain.columns_resolve import parse_settings, resolve_tag_names_to_ids
+from mondo.domain.columns_resolve import (
+    parse_settings,
+    resolve_tag_names_to_ids,
+    tags_value_all_ids,
+)
 from mondo.domain.resolve import resolve_by_filters
 from mondo.util.kvparse import parse_column_kv
 
@@ -218,6 +222,7 @@ def build_column_values(
     create_labels: bool = False,
     tag_cache: dict[str, int] | None = None,
     column_defs: dict[str, dict[str, Any]] | None = None,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Apply codecs to `--column K=V` pairs, using live board column types.
 
@@ -228,6 +233,10 @@ def build_column_values(
     in a batch: a 50-row batch tagging "urgent" issues one
     `create_or_get_tag` instead of fifty, and `fetch_column_defs` runs
     once per batch instead of once per row.
+
+    `dry_run=True` forbids tag name→id resolution (`create_or_get_tag` is a
+    real mutation): tags values must already be numeric ids, otherwise
+    `ValueError`.
     """
     from mondo.columns import UnknownColumnTypeError, parse_value
 
@@ -251,7 +260,16 @@ def build_column_values(
         settings = parse_settings(definition.get("settings_str"))
         str_value = raw_value if isinstance(raw_value, str) else json.dumps(raw_value)
         if col_type == "tags":
-            str_value = resolve_tag_names_to_ids(client, board_id, str_value, cache=tag_cache)
+            if dry_run:
+                # resolve_tag_names_to_ids mints tags via create_or_get_tag —
+                # a real mutation. Dry-run must never write.
+                if not tags_value_all_ids(str_value):
+                    raise ValueError(
+                        f"--column {col_id}={raw_value!r}: resolving tag names "
+                        "requires a live call; use tag ids in --dry-run."
+                    )
+            else:
+                str_value = resolve_tag_names_to_ids(client, board_id, str_value, cache=tag_cache)
         try:
             out[col_id] = parse_value(col_type, str_value, settings, create_labels=create_labels)
         except UnknownColumnTypeError:
@@ -272,6 +290,7 @@ def build_create_variables_for_row(
     create_labels_default: bool,
     tag_cache: dict[str, int] | None = None,
     column_defs: dict[str, dict[str, Any]] | None = None,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
     """Render one batch row into the `ITEM_CREATE` variable dict.
 
@@ -299,6 +318,7 @@ def build_create_variables_for_row(
                 create_labels=create_labels,
                 tag_cache=tag_cache,
                 column_defs=column_defs,
+                dry_run=dry_run,
             )
     prm = row.get("position_relative_method")
     if prm is not None:

--- a/src/mondo/services/items.py
+++ b/src/mondo/services/items.py
@@ -20,7 +20,6 @@ from mondo.domain.column_cache import fetch_board_columns
 from mondo.domain.columns_resolve import (
     parse_settings,
     resolve_tag_names_to_ids,
-    tags_value_all_ids,
 )
 from mondo.domain.resolve import resolve_by_filters
 from mondo.util.kvparse import parse_column_kv
@@ -260,16 +259,14 @@ def build_column_values(
         settings = parse_settings(definition.get("settings_str"))
         str_value = raw_value if isinstance(raw_value, str) else json.dumps(raw_value)
         if col_type == "tags":
-            if dry_run:
-                # resolve_tag_names_to_ids mints tags via create_or_get_tag —
-                # a real mutation. Dry-run must never write.
-                if not tags_value_all_ids(str_value):
-                    raise ValueError(
-                        f"--column {col_id}={raw_value!r}: resolving tag names "
-                        "requires a live call; use tag ids in --dry-run."
-                    )
-            else:
-                str_value = resolve_tag_names_to_ids(client, board_id, str_value, cache=tag_cache)
+            # The shared resolver refuses name→id resolution under dry-run
+            # (create_or_get_tag is a real mutation), raising ValueError.
+            try:
+                str_value = resolve_tag_names_to_ids(
+                    client, board_id, str_value, cache=tag_cache, dry_run=dry_run
+                )
+            except ValueError as e:
+                raise ValueError(f"--column {col_id}={raw_value!r}: {e}") from e
         try:
             out[col_id] = parse_value(col_type, str_value, settings, create_labels=create_labels)
         except UnknownColumnTypeError:

--- a/tests/unit/test_cli_cache_paths.py
+++ b/tests/unit/test_cli_cache_paths.py
@@ -305,9 +305,7 @@ class TestUserListCache:
         httpx_mock.add_response(
             url=ENDPOINT,
             method="POST",
-            json=_ok(
-                {"users": [{"id": "1", "name": "Zoe", "email": "z@x", "status": "ACTIVE"}]}
-            ),
+            json=_ok({"users": [{"id": "1", "name": "Zoe", "email": "z@x", "status": "ACTIVE"}]}),
         )
         r1 = runner.invoke(app, ["user", "list"])
         assert r1.exit_code == 0, r1.stdout

--- a/tests/unit/test_cli_column.py
+++ b/tests/unit/test_cli_column.py
@@ -974,6 +974,58 @@ class TestColumnSetBatch:
         combined = (result.output or "") + (result.stderr or "")
         assert "mondo item rename" in combined
 
+    def test_single_dry_run_tag_names_issue_no_mutation(self, httpx_mock: HTTPXMock) -> None:
+        # Single-item `column set --dry-run` with tags-by-name must error
+        # instead of minting via create_or_get_tag (same invariant as --batch).
+        cols = [{"id": "tags", "title": "Tags", "type": "tags", "settings_str": "{}"}]
+        values = [{"id": "tags", "type": "tags", "text": "", "value": None}]
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_context_response(42, cols, values)
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "column",
+                "set",
+                "--item",
+                "1",
+                "--column",
+                "tags",
+                "--value",
+                "urgent,blocked",
+            ],
+        )
+        assert result.exit_code == 5, result.output
+        assert "tag ids in --dry-run" in ((result.output or "") + (result.stderr or ""))
+        # Only the read-only context fetch happened; create_or_get_tag never fired.
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
+    def test_single_dry_run_tag_ids_pass_through(self, httpx_mock: HTTPXMock) -> None:
+        cols = [{"id": "tags", "title": "Tags", "type": "tags", "settings_str": "{}"}]
+        values = [{"id": "tags", "type": "tags", "text": "", "value": None}]
+        httpx_mock.add_response(
+            url=ENDPOINT, method="POST", json=_context_response(42, cols, values)
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "column",
+                "set",
+                "--item",
+                "1",
+                "--column",
+                "tags",
+                "--value",
+                "1001,1002",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        env = json.loads(result.stdout)
+        assert env["variables"]["value"] == json.dumps({"tag_ids": [1001, 1002]})
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
     def test_dry_run_tag_names_issue_no_mutation(self, httpx_mock: HTTPXMock) -> None:
         # A tags value given as names can't be resolved in --dry-run without a
         # real create_or_get_tag mutation, so it errors instead of writing.

--- a/tests/unit/test_cli_import.py
+++ b/tests/unit/test_cli_import.py
@@ -121,6 +121,64 @@ class TestBasicImport:
         # Only the preflight query should have been sent.
         assert len(httpx_mock.get_requests()) == 1
 
+    TAGS_COLS_RESPONSE = _ok(
+        {
+            "boards": [
+                {
+                    "id": "42",
+                    "name": "B",
+                    "columns": [
+                        {
+                            "id": "tags7",
+                            "title": "Tags",
+                            "type": "tags",
+                            "settings_str": "{}",
+                            "archived": False,
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+
+    def test_dry_run_tag_names_row_fails_no_mutation(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        # A tags value given as names can't be resolved in --dry-run without a
+        # real create_or_get_tag mutation — the row fails instead of writing.
+        src = tmp_path / "i.csv"
+        _write_csv(src, ["name,Tags", 'Alpha,"urgent,blocked"'])
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=self.TAGS_COLS_RESPONSE)
+        result = runner.invoke(
+            app,
+            ["--dry-run", "import", "board", "--board", "42", "--from", str(src)],
+        )
+        assert result.exit_code == 1, result.stdout
+        parsed = json.loads(result.stdout)
+        assert parsed["summary"]["failed"] == 1
+        assert parsed["summary"]["created"] == 0
+        assert parsed["results"][0]["status"] == "failed"
+        assert "tag ids in --dry-run" in parsed["results"][0]["error"]
+        # Only the read-only defs fetch happened; create_or_get_tag never fired.
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
+    def test_dry_run_tag_ids_pass_through(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        # Numeric tag ids need no resolution, so the row dry-runs cleanly with
+        # only the read-only defs fetch and never touches create_or_get_tag.
+        src = tmp_path / "i.csv"
+        _write_csv(src, ["name,Tags", 'Alpha,"1001,1002"'])
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=self.TAGS_COLS_RESPONSE)
+        result = runner.invoke(
+            app,
+            ["--dry-run", "import", "board", "--board", "42", "--from", str(src)],
+        )
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert parsed["results"][0]["status"] == "dry-run"
+        values = json.loads(parsed["results"][0]["variables"]["values"])
+        assert values["tags7"] == {"tag_ids": [1001, 1002]}
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
 
 class TestMapping:
     def test_explicit_mapping(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -691,6 +691,60 @@ class TestItemCreate:
         assert "create_item" in parsed["query"]
         assert parsed["variables"]["name"] == "Hi"
 
+    def test_dry_run_tag_names_issue_no_mutation(self, httpx_mock: HTTPXMock) -> None:
+        # A tags value given as names can't be resolved in --dry-run without a
+        # real create_or_get_tag mutation, so it errors instead of writing.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_columns_response([{"id": "tags", "type": "tags"}]),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "item",
+                "create",
+                "--board",
+                "42",
+                "--name",
+                "Hi",
+                "--column",
+                "tags=urgent,blocked",
+            ],
+        )
+        assert result.exit_code == 5, result.stdout
+        assert "tag ids in --dry-run" in ((result.output or "") + (result.stderr or ""))
+        # Only the read-only defs fetch happened; create_or_get_tag never fired.
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
+    def test_dry_run_tag_ids_pass_through(self, httpx_mock: HTTPXMock) -> None:
+        # Numeric tag ids need no resolution, so --dry-run works offline-ish
+        # (only the read-only defs fetch).
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_columns_response([{"id": "tags", "type": "tags"}]),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "item",
+                "create",
+                "--board",
+                "42",
+                "--name",
+                "Hi",
+                "--column",
+                "tags=1001,1002",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert json.loads(parsed["variables"]["values"]) == {"tags": {"tag_ids": [1001, 1002]}}
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
     def test_position_relative_method(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(
             url=ENDPOINT,
@@ -961,6 +1015,46 @@ class TestItemCreateBatch:
         assert "m_0:" in env["chunks"][0]["query"]
         # No HTTP calls were made.
         assert httpx_mock.get_requests() == []
+
+    def test_batch_dry_run_tag_names_issue_no_mutation(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        # Same invariant as single create: batch --dry-run must never mint
+        # tags via create_or_get_tag; names error out, only ids pass.
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_columns_response([{"id": "tags", "type": "tags"}]),
+        )
+        batch_file = tmp_path / "items.json"
+        batch_file.write_text(json.dumps([{"name": "A", "columns": ["tags=urgent"]}]))
+        result = runner.invoke(
+            app,
+            ["--dry-run", "item", "create", "--board", "42", "--batch", str(batch_file)],
+        )
+        assert result.exit_code == 5, result.stdout
+        assert "tag ids in --dry-run" in ((result.output or "") + (result.stderr or ""))
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
+    def test_batch_dry_run_tag_ids_pass_through(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_columns_response([{"id": "tags", "type": "tags"}]),
+        )
+        batch_file = tmp_path / "items.json"
+        batch_file.write_text(json.dumps([{"name": "A", "columns": ["tags=1001,1002"]}]))
+        result = runner.invoke(
+            app,
+            ["--dry-run", "item", "create", "--board", "42", "--batch", str(batch_file)],
+        )
+        assert result.exit_code == 0, result.stdout
+        env = json.loads(result.stdout)
+        values = json.loads(env["chunks"][0]["variables"]["values_0"])
+        assert values == {"tags": {"tag_ids": [1001, 1002]}}
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
 
     def test_batch_mutex_with_single_item_flags(
         self, httpx_mock: HTTPXMock, tmp_path: Path

--- a/tests/unit/test_cli_subitem.py
+++ b/tests/unit/test_cli_subitem.py
@@ -414,6 +414,76 @@ class TestCreate:
         v = _last_body(httpx_mock)["variables"]
         assert json.loads(v["values"]) == {"tags9": {"tag_ids": [111]}}
 
+    def _tags_board_response(self) -> dict:
+        return _ok(
+            {
+                "boards": [
+                    {
+                        "id": "99",
+                        "name": "SubBoard",
+                        "columns": [
+                            {
+                                "id": "tags9",
+                                "title": "Tags",
+                                "type": "tags",
+                                "settings_str": "{}",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    def test_dry_run_tag_names_issue_no_mutation(self, httpx_mock: HTTPXMock) -> None:
+        # A tags value given as names can't be resolved in --dry-run without a
+        # real create_or_get_tag mutation, so it errors instead of writing.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=self._tags_board_response())
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "subitem",
+                "create",
+                "--parent",
+                "1",
+                "--name",
+                "Hi",
+                "--subitems-board",
+                "99",
+                "--column",
+                "tags9=urgent,blocked",
+            ],
+        )
+        assert result.exit_code == 5, result.stdout
+        assert "tag ids in --dry-run" in ((result.output or "") + (result.stderr or ""))
+        # Only the read-only defs fetch happened; create_or_get_tag never fired.
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
+    def test_dry_run_tag_ids_pass_through(self, httpx_mock: HTTPXMock) -> None:
+        # Numeric tag ids need no resolution, so --dry-run works with only the
+        # read-only defs fetch and never touches create_or_get_tag.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=self._tags_board_response())
+        result = runner.invoke(
+            app,
+            [
+                "--dry-run",
+                "subitem",
+                "create",
+                "--parent",
+                "1",
+                "--name",
+                "Hi",
+                "--subitems-board",
+                "99",
+                "--column",
+                "tags9=1001,1002",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert json.loads(parsed["variables"]["values"]) == {"tags9": {"tag_ids": [1001, 1002]}}
+        assert all(b"create_or_get_tag" not in r.content for r in httpx_mock.get_requests())
+
 
 class TestMoveRenameArchive:
     def test_rename(self, httpx_mock: HTTPXMock) -> None:


### PR DESCRIPTION
## What

`--dry-run` runs could still issue real `create_or_get_tag` mutations when a tags column value was given by name. Affected paths:

- `item create --column tags=<names>` (single **and** `--batch`)
- single-item `column set --column <tags-col> --value <names>`
- `subitem create --subitems-board ... --column tags=<names>`

All three resolved tag names via `resolve_tag_names_to_ids` (which mints through `create_or_get_tag`) *before* their dry-run checks. Dry-run must never write.

## How

- Thread a `dry_run` flag into `build_column_values` / `build_create_variables_for_row` (`services/items.py`). In dry-run, tags values must already be all-numeric ids (passed through to the codec as before); names raise `ValidationError` (exit 5) with the same message as the already-fixed `column set --batch` path: `resolving tag names requires a live call; use tag ids in --dry-run.`
- Guard the single-item `column set` tags resolution the same way (`cli/column.py`).
- Move `_tags_value_all_ids` from `cli/column.py` to `domain/columns_resolve.py` as `tags_value_all_ids` so `services/` can use it without importing from `cli/`.

## Notes for the reviewer

- The single-item `column set` path was believed fixed in #94 but only the `--batch` path was — it resolved names before its dry-run check. Covered here with tests.
- Live (non-dry-run) behavior is unchanged: names still resolve through `create_or_get_tag`, ids still pass through.
- Verified end-to-end by running the CLI against a request-logging stub monday API: on `main`, the dry-run repro sends 1× `create_or_get_tag`; with this fix, 0× across all paths, while a live run still mints and resolves correctly.

## Tests

6 new unit tests (4 in `test_cli_item.py`, 2 in `test_cli_column.py`) mirroring `test_dry_run_tag_names_issue_no_mutation` / `test_dry_run_tag_ids_pass_through`, asserting no `create_or_get_tag` request is dispatched under `--dry-run`. Full suite: 1984 passed, 6 skipped.