### PR TITLE
fix(security): CSV/xlsx/terminal export hardening (re-land of #99)

### DIFF
--- a/src/mondo/cli/export.py
+++ b/src/mondo/cli/export.py
@@ -9,7 +9,9 @@ every format is rendered client-side. Formats:
   don't execute them as formulas; `--no-sanitize-formulas` disables the guard
   and `mondo import board` strips it back off.
 - json: list of objects keyed by column id + metadata
-- xlsx: one styled sheet for items (+ one for subitems if --include-subitems)
+- xlsx: one styled sheet for items (+ one for subitems if --include-subitems).
+  "="-leading cells are written as text (not live formulas) unless
+  `--no-sanitize-formulas`; the value itself is unchanged.
 - md / html / pdf: human-readable; grouped per monday group by default
   (one section per group), or a single flat table with `--flat`. html reuses
   the doc stylesheet; pdf renders that HTML through WeasyPrint.
@@ -347,15 +349,27 @@ def _write_xlsx(
     subitems_rows: list[dict[str, Any]] | None,
     subitems_headers: list[str] | None,
     out_path: Path,
+    *,
+    sanitize: bool,
 ) -> None:
     from openpyxl import Workbook  # type: ignore[import-untyped]
     from openpyxl.styles import Font  # type: ignore[import-untyped]
     from openpyxl.utils import get_column_letter  # type: ignore[import-untyped]
 
+    def append_row(ws: Any, values: list[Any]) -> None:
+        ws.append(values)
+        if sanitize:
+            # openpyxl stores "="-leading strings as live formulas; board
+            # data must stay text, so downgrade those cells back to strings
+            # (value is unchanged — Excel just shows it verbatim).
+            for cell in ws[ws.max_row]:
+                if cell.data_type == "f":
+                    cell.data_type = "s"
+
     def fill_sheet(ws: Any, headers: list[str], rows: list[dict[str, Any]]) -> None:
-        ws.append(headers)
+        append_row(ws, headers)
         for row in rows:
-            ws.append([row.get(h, "") for h in headers])
+            append_row(ws, [row.get(h, "") for h in headers])
         for cell in ws[1]:
             cell.font = Font(bold=True)
         ws.freeze_panes = "A2"
@@ -434,8 +448,9 @@ def board_cmd(
         True,
         "--sanitize-formulas/--no-sanitize-formulas",
         help="csv/tsv: prefix cells starting with = + - @ (or tab/CR) with a "
-        "single quote so spreadsheets don't execute them as formulas. "
-        "`mondo import board` strips the prefix back off on re-import.",
+        "single quote so spreadsheets don't execute them as formulas "
+        "(`mondo import board` strips the prefix back off on re-import). "
+        'xlsx: store "="-leading cells as text instead of live formulas.',
     ),
     limit: int = typer.Option(MAX_PAGE_SIZE, "--limit", help=f"Page size (max {MAX_PAGE_SIZE})."),
     max_items: int | None = typer.Option(
@@ -553,7 +568,14 @@ def _dispatch(
     item_headers = [*META_FIELDS, *col_labels]
     if fmt is ExportFormat.xlsx:
         assert out is not None
-        _write_xlsx(item_rows, item_headers, subitem_rows, subitem_headers, out)
+        _write_xlsx(
+            item_rows,
+            item_headers,
+            subitem_rows,
+            subitem_headers,
+            out,
+            sanitize=sanitize_formulas,
+        )
         return
 
     if fmt is ExportFormat.pdf:

--- a/src/mondo/cli/export.py
+++ b/src/mondo/cli/export.py
@@ -244,7 +244,11 @@ def _write_json(payload: Any, stream: Any) -> None:
 
 def _md_table(rows: list[dict[str, Any]], headers: list[str], stream: Any) -> None:
     def esc(v: Any) -> str:
-        return str(v if v is not None else "").replace("|", "\\|").replace("\n", " ")
+        # HTML-escape first: board data is untrusted and many markdown
+        # renderers (pandoc, most SSGs) pass raw HTML through, so an
+        # unescaped `<img onerror=...>`/`<script>` would execute.
+        text = html.escape(str(v if v is not None else ""))
+        return text.replace("|", "\\|").replace("\n", " ")
 
     stream.write("| " + " | ".join(esc(h) for h in headers) + " |\n")
     stream.write("|" + "|".join(["---"] * len(headers)) + "|\n")
@@ -262,13 +266,15 @@ def _write_markdown(
     flat: bool,
     stream: Any,
 ) -> None:
-    stream.write(f"# {board_name}\n\n")
+    # Board/group titles are untrusted board data; escape HTML so raw-HTML
+    # renderers can't execute smuggled markup (see _md_table).
+    stream.write(f"# {html.escape(board_name)}\n\n")
     if flat:
         _md_table(item_rows, [*META_FIELDS, *col_labels], stream)
     else:
         headers = ["id", "name", "state", *col_labels]
         for title, group_rows in _group_rows(item_rows, group_keys):
-            stream.write(f"## {title}\n\n")
+            stream.write(f"## {html.escape(title)}\n\n")
             _md_table(group_rows, headers, stream)
             stream.write("\n")
     if subitem_rows is not None and subitem_headers is not None:
@@ -356,20 +362,23 @@ def _write_xlsx(
     from openpyxl.styles import Font  # type: ignore[import-untyped]
     from openpyxl.utils import get_column_letter  # type: ignore[import-untyped]
 
-    def append_row(ws: Any, values: list[Any]) -> None:
+    def append_row(ws: Any, row_idx: int, values: list[Any]) -> None:
         ws.append(values)
         if sanitize:
-            # openpyxl stores "="-leading strings as live formulas; board
-            # data must stay text, so downgrade those cells back to strings
-            # (value is unchanged — Excel just shows it verbatim).
-            for cell in ws[ws.max_row]:
-                if cell.data_type == "f":
-                    cell.data_type = "s"
+            # openpyxl stores "="-leading strings as live formulas (cell.py
+            # sets data_type "f" for `len>1` "="-leading strs); board data
+            # must stay text, so downgrade just those cells back to strings
+            # (value unchanged — Excel shows it verbatim). Address them by
+            # (row, col) using the row index we track: `ws.max_row` rescans
+            # every written cell, making the whole export O(rows^2 * cols).
+            for col_idx, value in enumerate(values, start=1):
+                if isinstance(value, str) and value.startswith("=") and len(value) > 1:
+                    ws.cell(row=row_idx, column=col_idx).data_type = "s"
 
     def fill_sheet(ws: Any, headers: list[str], rows: list[dict[str, Any]]) -> None:
-        append_row(ws, headers)
-        for row in rows:
-            append_row(ws, [row.get(h, "") for h in headers])
+        append_row(ws, 1, headers)
+        for row_idx, row in enumerate(rows, start=2):
+            append_row(ws, row_idx, [row.get(h, "") for h in headers])
         for cell in ws[1]:
             cell.font = Font(bold=True)
         ws.freeze_panes = "A2"
@@ -449,7 +458,8 @@ def board_cmd(
         "--sanitize-formulas/--no-sanitize-formulas",
         help="csv/tsv: prefix cells starting with = + - @ (or tab/CR) with a "
         "single quote so spreadsheets don't execute them as formulas "
-        "(`mondo import board` strips the prefix back off on re-import). "
+        "(plain numbers like -12 keep their sign; `mondo import board` strips "
+        "the prefix back off on re-import). "
         'xlsx: store "="-leading cells as text instead of live formulas.',
     ),
     limit: int = typer.Option(MAX_PAGE_SIZE, "--limit", help=f"Page size (max {MAX_PAGE_SIZE})."),

--- a/src/mondo/cli/export.py
+++ b/src/mondo/cli/export.py
@@ -4,7 +4,10 @@ Uses cursor pagination (reused from `item list`) plus a one-shot column-title
 fetch for readable headers. monday's API has no native board-export endpoint —
 every format is rendered client-side. Formats:
 
-- csv / tsv: RFC 4180, one row per item, columns = meta + one-per-board-column
+- csv / tsv: RFC 4180, one row per item, columns = meta + one-per-board-column.
+  Cells starting with = + - @ (or tab/CR) get a `'` prefix so spreadsheets
+  don't execute them as formulas; `--no-sanitize-formulas` disables the guard
+  and `mondo import board` strips it back off.
 - json: list of objects keyed by column id + metadata
 - xlsx: one styled sheet for items (+ one for subitems if --include-subitems)
 - md / html / pdf: human-readable; grouped per monday group by default
@@ -42,6 +45,7 @@ from mondo.docs import _HTML_STYLE
 from mondo.domain.column_cache import fetch_board_columns
 from mondo.domain.resolve import resolve_required_id
 from mondo.services.items import build_query_params, split_filter_expr
+from mondo.util.sanitize import guard_formula
 
 if TYPE_CHECKING:
     from mondo.api.client import MondayClient
@@ -203,7 +207,14 @@ def _subitem_row(
 # ----- format writers -----
 
 
-def _write_csv(rows: list[dict[str, Any]], headers: list[str], delimiter: str, stream: Any) -> None:
+def _write_csv(
+    rows: list[dict[str, Any]],
+    headers: list[str],
+    delimiter: str,
+    stream: Any,
+    *,
+    sanitize: bool,
+) -> None:
     writer = csv.DictWriter(
         stream,
         fieldnames=headers,
@@ -212,9 +223,16 @@ def _write_csv(rows: list[dict[str, Any]], headers: list[str], delimiter: str, s
         lineterminator="\n",
         extrasaction="ignore",
     )
-    writer.writeheader()
+
+    def cell(value: Any) -> Any:
+        # Board data (item names, column text, column titles) is controlled
+        # by anyone with board access — guard formula-looking cells so
+        # opening the export in a spreadsheet can't execute them.
+        return guard_formula(value) if sanitize else value
+
+    writer.writerow({h: cell(h) for h in headers})
     for row in rows:
-        writer.writerow({h: row.get(h, "") for h in headers})
+        writer.writerow({h: cell(row.get(h, "")) for h in headers})
 
 
 def _write_json(payload: Any, stream: Any) -> None:
@@ -412,6 +430,13 @@ def board_cmd(
     include_subitems: bool = typer.Option(
         False, "--include-subitems", help="Also export each item's subitems."
     ),
+    sanitize_formulas: bool = typer.Option(
+        True,
+        "--sanitize-formulas/--no-sanitize-formulas",
+        help="csv/tsv: prefix cells starting with = + - @ (or tab/CR) with a "
+        "single quote so spreadsheets don't execute them as formulas. "
+        "`mondo import board` strips the prefix back off on re-import.",
+    ),
     limit: int = typer.Option(MAX_PAGE_SIZE, "--limit", help=f"Page size (max {MAX_PAGE_SIZE})."),
     max_items: int | None = typer.Option(
         None, "--max-items", help="Stop after this many items total."
@@ -509,6 +534,7 @@ def board_cmd(
         board_name,
         flat,
         out,
+        sanitize_formulas,
     )
 
 
@@ -522,6 +548,7 @@ def _dispatch(
     board_name: str,
     flat: bool,
     out: Path | None,
+    sanitize_formulas: bool,
 ) -> None:
     item_headers = [*META_FIELDS, *col_labels]
     if fmt is ExportFormat.xlsx:
@@ -545,10 +572,10 @@ def _dispatch(
     try:
         if fmt in (ExportFormat.csv, ExportFormat.tsv):
             delim = "," if fmt is ExportFormat.csv else "\t"
-            _write_csv(item_rows, item_headers, delim, buf)
+            _write_csv(item_rows, item_headers, delim, buf, sanitize=sanitize_formulas)
             if subitem_rows is not None and subitem_headers is not None:
                 buf.write("\n")
-                _write_csv(subitem_rows, subitem_headers, delim, buf)
+                _write_csv(subitem_rows, subitem_headers, delim, buf, sanitize=sanitize_formulas)
         elif fmt is ExportFormat.json:
             payload: dict[str, Any] = {"items": item_rows}
             if subitem_rows is not None:

--- a/src/mondo/cli/import_.py
+++ b/src/mondo/cli/import_.py
@@ -12,6 +12,10 @@ Row flow per CSV line:
 4. Optional `--idempotency-name` pre-fetches existing item names on the
    board; rows whose name already exists are skipped without a mutation.
 
+Names, cell values, and header matching strip the `'` formula guard that
+`mondo export board` prefixes onto formula-looking cells (`'=x` → `=x`),
+keeping the export → import round-trip lossless.
+
 This command emits one result object per row, and a tailing summary.
 """
 
@@ -39,6 +43,7 @@ from mondo.cli._exec import (
 from mondo.cli.context import GlobalOpts
 from mondo.domain.column_cache import fetch_board_columns, invalidate_columns_cache
 from mondo.domain.resolve import resolve_required_id
+from mondo.util.sanitize import strip_formula_guard
 
 if TYPE_CHECKING:
     from mondo.api.client import MondayClient
@@ -98,7 +103,7 @@ def _build_header_to_column_id(
         if header in explicit:
             resolved[header] = str(explicit[header])
             continue
-        hit = by_title.get(header.casefold())
+        hit = by_title.get(strip_formula_guard(header).casefold())
         if hit:
             resolved[header] = hit
     return resolved
@@ -154,6 +159,7 @@ def _encode_row(
     for header, raw in row_values.items():
         if raw == "" or raw is None:
             continue
+        raw = strip_formula_guard(raw)
         col_id = header_to_col_id.get(header)
         if col_id is None:
             continue
@@ -256,7 +262,7 @@ def board_cmd(
                 existing_names = _fetch_existing_names(client, board_id)
 
             for row in reader:
-                name = (row.get(name_col) or "").strip()
+                name = strip_formula_guard((row.get(name_col) or "").strip())
                 if not name:
                     results.append({"status": "failed", "error": "empty name", "row": row})
                     failed += 1

--- a/src/mondo/cli/import_.py
+++ b/src/mondo/cli/import_.py
@@ -90,9 +90,15 @@ def _build_header_to_column_id(
     """Return {csv_header: monday_column_id} for header → column resolution.
 
     Priority per header:
-    1. Explicit entry in mapping['columns']
-    2. Case-insensitive title match against the board's columns
+    1. Explicit entry in mapping['columns'] (raw header, then guard-stripped)
+    2. Case-insensitive title match against the board's columns — the exact
+       header first, then the guard-stripped form
     3. Ignore (header is dropped from the write)
+
+    The exact-first order means a real column title that itself starts with
+    a guard-then-formula-lead (e.g. ``'-Priority``) round-trips: export
+    leaves an already-``'``-leading title verbatim, so import must match it
+    verbatim before trying the stripped ``-Priority``.
     """
     explicit = mapping.get("columns") or {}
     by_title = {c.get("title", "").casefold(): c.get("id") for c in board_columns if c.get("id")}
@@ -100,10 +106,14 @@ def _build_header_to_column_id(
     for header in headers:
         if header in {name_col, group_col, "id", "state"}:
             continue
+        stripped = strip_formula_guard(header)
         if header in explicit:
             resolved[header] = str(explicit[header])
             continue
-        hit = by_title.get(strip_formula_guard(header).casefold())
+        if stripped in explicit:
+            resolved[header] = str(explicit[stripped])
+            continue
+        hit = by_title.get(header.casefold()) or by_title.get(stripped.casefold())
         if hit:
             resolved[header] = hit
     return resolved
@@ -287,7 +297,7 @@ def board_cmd(
                     failed += 1
                     continue
 
-                group_id = (row.get(group_col) or "").strip() or default_group
+                group_id = strip_formula_guard((row.get(group_col) or "").strip()) or default_group
                 variables = {
                     "board": board_id,
                     "name": name,

--- a/src/mondo/output/csv_.py
+++ b/src/mondo/output/csv_.py
@@ -6,14 +6,21 @@ import csv
 import json
 from typing import Any, TextIO
 
+from mondo.util.sanitize import guard_formula
+
 
 def _stringify(value: Any) -> str:
-    """Encode a non-scalar value as JSON; leave scalars alone."""
+    """Encode a non-scalar value as JSON; leave scalars alone.
+
+    monday data is untrusted, so formula-looking cells get the ``'`` guard
+    (see ``mondo.util.sanitize``) — a spreadsheet opening the CSV won't
+    execute them.
+    """
     if value is None:
         return ""
     if isinstance(value, (str, int, float, bool)):
-        return str(value)
-    return json.dumps(value, ensure_ascii=False)
+        return guard_formula(str(value))
+    return guard_formula(json.dumps(value, ensure_ascii=False))
 
 
 def _write_rows(stream: TextIO, rows: list[dict[str, Any]]) -> None:
@@ -26,7 +33,7 @@ def _write_rows(stream: TextIO, rows: list[dict[str, Any]]) -> None:
             seen.setdefault(k, None)
     columns = list(seen)
     writer = csv.writer(stream)
-    writer.writerow(columns)
+    writer.writerow([guard_formula(c) for c in columns])
     for row in rows:
         writer.writerow([_stringify(row.get(col)) for col in columns])
 
@@ -48,7 +55,7 @@ def render(data: Any, stream: TextIO, tty: bool) -> None:
         writer = csv.writer(stream)
         writer.writerow(["key", "value"])
         for k, v in data.items():
-            writer.writerow([str(k), _stringify(v)])
+            writer.writerow([guard_formula(str(k)), _stringify(v)])
         return
 
     # Scalar

--- a/src/mondo/output/table.py
+++ b/src/mondo/output/table.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from typing import Any, TextIO
 
+from mondo.util.sanitize import strip_terminal_controls
+
 _SCALAR_TYPES = (str, int, float, bool, type(None))
 
 
@@ -20,7 +22,11 @@ def _render_cell(value: Any) -> str:
         return ""
     if isinstance(value, bool):
         return "true" if value else "false"
-    if isinstance(value, (int, float, str)):
+    if isinstance(value, str):
+        # API-controlled strings can smuggle ANSI/control escape sequences
+        # into the terminal; strip C0/C1 controls (keeping \n and \t).
+        return strip_terminal_controls(value)
+    if isinstance(value, (int, float)):
         return str(value)
     if isinstance(value, list):
         return f"<list:{len(value)}>"
@@ -51,6 +57,9 @@ def render(data: Any, stream: TextIO, tty: bool) -> None:
         force_terminal=tty,
         no_color=not tty,
         highlight=False,
+        # Cell data is untrusted API output — never interpret it as Rich
+        # markup (e.g. [link=...] would emit terminal escape sequences).
+        markup=False,
         width=None if tty else 200,
     )
 
@@ -62,7 +71,7 @@ def render(data: Any, stream: TextIO, tty: bool) -> None:
             columns = _ordered_columns(data)
             table = Table(show_header=True, header_style="bold cyan")
             for col in columns:
-                table.add_column(col)
+                table.add_column(strip_terminal_controls(col))
             for row in data:
                 table.add_row(*(_render_cell(row.get(col)) for col in columns))
             console.print(table)
@@ -80,7 +89,7 @@ def render(data: Any, stream: TextIO, tty: bool) -> None:
         table.add_column(style="cyan")
         table.add_column()
         for k, v in data.items():
-            table.add_row(str(k), _render_cell(v))
+            table.add_row(strip_terminal_controls(str(k)), _render_cell(v))
         console.print(table)
         return
 

--- a/src/mondo/output/tsv.py
+++ b/src/mondo/output/tsv.py
@@ -6,13 +6,17 @@ import csv
 import json
 from typing import Any, TextIO
 
+from mondo.util.sanitize import guard_formula
+
 
 def _stringify(value: Any) -> str:
+    # monday data is untrusted: guard formula-looking cells so a spreadsheet
+    # opening the TSV won't execute them (see mondo.util.sanitize).
     if value is None:
         return ""
     if isinstance(value, (str, int, float, bool)):
-        return str(value)
-    return json.dumps(value, ensure_ascii=False)
+        return guard_formula(str(value))
+    return guard_formula(json.dumps(value, ensure_ascii=False))
 
 
 def render(data: Any, stream: TextIO, tty: bool) -> None:
@@ -26,7 +30,7 @@ def render(data: Any, stream: TextIO, tty: bool) -> None:
                 for k in row:
                     seen.setdefault(k, None)
             columns = list(seen)
-            writer.writerow(columns)
+            writer.writerow([guard_formula(c) for c in columns])
             for row in data:
                 writer.writerow([_stringify(row.get(col)) for col in columns])
             return
@@ -38,7 +42,7 @@ def render(data: Any, stream: TextIO, tty: bool) -> None:
     if isinstance(data, dict):
         writer.writerow(["key", "value"])
         for k, v in data.items():
-            writer.writerow([str(k), _stringify(v)])
+            writer.writerow([guard_formula(str(k)), _stringify(v)])
         return
 
     writer.writerow(["value"])

--- a/src/mondo/util/sanitize.py
+++ b/src/mondo/util/sanitize.py
@@ -8,9 +8,23 @@ is controlled by anyone with board access. Two output surfaces guard it:
   injection). ``guard_formula`` prefixes them with a single quote — the
   spreadsheet convention for "treat as text" — and
   ``strip_formula_guard`` removes exactly that prefix on import, so the
-  ``mondo export`` → ``mondo import`` round-trip is lossless. (Corner
-  case: a value that itself starts with ``'=`` loses its apostrophe on
-  re-import; accepted for the simplicity of the conditional guard.)
+  ``mondo export`` → ``mondo import`` round-trip is lossless.
+
+  Plain-number exemption: a value that is only an optional ``+``/``-``
+  sign followed by digits/dots/commas (e.g. ``-1250``, ``+491234``,
+  ``1.234,50``) can't execute anything in a spreadsheet, so it is left
+  unguarded — otherwise every negative or plus-leading number would
+  become text and silently break ``=SUM()`` and numeric parsing in
+  pandas/DB loads. Anything with an operator or letter after the sign
+  (``-2+3``, ``-1e5``, ``+cmd|...``) is still guarded.
+
+  Corner cases (both accepted for the simplicity of the conditional
+  guard): a value that itself starts with ``'=`` loses its apostrophe on
+  re-import; and a hand-authored CSV whose cell is a literal ``'``
+  followed by a formula lead (``'=x``) is treated as a guard and loses
+  the apostrophe on import (``mondo export`` never emits such a cell —
+  it only guards non-``'``-leading values — so the round-trip it
+  produces is unaffected).
 - Terminal display (table output): raw C0/C1 control bytes (ESC, CSI,
   OSC, ...) in a value can inject escape sequences into the user's
   terminal. ``strip_terminal_controls`` drops them, keeping newline
@@ -19,10 +33,15 @@ is controlled by anyone with board access. Two output surfaces guard it:
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 # Leading characters Excel & friends interpret as the start of a formula.
 _FORMULA_LEADS = ("=", "+", "-", "@", "\t", "\r")
+
+# Plain numbers (optional sign, then only digits/dots/commas) can't execute
+# in a spreadsheet, so they stay unguarded — see the module docstring.
+_PLAIN_NUMBER = re.compile(r"^[+-]?\d[\d.,]*$")
 
 # C0 controls (minus \t and \n), DEL, and C1 controls.
 _CONTROL_CHARS: dict[int, None] = {
@@ -31,8 +50,16 @@ _CONTROL_CHARS: dict[int, None] = {
 
 
 def guard_formula(value: Any) -> Any:
-    """Prefix formula-looking strings with ``'`` (spreadsheet text guard)."""
-    if isinstance(value, str) and value.startswith(_FORMULA_LEADS):
+    """Prefix formula-looking strings with ``'`` (spreadsheet text guard).
+
+    Plain numbers (``-1250``, ``+491234``) are exempt so exports stay
+    numeric; see the module docstring.
+    """
+    if (
+        isinstance(value, str)
+        and value.startswith(_FORMULA_LEADS)
+        and not _PLAIN_NUMBER.match(value)
+    ):
         return "'" + value
     return value
 

--- a/src/mondo/util/sanitize.py
+++ b/src/mondo/util/sanitize.py
@@ -1,0 +1,49 @@
+"""Sanitizers for untrusted, API-controlled strings.
+
+monday.com data (item names, column text, mirror/formula display_value)
+is controlled by anyone with board access. Two output surfaces guard it:
+
+- CSV/TSV export opened in Excel / Google Sheets / LibreOffice: cells
+  starting with ``= + - @`` (or tab/CR) are evaluated as formulas (CSV
+  injection). ``guard_formula`` prefixes them with a single quote — the
+  spreadsheet convention for "treat as text" — and
+  ``strip_formula_guard`` removes exactly that prefix on import, so the
+  ``mondo export`` → ``mondo import`` round-trip is lossless. (Corner
+  case: a value that itself starts with ``'=`` loses its apostrophe on
+  re-import; accepted for the simplicity of the conditional guard.)
+- Terminal display (table output): raw C0/C1 control bytes (ESC, CSI,
+  OSC, ...) in a value can inject escape sequences into the user's
+  terminal. ``strip_terminal_controls`` drops them, keeping newline
+  and tab.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Leading characters Excel & friends interpret as the start of a formula.
+_FORMULA_LEADS = ("=", "+", "-", "@", "\t", "\r")
+
+# C0 controls (minus \t and \n), DEL, and C1 controls.
+_CONTROL_CHARS: dict[int, None] = {
+    c: None for c in (*range(0x00, 0x20), 0x7F, *range(0x80, 0xA0)) if c not in (0x09, 0x0A)
+}
+
+
+def guard_formula(value: Any) -> Any:
+    """Prefix formula-looking strings with ``'`` (spreadsheet text guard)."""
+    if isinstance(value, str) and value.startswith(_FORMULA_LEADS):
+        return "'" + value
+    return value
+
+
+def strip_formula_guard(value: str) -> str:
+    """Undo ``guard_formula``: drop a ``'`` that guards a formula lead."""
+    if value.startswith("'") and value[1:].startswith(_FORMULA_LEADS):
+        return value[1:]
+    return value
+
+
+def strip_terminal_controls(text: str) -> str:
+    """Remove C0/C1 control characters (except newline and tab)."""
+    return text.translate(_CONTROL_CHARS)

--- a/src/mondo/util/sanitize.py
+++ b/src/mondo/util/sanitize.py
@@ -11,12 +11,18 @@ is controlled by anyone with board access. Two output surfaces guard it:
   ``mondo export`` → ``mondo import`` round-trip is lossless.
 
   Plain-number exemption: a value that is only an optional ``+``/``-``
-  sign followed by digits/dots/commas (e.g. ``-1250``, ``+491234``,
-  ``1.234,50``) can't execute anything in a spreadsheet, so it is left
-  unguarded — otherwise every negative or plus-leading number would
-  become text and silently break ``=SUM()`` and numeric parsing in
-  pandas/DB loads. Anything with an operator or letter after the sign
-  (``-2+3``, ``-1e5``, ``+cmd|...``) is still guarded.
+  sign followed by digit groups joined by single ``.``/``,`` separators
+  (e.g. ``-1250``, ``+491234``, ``1.234,50``) can't execute anything in
+  a spreadsheet, so it is left unguarded — otherwise every negative or
+  plus-leading number would become text and silently break ``=SUM()``
+  and numeric parsing in pandas/DB loads. Anything with an operator or
+  letter after the sign (``-2+3``, ``-1e5``, ``+cmd|...``) or with
+  adjacent/trailing separators (``-1,,2``, ``+5.``) is still guarded —
+  only digit groups joined by single separators qualify, and digits,
+  dots, and commas alone cannot form an executable formula. Leading
+  U+FEFF chars are looked past when classifying: at file start the BOM
+  is eaten as the encoding signature, so ``\\ufeff=x`` must be guarded
+  like ``=x``.
 
   Corner cases (both accepted for the simplicity of the conditional
   guard): a value that itself starts with ``'=`` loses its apostrophe on
@@ -39,9 +45,15 @@ from typing import Any
 # Leading characters Excel & friends interpret as the start of a formula.
 _FORMULA_LEADS = ("=", "+", "-", "@", "\t", "\r")
 
-# Plain numbers (optional sign, then only digits/dots/commas) can't execute
-# in a spreadsheet, so they stay unguarded — see the module docstring.
-_PLAIN_NUMBER = re.compile(r"^[+-]?\d[\d.,]*$")
+# U+FEFF (BOM / zero-width no-break space): when a cell opens the file, the
+# BOM bytes are eaten as the encoding signature and the cell then starts
+# with the char after it — so look past BOMs when deciding to guard.
+_BOM = "\ufeff"
+
+# Plain numbers (optional sign, digit groups joined by single ./ ,
+# separators — ``-1250``, ``+49123``, ``1.234,50``) can't execute in a
+# spreadsheet, so they stay unguarded — see the module docstring.
+_PLAIN_NUMBER = re.compile(r"^[+-]?\d+([.,]\d+)*$")
 
 # C0 controls (minus \t and \n), DEL, and C1 controls.
 _CONTROL_CHARS: dict[int, None] = {
@@ -55,18 +67,17 @@ def guard_formula(value: Any) -> Any:
     Plain numbers (``-1250``, ``+491234``) are exempt so exports stay
     numeric; see the module docstring.
     """
-    if (
-        isinstance(value, str)
-        and value.startswith(_FORMULA_LEADS)
-        and not _PLAIN_NUMBER.match(value)
-    ):
+    if not isinstance(value, str):
+        return value
+    lead = value.lstrip(_BOM)
+    if lead.startswith(_FORMULA_LEADS) and not _PLAIN_NUMBER.match(lead):
         return "'" + value
     return value
 
 
 def strip_formula_guard(value: str) -> str:
     """Undo ``guard_formula``: drop a ``'`` that guards a formula lead."""
-    if value.startswith("'") and value[1:].startswith(_FORMULA_LEADS):
+    if value.startswith("'") and value[1:].lstrip(_BOM).startswith(_FORMULA_LEADS):
         return value[1:]
     return value
 

--- a/tests/unit/test_cli_export.py
+++ b/tests/unit/test_cli_export.py
@@ -194,6 +194,48 @@ class TestFormulaGuard:
         assert rows[1][1] == "=2+2"
         assert rows[1][4] == "+SUM(A1)"
 
+    def test_xlsx_stores_formula_cells_as_text(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        self._mock(httpx_mock)
+        out = tmp_path / "board.xlsx"
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "xlsx", "--out", str(out)],
+        )
+        assert result.exit_code == 0, result.stdout
+        ws = load_workbook(out)["items"]
+        # "="-leading cells keep their exact value but are plain text, not
+        # live formulas (no apostrophe prefix — that's the csv guard).
+        assert ws["B2"].value == "=2+2"
+        assert ws["B2"].data_type != "f"
+        assert ws["E1"].value == "=Evil"
+        assert ws["E1"].data_type != "f"
+        # "+"-leading strings were never formulas in xlsx; untouched.
+        assert ws["E2"].value == "+SUM(A1)"
+        assert ws["E2"].data_type != "f"
+
+    def test_xlsx_no_sanitize_keeps_live_formula(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        self._mock(httpx_mock)
+        out = tmp_path / "board.xlsx"
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                "board",
+                "--board",
+                "42",
+                "-f",
+                "xlsx",
+                "--out",
+                str(out),
+                "--no-sanitize-formulas",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        ws = load_workbook(out)["items"]
+        assert ws["B2"].data_type == "f"
+
     def test_json_export_is_not_guarded(self, httpx_mock: HTTPXMock) -> None:
         self._mock(httpx_mock)
         result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "json"])

--- a/tests/unit/test_cli_export.py
+++ b/tests/unit/test_cli_export.py
@@ -244,6 +244,41 @@ class TestFormulaGuard:
         assert parsed["items"][0]["name"] == "=2+2"
         assert parsed["items"][0]["=Evil"] == "+SUM(A1)"
 
+    def test_csv_leaves_plain_numbers_unguarded(self, httpx_mock: HTTPXMock) -> None:
+        # A "-"/"+"-leading plain number can't execute as a formula, so it
+        # must export verbatim — else =SUM()/pandas break on negatives.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=self.EVIL_COLS)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "Item", {"t1": "-1250"})]),
+        )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "csv"])
+        assert result.exit_code == 0, result.stdout
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[1][4] == "-1250"
+
+    def test_xlsx_non_formula_row_untouched(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        # A plain (non-"="-leading) row keeps openpyxl's inferred types after
+        # the sanitize rewrite — only "="-leading string cells are downgraded.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=self.EVIL_COLS)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "Plain", {"t1": "hello"})]),
+        )
+        out = tmp_path / "board.xlsx"
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "xlsx", "--out", str(out)],
+        )
+        assert result.exit_code == 0, result.stdout
+        ws = load_workbook(out)["items"]
+        assert ws["B2"].value == "Plain"
+        assert ws["B2"].data_type == "s"
+        assert ws["E2"].value == "hello"
+        assert ws["E2"].data_type == "s"
+
 
 class TestJsonExport:
     def test_shape(self, httpx_mock: HTTPXMock) -> None:
@@ -371,6 +406,23 @@ class TestMarkdownExport:
         assert result.exit_code == 0, result.stdout
         # A pipe in a column title must be escaped so the GFM table stays aligned.
         assert "Cost \\| EUR" in result.stdout
+
+    def test_escapes_html_in_cells_and_titles(self, httpx_mock: HTTPXMock) -> None:
+        # Board data is untrusted; raw-HTML renderers (pandoc, most SSGs)
+        # would execute smuggled markup, so cells + titles are HTML-escaped.
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=_board_name("A & B"))
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page([_item("1", "<script>x</script>", {"status": "Done"})]),
+        )
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "md", "--flat"])
+        assert result.exit_code == 0, result.stdout
+        out = result.stdout
+        assert "<script>" not in out
+        assert "&lt;script&gt;x&lt;/script&gt;" in out
+        assert "# A &amp; B" in out
 
 
 class TestHtmlExport:

--- a/tests/unit/test_cli_export.py
+++ b/tests/unit/test_cli_export.py
@@ -142,6 +142,67 @@ class TestCsvExport:
         assert "id,name,state,group,Status,Due" in content
 
 
+class TestFormulaGuard:
+    EVIL_COLS = _ok(
+        {
+            "boards": [
+                {
+                    "id": "42",
+                    "name": "B",
+                    "columns": [
+                        {"id": "t1", "title": "=Evil", "type": "text", "archived": False},
+                    ],
+                }
+            ]
+        }
+    )
+
+    def _mock(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=self.EVIL_COLS)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_items_page(
+                [
+                    _item("1", "=2+2", {"t1": "+SUM(A1)"}),
+                    _item("2", "Safe", {"t1": "a=b"}),
+                ]
+            ),
+        )
+
+    def test_csv_guards_formula_cells_and_headers(self, httpx_mock: HTTPXMock) -> None:
+        self._mock(httpx_mock)
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "csv"])
+        assert result.exit_code == 0, result.stdout
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[0] == ["id", "name", "state", "group", "'=Evil"]
+        assert rows[1][1] == "'=2+2"
+        assert rows[1][4] == "'+SUM(A1)"
+        # Non-leading formula chars stay untouched.
+        assert rows[2][1] == "Safe"
+        assert rows[2][4] == "a=b"
+
+    def test_no_sanitize_formulas_flag(self, httpx_mock: HTTPXMock) -> None:
+        self._mock(httpx_mock)
+        result = runner.invoke(
+            app,
+            ["export", "board", "--board", "42", "-f", "csv", "--no-sanitize-formulas"],
+        )
+        assert result.exit_code == 0, result.stdout
+        rows = list(csv.reader(io.StringIO(result.stdout)))
+        assert rows[0][4] == "=Evil"
+        assert rows[1][1] == "=2+2"
+        assert rows[1][4] == "+SUM(A1)"
+
+    def test_json_export_is_not_guarded(self, httpx_mock: HTTPXMock) -> None:
+        self._mock(httpx_mock)
+        result = runner.invoke(app, ["export", "board", "--board", "42", "-f", "json"])
+        assert result.exit_code == 0, result.stdout
+        parsed = json.loads(result.stdout)
+        assert parsed["items"][0]["name"] == "=2+2"
+        assert parsed["items"][0]["=Evil"] == "+SUM(A1)"
+
+
 class TestJsonExport:
     def test_shape(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)

--- a/tests/unit/test_cli_import.py
+++ b/tests/unit/test_cli_import.py
@@ -158,6 +158,42 @@ class TestFormulaGuardStrip:
         assert body["variables"]["name"] == "=EvilName"
         assert json.loads(body["variables"]["values"]) == {"t1": "+SUM(A1)"}
 
+    def test_apostrophe_lead_title_round_trips(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        """A real title that itself starts with '-lead exports verbatim and
+        must match the EXACT header first (stripping it would miss)."""
+        cols = _ok(
+            {
+                "boards": [
+                    {
+                        "id": "42",
+                        "name": "B",
+                        "columns": [
+                            {
+                                "id": "t1",
+                                "title": "'-Priority",
+                                "type": "text",
+                                "settings_str": "{}",
+                                "archived": False,
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        src = tmp_path / "i.csv"
+        # Export left the already-'-leading title verbatim; import must match it.
+        _write_csv(src, ["name,'-Priority", "Alpha,high"])
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=cols)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_item": {"id": "1", "name": "Alpha"}}),
+        )
+        result = runner.invoke(app, ["import", "board", "--board", "42", "--from", str(src)])
+        assert result.exit_code == 0, result.stdout
+        body = json.loads(httpx_mock.get_requests()[1].content)
+        assert json.loads(body["variables"]["values"]) == {"t1": "high"}
+
 
 class TestMapping:
     def test_explicit_mapping(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
@@ -194,6 +230,27 @@ class TestMapping:
         body = json.loads(httpx_mock.get_requests()[1].content)
         values = json.loads(body["variables"]["values"])
         assert "status" in values and "date4" in values
+
+    def test_mapping_honors_formula_lead_title(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        """A mapping keyed on the raw (formula-lead) title is honored even
+        though export guarded the CSV header (`=Total` → `'=Total`)."""
+        src = tmp_path / "i.csv"
+        _write_csv(src, ["name,'=Total", "Alpha,42"])
+        mapping = tmp_path / "map.yaml"
+        mapping.write_text("columns:\n  '=Total': status\n", encoding="utf-8")
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_item": {"id": "1", "name": "Alpha"}}),
+        )
+        result = runner.invoke(
+            app,
+            ["import", "board", "--board", "42", "--from", str(src), "--mapping", str(mapping)],
+        )
+        assert result.exit_code == 0, result.stdout
+        body = json.loads(httpx_mock.get_requests()[1].content)
+        assert "status" in json.loads(body["variables"]["values"])
 
     def test_unknown_header_ignored(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
         src = tmp_path / "i.csv"
@@ -320,6 +377,22 @@ class TestGroup:
         b2 = json.loads(httpx_mock.get_requests()[2].content)
         assert b1["variables"]["group"] == "grp_a"
         assert b2["variables"]["group"] == "grp_default"
+
+    def test_group_cell_guard_is_stripped(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        # Export guards the group cell like any other; import must strip it
+        # back off so a formula-lead group id/title round-trips.
+        src = tmp_path / "i.csv"
+        _write_csv(src, ["name,group", "Alpha,'=grp"])
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=COLS_RESPONSE)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_item": {"id": "1", "name": "Alpha"}}),
+        )
+        result = runner.invoke(app, ["import", "board", "--board", "42", "--from", str(src)])
+        assert result.exit_code == 0, result.stdout
+        body = json.loads(httpx_mock.get_requests()[1].content)
+        assert body["variables"]["group"] == "=grp"
 
 
 class TestCsvErrors:

--- a/tests/unit/test_cli_import.py
+++ b/tests/unit/test_cli_import.py
@@ -122,6 +122,43 @@ class TestBasicImport:
         assert len(httpx_mock.get_requests()) == 1
 
 
+class TestFormulaGuardStrip:
+    def test_export_guard_prefix_is_stripped(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        """Round-trip: guarded name, cell, and header land unguarded on monday."""
+        cols = _ok(
+            {
+                "boards": [
+                    {
+                        "id": "42",
+                        "name": "B",
+                        "columns": [
+                            {
+                                "id": "t1",
+                                "title": "=Evil",
+                                "type": "text",
+                                "settings_str": "{}",
+                                "archived": False,
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        src = tmp_path / "i.csv"
+        _write_csv(src, ["name,'=Evil", "'=EvilName,'+SUM(A1)"])
+        httpx_mock.add_response(url=ENDPOINT, method="POST", json=cols)
+        httpx_mock.add_response(
+            url=ENDPOINT,
+            method="POST",
+            json=_ok({"create_item": {"id": "1", "name": "=EvilName"}}),
+        )
+        result = runner.invoke(app, ["import", "board", "--board", "42", "--from", str(src)])
+        assert result.exit_code == 0, result.stdout
+        body = json.loads(httpx_mock.get_requests()[1].content)
+        assert body["variables"]["name"] == "=EvilName"
+        assert json.loads(body["variables"]["values"]) == {"t1": "+SUM(A1)"}
+
+
 class TestMapping:
     def test_explicit_mapping(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
         src = tmp_path / "i.csv"

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import io
 import json
 
@@ -113,6 +114,15 @@ class TestCsvFormatter:
         body = buf.getvalue().splitlines()[1]
         assert '"[""a"", ""b""]"' in body or '"[\\"a\\", \\"b\\"]"' in body or "[" in body
 
+    def test_guards_formula_cells_and_headers(self) -> None:
+        # Untrusted board data must not become live formulas when the CSV is
+        # opened in a spreadsheet — guard cells and headers (unconditional).
+        buf = io.StringIO()
+        format_output([{"=Evil": "=2+2", "n": "-5"}], fmt="csv", stream=buf)
+        rows = list(csv.reader(io.StringIO(buf.getvalue())))
+        assert rows[0] == ["'=Evil", "n"]
+        assert rows[1] == ["'=2+2", "-5"]  # plain number stays unguarded
+
 
 class TestTsvFormatter:
     def test_tab_separated(self) -> None:
@@ -121,6 +131,13 @@ class TestTsvFormatter:
         lines = buf.getvalue().splitlines()
         assert "\t" in lines[0]
         assert "," not in lines[0]
+
+    def test_guards_formula_cells_and_headers(self) -> None:
+        buf = io.StringIO()
+        format_output([{"@cmd": "+SUM(A1)", "n": "-5"}], fmt="tsv", stream=buf)
+        rows = list(csv.reader(io.StringIO(buf.getvalue()), delimiter="\t"))
+        assert rows[0] == ["'@cmd", "n"]
+        assert rows[1] == ["'+SUM(A1)", "-5"]
 
 
 # ---------- None ----------

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -185,6 +185,37 @@ class TestTableFormatter:
         # Empty table is fine — should not crash
         assert buf.getvalue() is not None
 
+    def test_strips_control_chars_from_cells_and_headers(self) -> None:
+        buf = io.StringIO()
+        format_output(
+            [{"na\x1b]0;evil\x07me": "\x1b[31mred\x1b[0m", "id": "\x9bJunk"}],
+            fmt="table",
+            stream=buf,
+            tty=False,
+        )
+        out = buf.getvalue()
+        assert "\x1b" not in out and "\x07" not in out and "\x9b" not in out
+        assert "na]0;evilme" in out and "red" in out and "Junk" in out
+
+    def test_strips_control_chars_from_kv_object(self) -> None:
+        buf = io.StringIO()
+        format_output({"k\x1bey": "va\x1b[2Jlue"}, fmt="table", stream=buf, tty=False)
+        out = buf.getvalue()
+        assert "\x1b" not in out
+        assert "key" in out and "va[2Jlue" in out
+
+    def test_rich_markup_not_interpreted(self) -> None:
+        buf = io.StringIO()
+        format_output(
+            [{"name": "[link=http://evil]click[/link]"}],
+            fmt="table",
+            stream=buf,
+            tty=True,
+        )
+        # With markup off the tag text survives verbatim (Rich may wrap it,
+        # so check a short prefix) instead of becoming an OSC 8 hyperlink.
+        assert "[link=" in buf.getvalue()
+
 
 # ---------- Registry + auto-detect ----------
 

--- a/tests/unit/test_sanitize.py
+++ b/tests/unit/test_sanitize.py
@@ -10,13 +10,25 @@ from mondo.util.sanitize import guard_formula, strip_formula_guard, strip_termin
 class TestGuardFormula:
     @pytest.mark.parametrize(
         "raw",
-        ["=SUM(A1:A9)", "+491234", "-5", "@cmd", "\tx", "\rx"],
+        # Formula leads that are NOT plain numbers stay guarded, including
+        # sign-then-operator/exponent/text and pipe-command payloads.
+        ["=SUM(A1:A9)", "@cmd", "\tx", "\rx", "-2+3", "-1e5", "+cmd|calc", "=-5", "+"],
     )
     def test_guards_formula_leads(self, raw: str) -> None:
         assert guard_formula(raw) == "'" + raw
 
     @pytest.mark.parametrize("raw", ["hello", "", "a=b", "'=already quoted"])
     def test_leaves_safe_strings(self, raw: str) -> None:
+        assert guard_formula(raw) == raw
+
+    @pytest.mark.parametrize(
+        "raw",
+        # Plain numbers (optional sign, then only digits/dots/commas) can't
+        # execute in a spreadsheet, so they must round-trip unguarded —
+        # otherwise =SUM()/pandas silently break on negatives.
+        ["-5", "+491234", "-1250", "1.234,50", "-0.5", "+1"],
+    )
+    def test_leaves_plain_numbers(self, raw: str) -> None:
         assert guard_formula(raw) == raw
 
     def test_leaves_non_strings(self) -> None:

--- a/tests/unit/test_sanitize.py
+++ b/tests/unit/test_sanitize.py
@@ -1,0 +1,49 @@
+"""Unit tests for mondo.util.sanitize (CSV formula guard + control stripping)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mondo.util.sanitize import guard_formula, strip_formula_guard, strip_terminal_controls
+
+
+class TestGuardFormula:
+    @pytest.mark.parametrize(
+        "raw",
+        ["=SUM(A1:A9)", "+491234", "-5", "@cmd", "\tx", "\rx"],
+    )
+    def test_guards_formula_leads(self, raw: str) -> None:
+        assert guard_formula(raw) == "'" + raw
+
+    @pytest.mark.parametrize("raw", ["hello", "", "a=b", "'=already quoted"])
+    def test_leaves_safe_strings(self, raw: str) -> None:
+        assert guard_formula(raw) == raw
+
+    def test_leaves_non_strings(self) -> None:
+        assert guard_formula(None) is None
+        assert guard_formula(5) == 5
+
+
+class TestStripFormulaGuard:
+    @pytest.mark.parametrize(
+        "raw",
+        ["=SUM(A1:A9)", "+491234", "-5", "@cmd", "\tx", "\rx", "hello", ""],
+    )
+    def test_round_trips_guard(self, raw: str) -> None:
+        assert strip_formula_guard(guard_formula(raw)) == raw
+
+    def test_leaves_plain_apostrophe_strings(self) -> None:
+        # Only the guard pattern (' + formula lead) is stripped.
+        assert strip_formula_guard("'hello'") == "'hello'"
+        assert strip_formula_guard("=x") == "=x"
+
+
+class TestStripTerminalControls:
+    def test_strips_ansi_escapes(self) -> None:
+        assert strip_terminal_controls("\x1b[31mred\x1b[0m") == "[31mred[0m"
+
+    def test_strips_c1_del_and_bell(self) -> None:
+        assert strip_terminal_controls("a\x9bJ\x7f\x07b") == "aJb"
+
+    def test_keeps_newline_and_tab(self) -> None:
+        assert strip_terminal_controls("a\nb\tc") == "a\nb\tc"

--- a/tests/unit/test_sanitize.py
+++ b/tests/unit/test_sanitize.py
@@ -31,6 +31,20 @@ class TestGuardFormula:
     def test_leaves_plain_numbers(self, raw: str) -> None:
         assert guard_formula(raw) == raw
 
+    @pytest.mark.parametrize(
+        "raw",
+        # Adjacent/trailing separators are not plain numbers — guarded.
+        ["-1,,2", "+5.", "-1.", "+.5"],
+    )
+    def test_guards_malformed_numbers(self, raw: str) -> None:
+        assert guard_formula(raw) == "'" + raw
+
+    def test_guards_past_leading_bom(self) -> None:
+        # At file start the BOM is eaten as the encoding signature, leaving
+        # the cell to start with "=" — so BOM-prefixed leads must be guarded.
+        assert guard_formula("\ufeff=SUM(A1)") == "'\ufeff=SUM(A1)"
+        assert guard_formula("\ufeff-1250") == "\ufeff-1250"  # still a plain number
+
     def test_leaves_non_strings(self) -> None:
         assert guard_formula(None) is None
         assert guard_formula(5) == 5
@@ -39,7 +53,7 @@ class TestGuardFormula:
 class TestStripFormulaGuard:
     @pytest.mark.parametrize(
         "raw",
-        ["=SUM(A1:A9)", "+491234", "-5", "@cmd", "\tx", "\rx", "hello", ""],
+        ["=SUM(A1:A9)", "+491234", "-5", "@cmd", "\tx", "\rx", "hello", "", "\ufeff=x"],
     )
     def test_round_trips_guard(self, raw: str) -> None:
         assert strip_formula_guard(guard_formula(raw)) == raw


### PR DESCRIPTION
Re-lands #98 + #99: PR #99 was stacked on #98's branch, so its squash-merge landed on `claude/vigorous-kepler-865a38` instead of `main` — main never received the change. This PR carries the identical, fully-reviewed content (branch `claude/busy-meninsky-02f8c0` @ efae0cc merged onto current main).

Content summary:
- `guard_formula`/`strip_formula_guard`/`strip_terminal_controls` in new `src/mondo/util/sanitize.py`
- CSV/TSV/xlsx export formula-injection guard (`--sanitize-formulas` flag, default on; xlsx stores `=`-leading cells as text) + lossless import round-trip stripping
- generic `-o csv`/`-o tsv` formatters guarded too
- plain-number exemption (negative numbers stay numeric), BOM-aware guard, tightened number grammar
- non-quadratic xlsx sanitize; import header exact-match-first + raw-first `--mapping`; group cell stripped
- markdown export HTML-escapes cells/titles; terminal table output strips C0/C1 controls, Rich markup off

Review trail (on #99): 8-angle /code-review + 5-angle adversarial-verify workflow + /simplify + codex gpt-5.5-high ×3, final verdict APPROVE. Verified here: 2049 non-integration tests pass, ruff clean on this exact tree.