### PR TITLE
docs: sync doc surfaces with 0.14 hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,10 @@ mondo --dry-run import board --board 1234567890 --from items.csv
 
 Column values use the same codec registry as `mondo item create` — so CSV
 cells like `Done`, `2026-04-25`, `urgent,blocked` parse into the right JSON.
+The importer keeps export round-trips lossless: it strips the export's `'`
+formula guard from names, values, and headers, and resolves export's
+disambiguated `Title (<colid>)` headers (duplicate or meta-shadowing column
+titles) straight to the column id.
 Each row emits a result record (`created`/`skipped`/`failed`/`dry-run`); a
 single failing row does not abort the run, and the command exits `1` if any
 row failed.
@@ -461,6 +465,12 @@ mondo export board --board 1234567890 --format md   --group topics        # one 
 Formats: `csv | tsv | json | xlsx | md | html | pdf`. Column headers are the
 board's column titles (archived columns are dropped). monday has no native
 board-export API, so every format is rendered client-side.
+
+Formula-looking cells are guarded by default: csv/tsv values starting with
+`=` `+` `-` `@` (plain numbers exempt) get a `'` prefix and xlsx stores
+`=`-leading cells as text, so spreadsheets don't execute board-controlled
+data — opt out with `--no-sanitize-formulas`. The same guard applies to any
+command's generic `-o csv` / `-o tsv` output.
 
 The human-readable formats (`md`, `html`, `pdf`) are **grouped by default**: the
 output opens with a board-name title and then one section per group that contains
@@ -860,7 +870,7 @@ codec registry (22 writable column types):
 | `country` | `US` | `{"countryCode":"US","countryName":"United States"}` |
 | `checkbox` | `true` / `false` / `clear` | `{"checked":"true"}` / `null` |
 | `rating` | `4` | `{"rating":4}` |
-| `tags` | `urgent,blocked` | `{"tag_ids":[…]}` (names resolved via `create_or_get_tag`) |
+| `tags` | `urgent,blocked` | `{"tag_ids":[…]}` (names resolved via `create_or_get_tag`; under `--dry-run` names are rejected — pass tag ids) |
 | `board_relation` | `12345,23456` | `{"item_ids":[…]}` |
 | `dependency` | `12345,23456` | `{"item_ids":[…]}` |
 | `world_clock` | `Europe/London` | `{"timezone":"Europe/London"}` |

--- a/src/mondo/help/batch-operations.md
+++ b/src/mondo/help/batch-operations.md
@@ -160,8 +160,10 @@ Exit 0 when every row succeeds, exit 1 when any row failed (the envelope
 is still emitted; a mid-batch HTTP error marks the failing + not-attempted
 rows failed rather than discarding everything). Notes:
 
-- In `--dry-run`, pass tag **ids** (name-minting is deferred until the
-  whole batch validates, so it can't run offline).
+- In `--dry-run`, pass tag **ids** — resolving tag names mints tags via a
+  real mutation, so every tag write refuses names under `--dry-run` with
+  exit 5 (`column set` single + `--batch`, `item`/`subitem create`,
+  `import board`).
 - The `name` column is rejected — rename items with `mondo item rename`.
 - Clear-shaped values (`""`, `{}`, `[]`, `null`, `{"labels":[]}`) fail
   codec validation; the error points you at `mondo column clear`.

--- a/src/mondo/help/output.md
+++ b/src/mondo/help/output.md
@@ -53,11 +53,16 @@ just want a smaller dict per row.
 
 ## Format notes
 
-- `table` — rich-rendered, TTY only. Dropped columns become `…`.
+- `table` — rich-rendered, TTY only. Dropped columns become `…`. Cell text
+  is sanitized: terminal control characters are stripped and Rich markup in
+  API data is never interpreted.
 - `json` — compact, newline-terminated. Safe to pipe into `jq`.
 - `jsonc` — pretty-printed with 2-space indent. For humans reading logs.
 - `yaml` — ruamel.yaml round-trip safe. Preserves ordering.
 - `tsv` / `csv` — flattens nested records using dotted paths. Header row first.
+  Formula-leading cells (`=` `+` `-` `@`; plain numbers exempt) get a `'`
+  prefix so a spreadsheet opening the file won't execute board-controlled
+  text — same guard as `mondo export board`, here unconditional.
 - `none` — prints the raw scalar when `--query` collapses the payload to one.
 
 ## Errors and stderr

--- a/src/mondo/skill/SKILL.md
+++ b/src/mondo/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mondo
 description: Use when the user wants to do anything against monday.com via the `mondo` CLI — reading or writing workspaces, folders, boards, groups, items, subitems, columns, updates, docs, files, users, teams, webhooks, or when they paste a monday.com URL.
-version: "1.11.0"
+version: "1.12.0"
 ---
 
 # mondo
@@ -65,13 +65,13 @@ Consult these *before* improvising. Each is a Goal / Command / Output / Gotcha s
 
 ## Operating norms (every command obeys these)
 
-- **Output format:** auto-JSON when stdout isn't a TTY. Don't set `-o json` in scripts; mondo detects it. Force with `-o json|yaml|tsv|csv`.
+- **Output format:** auto-JSON when stdout isn't a TTY. Don't set `-o json` in scripts; mondo detects it. Force with `-o json|yaml|tsv|csv`. Board data is untrusted: `csv`/`tsv` output prefixes formula-leading cells (`=` `+` `-` `@`; plain numbers exempt) with `'` so spreadsheets don't execute them, and `table` output strips terminal control characters (Rich markup is never interpreted). `json`/`yaml` pass values through raw.
 - **Project before format** with `-q JMESPATH` (applied before the formatter). For the "give me id, name, status" case, `--fields KEY1,KEY2,...` (CSV of keys; dotted paths walk nested dicts) is shorter than the equivalent `-q` projection. Both are global flags surfaced in the "Output / Query" help panel.
 - **Narrow server-side, always.** On boards beyond a few hundred items a full `item list` costs ~10s per 500 items, and the full `column_values` selection is ~3x the bare item fields. Use `--group <id>`, `--filter col=val` (repeatable, AND'ed), `--max-items N`, and `--columns col1,col2`; reach for `-q` to *project*, not to *filter* — a client-side `[?group.id=='…']` still pays for every item on the board. For the lookup-by-value case use `mondo item find --board X --column COL --value VAL`. `--parent <item-id>` is the first-class subitems shortcut. See `mondo help complexity` for the cost model.
 - **Resolve ids by name with the cheap shape:** `mondo item list --board X --group G --fields id,name` is the canonical id lookup — `--fields id,name` drops `column_values` from the GraphQL query, ~3x faster per page. A `-q` expression never narrows the request (it shapes output client-side) — combine `-q` for shape with `--fields` for slimming.
 - **JSON error envelope** on stderr (non-TTY): `{"error": "...", "code": "...", "exit_code": N, "request_id": "...", "retry_in_seconds": N, "suggestion": "..."}`. Branch on `exit_code`, never parse stderr text.
 - **Stable exit codes:** 0 ok · 2 usage · 3 auth/permission · 4 rate/complexity (retry after 60s) · 5 validation · 6 not-found · 7 network. Exit 3 on a write is a **policy wall** (workspace permission or license), not bad syntax — don't burn calls retrying with different flags (`--kind private`, `--kind share`, …); surface the error to the user.
-- **Dry-run writes first:** every typed mutating command takes `--dry-run` (prints GraphQL + variables, sends nothing). Use it when the task is unfamiliar. Not supported on `mondo graphql` — the raw passthrough refuses `--dry-run` with exit 2 because mondo can't safely preview a query it doesn't parse.
+- **Dry-run writes first:** every typed mutating command takes `--dry-run` (prints GraphQL + variables, sends nothing). Use it when the task is unfamiliar. Not supported on `mondo graphql` — the raw passthrough refuses `--dry-run` with exit 2 because mondo can't safely preview a query it doesn't parse. Tags by **name** are refused under `--dry-run` everywhere (`item`/`subitem create`, `column set` single + `--batch`, `import board`) because name→id resolution mints tags via a real mutation — pass tag **ids** in dry runs (exit 5 otherwise).
 - **Batch:** `item create --batch <file.json|- >` and `column set --board <id> --batch <file.json|- >` bulk-write via aliased mutations (~10 rows per HTTP call, `--chunk-size` to tune; per-row envelope: partial failure → exit 1). `column set --batch` rows are `{item, value}` or `{item, column, value}` (a top-level `--column` supplies the default). A batch still costs ~2.4s/chunk, so a few hundred rows will blow a 2-minute Bash timeout: run it in the background or raise the timeout.
 - **URLs:** pass `--with-url` on `board get`, `board list`, `board create`, `item get`, `item list`, `item find`, `item create`, `subitem get`, `doc get`, `doc list`, `doc create` to return a clickable monday.com link to the user. On the create commands this is single-call create + URL retrieval (no extra request).
 - **Wait for async state changes** with `--poll-until '<jmespath>'` + `--poll-interval` + `--poll-timeout` on `item list`, `item get`, `board get` — replaces hand-rolled bash `until/sleep` loops.

--- a/src/mondo/skill/references/bulk.md
+++ b/src/mondo/skill/references/bulk.md
@@ -81,7 +81,7 @@ mondo column set --board 5094861043 --column e2e_status --batch ./col_batch.json
 }
 ```
 
-*Gotcha:* in `--dry-run` pass tag **ids**, not names (name-minting is deferred until the whole batch validates). Clear-shaped values (`""`, `{}`, `[]`, `null`, `{"labels":[]}`) fail codec validation — use `mondo column clear` instead (the error says so). Full walkthrough: `mondo help batch-operations`.
+*Gotcha:* in `--dry-run` pass tag **ids**, not names — resolving names mints tags via a real mutation, so every tag write refuses names under `--dry-run` with exit 5 (this batch mode, single `column set`, `item`/`subitem create`, `import board`). Clear-shaped values (`""`, `{}`, `[]`, `null`, `{"labels":[]}`) fail codec validation — use `mondo column clear` instead (the error says so). Full walkthrough: `mondo help batch-operations`.
 
 ## Export a board
 
@@ -106,6 +106,19 @@ mondo export board 5094861043 --format html --out ./pm_export.html
 # PDF via WeasyPrint (requires --out):
 mondo export board 5094861043 --format pdf --out ./pm_export.pdf
 ```
+
+### Formula guard (csv / tsv / xlsx — on by default)
+
+Board data is controlled by anyone with board access, so exports defend the
+spreadsheet that opens them: csv/tsv cells starting with `=` `+` `-` `@`
+(or tab/CR) get a `'` prefix — the spreadsheet "treat as text" convention —
+and xlsx stores `=`-leading cells as text instead of live formulas. Plain
+numbers (`-1250`, `1.234,50`) are exempt so numeric columns stay numeric.
+`mondo import board` strips the prefix back off, keeping the round-trip
+lossless; other consumers (pandas, DB loads) will see the literal `'` on
+formula-looking text cells — disable with `--no-sanitize-formulas` if the
+destination is trusted. md/html exports HTML-escape cell text and titles
+instead.
 
 ### Grouped vs flat (md / html / pdf only)
 
@@ -176,6 +189,14 @@ mondo import board <new_board_id> --from /tmp/pm.csv \
 ```
 
 *Gotcha:* the round-trip is **lossy** for typed columns whose values are labels (status, dropdown, people). For full fidelity, use JSON export + scripting around `item create` directly.
+
+Round-trip fidelity details the importer handles for you: the `'` formula
+guard the export adds is stripped from names, cell values, headers, and the
+group cell; and export's disambiguated `Title (<colid>)` headers (emitted
+when two columns share a title or a title shadows `id`/`name`/`state`/
+`group`) resolve straight to the column id, so duplicate-title boards no
+longer drop those columns on import. Header resolution priority: explicit
+`--mapping` → `Title (<colid>)` suffix → case-insensitive title match.
 
 ## JSON error envelope (server errors only)
 

--- a/src/mondo/skill/references/columns.md
+++ b/src/mondo/skill/references/columns.md
@@ -154,7 +154,7 @@ echo '[
 ```
 
 - **Exit 1 on any per-row failure** (the envelope is still emitted — inspect `results[].ok` and retry the failures). A mid-batch HTTP error marks the failing + not-yet-attempted rows failed and still returns the partial envelope.
-- `--dry-run` prints the resolved GraphQL document per chunk without sending. Tags-by-name can't be minted in `--dry-run` — pass tag **ids** there.
+- `--dry-run` prints the resolved GraphQL document per chunk without sending. Tags by **name** are refused in `--dry-run` with exit 5 ("resolving tag names requires a live call; use tag ids in --dry-run.") — the rule applies to every tag write: `column set` single + `--batch`, `item`/`subitem create`, and `import board`.
 - The `name` column is rejected (rename items with `mondo item rename`), same as single-item mode.
 - Clear-shaped values (`""`, `{}`, `[]`, `null`, `{"labels":[]}`) fail codec validation and the error points you at `mondo column clear`.
 


### PR DESCRIPTION
## Audit finding

Audited all doc surfaces against the three merges since the last docs sync (#101 dry-run tags, #103 export hardening, #102 import header resolution), via four parallel surface audits (README / skill / help topics / matrix+maintainer skills).

- **Outdated (fixed):** the skill's dry-run-tags note (`references/columns.md`, `help/batch-operations.md`, `references/bulk.md`) was scoped to `column set --batch` only — the guard is now universal (`item`/`subitem create`, `column set` single+batch, `import board`) and hard-fails with exit 5.
- **Missing (added):** `--sanitize-formulas` formula guard + plain-number exemption + xlsx text-cell behavior (README export section, new `references/bulk.md` subsection); generic `-o csv`/`-o tsv` guard + table control-char stripping (SKILL.md operating norms, `help/output.md` format notes); import round-trip fidelity — guard stripping + `Title (<colid>)` header resolution (README import section, `references/bulk.md`); tags-row dry-run caveat in the README codec table.
- **Clean:** contract matrix regenerates byte-identical (no output shapes changed); maintainer skills make no affected claims.

SKILL.md version 1.11.0 → 1.12.0 (freshness-checker re-pull trigger).

## Verification

- `pytest -k "matrix or help or skill or contract"`: 91 passed
- ruff clean; matrix regeneration: zero diff
- Full live integration suite on main pre-branch: 149 passed, 3 pre-existing xfails

🤖 Generated with [Claude Code](https://claude.com/claude-code)