### PR TITLE
fix(import): resolve export's "Title (colid)" CSV headers to column ids

### DIFF
--- a/src/mondo/cli/column.py
+++ b/src/mondo/cli/column.py
@@ -611,7 +611,7 @@ def _build_column_set_row_vars(
                 _str_value: str = str_value,
                 _settings: dict[str, Any] = settings,
                 _create_labels: bool = create_labels,
-                _column_id: str = column_id,
+                _column_id: str = str(column_id),
                 _index: int = index,
             ) -> str:
                 resolved = resolve_tag_names_to_ids(cl, board_id, _str_value, cache=cache)

--- a/src/mondo/cli/import_.py
+++ b/src/mondo/cli/import_.py
@@ -89,9 +89,12 @@ def _build_header_to_column_id(
 
     Priority per header:
     1. Explicit entry in mapping['columns'] (raw header, then guard-stripped)
-    2. Case-insensitive title match against the board's columns — the exact
+    2. `Title (<colid>)` suffix, as written by `mondo export board` when a
+       title repeats or shadows a meta field — the id must exist on the board
+       (a leading formula guard can't reach the suffix, so raw suffices)
+    3. Case-insensitive title match against the board's columns — the exact
        header first, then the guard-stripped form
-    3. Ignore (header is dropped from the write)
+    4. Ignore (header is dropped from the write)
 
     The exact-first order means a real column title that itself starts with
     a guard-then-formula-lead (e.g. ``'-Priority``) round-trips: export
@@ -99,6 +102,7 @@ def _build_header_to_column_id(
     verbatim before trying the stripped ``-Priority``.
     """
     explicit = mapping.get("columns") or {}
+    col_ids = {c.get("id") for c in board_columns if c.get("id")}
     by_title = {c.get("title", "").casefold(): c.get("id") for c in board_columns if c.get("id")}
     resolved: dict[str, str] = {}
     for header in headers:
@@ -111,6 +115,11 @@ def _build_header_to_column_id(
         if stripped in explicit:
             resolved[header] = str(explicit[stripped])
             continue
+        if header.endswith(")"):
+            _, sep, rest = header.rpartition(" (")
+            if sep and rest[:-1] in col_ids:
+                resolved[header] = rest[:-1]
+                continue
         hit = by_title.get(header.casefold()) or by_title.get(stripped.casefold())
         if hit:
             resolved[header] = hit

--- a/src/mondo/columns/readonly.py
+++ b/src/mondo/columns/readonly.py
@@ -35,7 +35,7 @@ class MirrorCodec(_ReadOnly):
         # lives in `display_value` (MirrorValue inline fragment).
         display = entry.get("display_value")
         if display:
-            return display
+            return str(display)
         return entry.get("text") or ""
 
 
@@ -47,7 +47,7 @@ class FormulaCodec(_ReadOnly):
         # lives in `display_value` (FormulaValue inline fragment).
         display = entry.get("display_value")
         if display:
-            return display
+            return str(display)
         return entry.get("text") or ""
 
 

--- a/src/mondo/columns/relation.py
+++ b/src/mondo/columns/relation.py
@@ -73,10 +73,10 @@ class BoardRelationCodec(ColumnCodec):
         # (all from the BoardRelationValue inline fragment).
         display = entry.get("display_value")
         if display:
-            return display
+            return str(display)
         text = entry.get("text")
         if text:
-            return text
+            return str(text)
         linked = entry.get("linked_item_ids")
         if linked:
             return ", ".join(str(i) for i in linked)
@@ -101,10 +101,10 @@ class DependencyCodec(ColumnCodec):
         # the DependencyValue inline fragment). Mirrors BoardRelationCodec.
         display = entry.get("display_value")
         if display:
-            return display
+            return str(display)
         text = entry.get("text")
         if text:
-            return text
+            return str(text)
         linked = entry.get("linked_item_ids")
         if linked:
             return ", ".join(str(i) for i in linked)

--- a/src/mondo/util/sanitize.py
+++ b/src/mondo/util/sanitize.py
@@ -40,7 +40,7 @@ is controlled by anyone with board access. Two output surfaces guard it:
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Any, overload
 
 # Leading characters Excel & friends interpret as the start of a formula.
 _FORMULA_LEADS = ("=", "+", "-", "@", "\t", "\r")
@@ -61,6 +61,10 @@ _CONTROL_CHARS: dict[int, None] = {
 }
 
 
+@overload
+def guard_formula(value: str) -> str: ...
+@overload
+def guard_formula(value: Any) -> Any: ...
 def guard_formula(value: Any) -> Any:
     """Prefix formula-looking strings with ``'`` (spreadsheet text guard).
 

--- a/tests/unit/test_cli_import.py
+++ b/tests/unit/test_cli_import.py
@@ -327,6 +327,102 @@ class TestMapping:
         assert "status" in values
 
 
+class TestIdSuffixHeaders:
+    """Headers like `Notes (text1)` — written by `mondo export board` when a
+    column title repeats or shadows a meta field — resolve by the embedded id."""
+
+    @staticmethod
+    def _cols(columns: list[dict]) -> dict:
+        for c in columns:
+            c.setdefault("settings_str", "{}")
+            c.setdefault("archived", False)
+        return _ok({"boards": [{"id": "42", "name": "B", "columns": columns}]})
+
+    def test_duplicate_title_headers_resolve_by_id(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        src = tmp_path / "i.csv"
+        _write_csv(src, ["name,Notes (text1),Notes (text2)", "Alpha,first,second"])
+        cols = self._cols(
+            [
+                {"id": "text1", "title": "Notes", "type": "text"},
+                {"id": "text2", "title": "Notes", "type": "text"},
+            ]
+        )
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=cols)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_item": {"id": "1", "name": "Alpha"}}),
+        )
+        result = runner.invoke(app, ["import", "board", "--board", "42", "--from", str(src)])
+        assert result.exit_code == 0, result.stdout
+        body = json.loads(httpx_mock.get_requests()[1].content)
+        values = json.loads(body["variables"]["values"])
+        assert values["text1"] == "first"
+        assert values["text2"] == "second"
+
+    def test_meta_shadow_header_resolves_by_id(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        # A column literally titled "name" exports as "name (text9)".
+        src = tmp_path / "i.csv"
+        _write_csv(src, ["name,name (text9)", "Alpha,shadowed"])
+        cols = self._cols([{"id": "text9", "title": "name", "type": "text"}])
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=cols)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_item": {"id": "1", "name": "Alpha"}}),
+        )
+        result = runner.invoke(app, ["import", "board", "--board", "42", "--from", str(src)])
+        assert result.exit_code == 0, result.stdout
+        body = json.loads(httpx_mock.get_requests()[1].content)
+        assert body["variables"]["name"] == "Alpha"
+        values = json.loads(body["variables"]["values"])
+        assert values["text9"] == "shadowed"
+
+    def test_literal_paren_title_still_matches_by_title(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        # "(mm)" is not a column id on the board, so the header must fall
+        # through to the plain title match, not be dropped.
+        src = tmp_path / "i.csv"
+        _write_csv(src, ["name,Size (mm)", "Alpha,120"])
+        cols = self._cols([{"id": "text1", "title": "Size (mm)", "type": "text"}])
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=cols)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_item": {"id": "1", "name": "Alpha"}}),
+        )
+        result = runner.invoke(app, ["import", "board", "--board", "42", "--from", str(src)])
+        assert result.exit_code == 0, result.stdout
+        body = json.loads(httpx_mock.get_requests()[1].content)
+        values = json.loads(body["variables"]["values"])
+        assert values["text1"] == "120"
+
+    def test_export_labels_round_trip_to_import_resolution(self) -> None:
+        # The contract: whatever header `mondo export board` writes for a
+        # column, `mondo import board` must resolve back to that column's id.
+        from mondo.cli.export import _column_labels
+        from mondo.cli.import_ import _build_header_to_column_id
+
+        columns = [
+            {"id": "text1", "title": "Notes", "type": "text"},
+            {"id": "text2", "title": "Notes", "type": "text"},
+            {"id": "text9", "title": "name", "type": "text"},
+            {"id": "status", "title": "Status", "type": "status"},
+        ]
+        labels = _column_labels(columns)
+        resolved = _build_header_to_column_id(
+            headers=["name", *labels],
+            mapping={},
+            board_columns=columns,
+            name_col="name",
+            group_col="group",
+        )
+        assert [resolved[label] for label in labels] == [c["id"] for c in columns]
+
+
 class TestIdempotency:
     def test_skips_existing(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
         src = tmp_path / "i.csv"


### PR DESCRIPTION
## Summary
- `mondo export board` disambiguates duplicate or meta-shadowing column titles into CSV headers like `Notes (text1)` (`_column_labels` in `src/mondo/cli/export.py`), but `mondo import board` only matched headers against raw column titles or explicit `--mapping` entries — an export→import round-trip silently dropped all values for any column whose title repeats on the board or equals a meta field name (`id`/`name`/`state`/`group`). Pre-existing on main, confirmed during the July 2026 review of #98/#99/#101.
- `_build_header_to_column_id` now resolves a `Title (<colid>)` suffix directly when that column id exists on the target board. Priority: explicit mapping → id suffix → case-insensitive title match, so `--mapping` still overrides everything and literal titles containing parentheses (e.g. `Size (mm)`) still title-match.
- Unit tests: duplicate-title and meta-shadow CLI round-trips, the literal-paren-title guard, and a function-level contract test tying `_column_labels` output to import resolution.

Also includes a separate commit unblocking CI, which has been red on main since v1.11.0 (ruff SIM115 in the monday-api-watch snapshot script, two unformatted files, and seven mypy errors that CI never reached because it stops at the ruff step). All mechanical, no behavior change.

## Testing
- `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run pytest tests/unit` (1982 passed) — the full CI sequence, all green locally.